### PR TITLE
Port documentation from incubator-pinot repo for kafka consumer with …

### DIFF
--- a/developers-and-contributors/extending-pinot/pluggable-streams.md
+++ b/developers-and-contributors/extending-pinot/pluggable-streams.md
@@ -179,6 +179,63 @@ Please note:
 2. Config `stream.kafka.consumer.type` should be specified as `LowLevel` to use partition level consumer. \(The use of `simple` instead of `LowLevel` is deprecated\)
 3. Configs `stream.kafka.zk.broker.url` and `stream.kafka.broker.list` are required under `tableIndexConfig.streamConfigs` to provide kafka related information.
 
+* **Use Kafka Partition(Low) Level Consumer with SSL**
+
+Here is another example which uses SSL based authentication to talk with kafka
+and schema-registry. Notice there are two sets of SSL options, ones starting with
+`ssl.` are for kafka consumer and ones with `stream.kafka.decoder.prop.schema.registry.`
+are for `SchemaRegistryClient` used by `KafkaConfluentSchemaRegistryAvroMessageDecoder`.
+
+
+```text
+
+  {
+    "tableName": "meetupRsvp",
+    "tableType": "REALTIME",
+    "segmentsConfig": {
+      "timeColumnName": "mtime",
+      "timeType": "MILLISECONDS",
+      "segmentPushType": "APPEND",
+      "segmentAssignmentStrategy": "BalanceNumSegmentAssignmentStrategy",
+      "schemaName": "meetupRsvp",
+      "replication": "1",
+      "replicasPerPartition": "1"
+    },
+    "tenants": {},
+    "tableIndexConfig": {
+      "loadMode": "MMAP",
+      "streamConfigs": {
+        "streamType": "kafka",
+        "stream.kafka.consumer.type": "LowLevel",
+        "stream.kafka.topic.name": "meetupRSVPEvents",
+        "stream.kafka.decoder.class.name": "org.apache.pinot.plugin.inputformat.avro.confluent.KafkaConfluentSchemaRegistryAvroMessageDecoder",
+        "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory",
+        "stream.kafka.zk.broker.url": "localhost:2191/kafka",
+        "stream.kafka.broker.list": "localhost:19092",
+        "schema.registry.url": "",
+        "security.protocol": "",
+        "ssl.truststore.location": "",
+        "ssl.keystore.location": "",
+        "ssl.truststore.password": "",
+        "ssl.keystore.password": "",
+        "ssl.key.password": "",
+        "stream.kafka.decoder.prop.schema.registry.rest.url": "",
+        "stream.kafka.decoder.prop.schema.registry.ssl.truststore.location": "",
+        "stream.kafka.decoder.prop.schema.registry.ssl.keystore.location": "",
+        "stream.kafka.decoder.prop.schema.registry.ssl.truststore.password": "",
+        "stream.kafka.decoder.prop.schema.registry.ssl.keystore.password": "",
+        "stream.kafka.decoder.prop.schema.registry.ssl.keystore.type": "",
+        "stream.kafka.decoder.prop.schema.registry.ssl.truststore.type": "",
+        "stream.kafka.decoder.prop.schema.registry.ssl.key.password": "",
+        "stream.kafka.decoder.prop.schema.registry.ssl.protocol": "",
+      }
+    },
+    "metadata": {
+      "customConfigs": {}
+    }
+  }
+```
+
 #### Upgrade from Kafka 0.9 connector to Kafka 2.x connector
 
 * Update table config for both high level and low level consumer: Update config: `stream.kafka.consumer.factory.class.name` from `org.apache.pinot.core.realtime.impl.kafka.KafkaConsumerFactory` to `org.apache.pinot.core.realtime.impl.kafka2.KafkaConsumerFactory`.

--- a/developers/developers-and-contributors/extending-pinot/pluggable-streams.md
+++ b/developers/developers-and-contributors/extending-pinot/pluggable-streams.md
@@ -179,6 +179,63 @@ Please note:
 2. Config `stream.kafka.consumer.type` should be specified as `LowLevel` to use partition level consumer. \(The use of `simple` instead of `LowLevel` is deprecated\)
 3. Configs `stream.kafka.zk.broker.url` and `stream.kafka.broker.list` are required under `tableIndexConfig.streamConfigs` to provide kafka related information.
 
+* **Use Kafka Partition(Low) Level Consumer with SSL**
+
+Here is another example which uses SSL based authentication to talk with kafka
+and schema-registry. Notice there are two sets of SSL options, ones starting with
+`ssl.` are for kafka consumer and ones with `stream.kafka.decoder.prop.schema.registry.`
+are for `SchemaRegistryClient` used by `KafkaConfluentSchemaRegistryAvroMessageDecoder`.
+
+
+```text
+
+  {
+    "tableName": "meetupRsvp",
+    "tableType": "REALTIME",
+    "segmentsConfig": {
+      "timeColumnName": "mtime",
+      "timeType": "MILLISECONDS",
+      "segmentPushType": "APPEND",
+      "segmentAssignmentStrategy": "BalanceNumSegmentAssignmentStrategy",
+      "schemaName": "meetupRsvp",
+      "replication": "1",
+      "replicasPerPartition": "1"
+    },
+    "tenants": {},
+    "tableIndexConfig": {
+      "loadMode": "MMAP",
+      "streamConfigs": {
+        "streamType": "kafka",
+        "stream.kafka.consumer.type": "LowLevel",
+        "stream.kafka.topic.name": "meetupRSVPEvents",
+        "stream.kafka.decoder.class.name": "org.apache.pinot.plugin.inputformat.avro.confluent.KafkaConfluentSchemaRegistryAvroMessageDecoder",
+        "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory",
+        "stream.kafka.zk.broker.url": "localhost:2191/kafka",
+        "stream.kafka.broker.list": "localhost:19092",
+        "schema.registry.url": "",
+        "security.protocol": "",
+        "ssl.truststore.location": "",
+        "ssl.keystore.location": "",
+        "ssl.truststore.password": "",
+        "ssl.keystore.password": "",
+        "ssl.key.password": "",
+        "stream.kafka.decoder.prop.schema.registry.rest.url": "",
+        "stream.kafka.decoder.prop.schema.registry.ssl.truststore.location": "",
+        "stream.kafka.decoder.prop.schema.registry.ssl.keystore.location": "",
+        "stream.kafka.decoder.prop.schema.registry.ssl.truststore.password": "",
+        "stream.kafka.decoder.prop.schema.registry.ssl.keystore.password": "",
+        "stream.kafka.decoder.prop.schema.registry.ssl.keystore.type": "",
+        "stream.kafka.decoder.prop.schema.registry.ssl.truststore.type": "",
+        "stream.kafka.decoder.prop.schema.registry.ssl.key.password": "",
+        "stream.kafka.decoder.prop.schema.registry.ssl.protocol": "",
+      }
+    },
+    "metadata": {
+      "customConfigs": {}
+    }
+  }
+```
+
 #### Upgrade from Kafka 0.9 connector to Kafka 2.x connector
 
 * Update table config for both high level and low level consumer: Update config: `stream.kafka.consumer.factory.class.name` from `org.apache.pinot.core.realtime.impl.kafka.KafkaConsumerFactory` to `org.apache.pinot.core.realtime.impl.kafka2.KafkaConsumerFactory`.


### PR DESCRIPTION
Port documentation from incubator-pinot repo for kafka consumer with SSL configs 
context: https://github.com/apache/incubator-pinot/pull/5758/files