### PR TITLE
Add link to JSON queries doc.

### DIFF
--- a/users/user-guide-query/README.md
+++ b/users/user-guide-query/README.md
@@ -20,3 +20,5 @@ description: >-
 
 {% page-ref page="lookup-udf-join.md" %}
 
+{% page-ref page="json-queries.md" %}
+


### PR DESCRIPTION
Adding link to JSON queries doc on the main queries page. @xiangfu0 can you please review and merge again. For some reason the change didn't appear in the online doc last time and hence got overwritten by another change. Thanks.

Previous PR: https://github.com/pinot-contrib/pinot-docs/pull/51