### PR TITLE
Update docs to show decimal enabled percentile functions.

### DIFF
--- a/users/user-guide-query/pinot-query-language/README.md
+++ b/users/user-guide-query/pinot-query-language/README.md
@@ -149,9 +149,9 @@ For Multi-Valued columns, EQUALS is similar to CONTAINS.
 * `DISTINCTCOUNTHLL`
 * `DISTINCTCOUNTRAWHLL`: Returns HLL response serialized as string. The serialized HLL can be converted back into an HLL \(see pinot-core/\*\*/HllUtil.java as an example\) and then aggregated with other HLLs. A common use case may be to merge HLL responses from different Pinot tables, or to allow aggregation after client-side batching.
 * `FASTHLL` \(**WARN**: will be deprecated soon. `FASTHLL` stores serialized HyperLogLog in String format, which performs worse than `DISTINCTCOUNTHLL`, which supports serialized HyperLogLog in BYTES \(byte array\) format\)
-* `PERCENTILE[0-100]`: e.g. `PERCENTILE5`, `PERCENTILE50`, `PERCENTILE99`, etc.
-* `PERCENTILEEST[0-100]`: e.g. `PERCENTILEEST5`, `PERCENTILEEST50`, `PERCENTILEEST99`, etc.
-* `PERCENTILETDIGEST[0-100]`: e.g. `PERCENTILETDIGEST5`, `PERCENTILETDIGEST50`, `PERCENTILETDIGEST99`, etc. 
+* `PERCENTILE`: e.g. `PERCENTILE(column, 0.05)`, `PERCENTILE(column, 50)`, `PERCENTILE(column, 99.9)`, etc.
+* `PERCENTILEEST`: e.g. `PERCENTILEEST(column, 0.05)`, `PERCENTILEEST(column, 50)`, `PERCENTILEEST(column, 99.9)`, etc.
+* `PERCENTILETDIGEST`: e.g. `PERCENTILETDIGEST(column, 0.05)`, `PERCENTILETDIGEST(column, 50)`, `PERCENTILETDIGEST(column, 99.9)`, etc. 
   * `PERCENTILE` returns accurate percentile results.
   * `PERCENTILEEST` returns estimated percentile results based on [io.airlift.stats.QuantileDigest](https://github.com/airlift/airlift/blob/master/stats/src/main/java/io/airlift/stats/QuantileDigest.java).
   * `PERCENTILETDIGEST` returns estimated percentile results based on [T-Digest](https://raw.githubusercontent.com/tdunning/t-digest/master/docs/t-digest-paper/histo.pdf) algorithm.
@@ -168,9 +168,9 @@ For Multi-Valued columns, EQUALS is similar to CONTAINS.
 * `DISTINCTCOUNTHLLMV`
 * `DISTINCTCOUNTRAWHLLMV`: Returns HLL response serialized as string. The serialized HLL can be converted back into an HLL \(see pinot-core/\*\*/HllUtil.java as an example\) and then aggregated with other HLLs. A common use case may be to merge HLL responses from different Pinot tables, or to allow aggregation after client-side batching.
 * `FASTHLLMV` \(**WARN**: will be deprecated soon. It does not make lots of sense to configure serialized HyperLogLog column as a dimension\)
-* `PERCENTILE[0-100]MV`: e.g. `PERCENTILE5MV`, `PERCENTILE50MV`, `PERCENTILE99MV`, etc.
-* `PERCENTILEEST[0-100]MV`: e.g. `PERCENTILEEST5MV`, `PERCENTILEEST50MV`, `PERCENTILEEST99MV`, etc.
-* `PERCENTILETDIGEST[0-100]MV`: e.g. `PERCENTILETDIGEST5MV`, `PERCENTILETDIGEST50MV`, `PERCENTILETDIGEST99MV`, etc.
+* `PERCENTILEMV`: e.g. `PERCENTILEMV(column, 0.05)`, `PERCENTILEMV(column, 50)`, `PERCENTILEMV(column, 99.9)`, etc.
+* `PERCENTILEESTMV`: e.g. `PERCENTILEESTMV(column, 0.05)`, `PERCENTILEESTMV(column, 50)`, `PERCENTILEESTMV(column, 99.9)`, etc.
+* `PERCENTILETDIGESTMV`: e.g. `PERCENTILETDIGESTMV(column, 0.05)`, `PERCENTILETDIGESTMV(column, 50)`, `PERCENTILETDIGESTMV(column, 99.9)`, etc.
 
 ### WHERE
 

--- a/users/user-guide-query/supported-aggregations.md
+++ b/users/user-guide-query/supported-aggregations.md
@@ -54,24 +54,24 @@ Pinot provides support for aggregations using GROUP BY. You can use the followin
       </td>
     </tr>
     <tr>
-      <td style="text-align:left"><b>PERCENTILE</b>[0-100]</td>
-      <td style="text-align:left">Returns the Nth percentile of the group where N is between 0-100</td>
+      <td style="text-align:left"><b>PERCENTILE(column, N)</b></td>
+      <td style="text-align:left">Returns the Nth percentile of the group where N is a decimal number between 0 and 100 inclusive</td>
       <td
-      style="text-align:left"><code>PERCENTILE50(playerScore), PERCENTILE99(playerScore)</code>
+      style="text-align:left"><code>PERCENTILE(playerScore, 50), PERCENTILE(playerScore, 99.9)</code>
         </td>
     </tr>
     <tr>
-      <td style="text-align:left"><b>PERCENTILEEST</b>[0-100]</td>
+      <td style="text-align:left"><b>PERCENTILEEST(column, N)</b></td>
       <td style="text-align:left">Returns the Nth percentile of the group using <a href="https://github.com/airlift/airlift/blob/master/stats/src/main/java/io/airlift/stats/QuantileDigest.java">Quantile Digest</a> algorithm</td>
       <td
-      style="text-align:left"><code>PERCENTILEEST50(playerScore), PERCENTILEEST99(playerScore)</code>
+      style="text-align:left"><code>PERCENTILEEST(playerScore, 50), PERCENTILEEST(playerScore, 99.9)</code>
         </td>
     </tr>
     <tr>
-      <td style="text-align:left"><b>PercentileTDigest</b>[0-100]</td>
+      <td style="text-align:left"><b>PercentileTDigest(column, N)</b></td>
       <td style="text-align:left">Returns the Nth percentile of the group using <a href="https://raw.githubusercontent.com/tdunning/t-digest/master/docs/t-digest-paper/histo.pdf">T-digest algorithm</a>
       </td>
-      <td style="text-align:left"><code>PERCENTILETDIGEST50(playerScore), PERCENTILETDIGEST99(playerScore)</code>
+      <td style="text-align:left"><code>PERCENTILETDIGEST(playerScore, 50), PERCENTILETDIGEST(playerScore, 99.9)</code>
       </td>
     </tr>
     <tr>
@@ -198,38 +198,38 @@ The following aggregation functions can be used for multi-value columns
       </td>
     </tr>
     <tr>
-      <td style="text-align:left"><b>PERCENTILE</b>[0-100]<b>MV</b>
+      <td style="text-align:left"><b>PERCENTILEMV(column, N)</b>
       </td>
-      <td style="text-align:left">Returns the Nth percentile of the group where N is between 0-100</td>
+      <td style="text-align:left">Returns the Nth percentile of the group where N is a decimal number between 0 and 100 inclusive</td>
       <td
       style="text-align:left">
-        <p><code>PERCENTILE50MV(playerScores),</code>
+        <p><code>PERCENTILEMV(playerScores, 50),</code>
         </p>
-        <p><code>PERCENTILE99MV(playerScores)</code>
+        <p><code>PERCENTILEMV(playerScores, 99.9)</code>
         </p>
         </td>
     </tr>
     <tr>
-      <td style="text-align:left"><b>PERCENTILEEST</b>[0-100]<b>MV</b>
+      <td style="text-align:left"><b>PERCENTILEESTMV(column, N)</b>
       </td>
       <td style="text-align:left">Returns the Nth percentile of the group using <a href="https://github.com/airlift/airlift/blob/master/stats/src/main/java/io/airlift/stats/QuantileDigest.java">Quantile Digest</a> algorithm</td>
       <td
       style="text-align:left">
-        <p><code>PERCENTILEEST50MV(playerScores),</code>
+        <p><code>PERCENTILEESTMV(playerScores, 50),</code>
         </p>
-        <p><code>PERCENTILEEST99MV(playerScores)</code>
+        <p><code>PERCENTILEESTMV(playerScores, 99.9)</code>
         </p>
         </td>
     </tr>
     <tr>
-      <td style="text-align:left"><b>PercentileTDigest[0-100]MV</b>
+      <td style="text-align:left"><b>PercentileTDigestMV(column, N)</b>
       </td>
       <td style="text-align:left">Returns the Nth percentile of the group using <a href="https://raw.githubusercontent.com/tdunning/t-digest/master/docs/t-digest-paper/histo.pdf">T-digest algorithm</a>
       </td>
       <td style="text-align:left">
-        <p><code>PERCENTILETDIGEST50MV(playerScores),</code>
+        <p><code>PERCENTILETDIGESTMV(playerScores, 50),</code>
         </p>
-        <p><code>PERCENTILETDIGEST99MV(playerScores),</code>
+        <p><code>PERCENTILETDIGESTMV(playerScores, 99.9),</code>
         </p>
       </td>
     </tr>


### PR DESCRIPTION
This the documentation change corresponding to https://github.com/apache/incubator-pinot/pull/6323. I have removed the previous version of percentile function from docs to discourage their use and replaced it with new versions of percentile functions.