### PR TITLE
Add info about cmd + enter shortcut in explorer docs

### DIFF
--- a/basics/components/exploring-pinot.md
+++ b/basics/components/exploring-pinot.md
@@ -16,7 +16,9 @@ Let's take a look at the following two features on the UI
 Let us run some queries on the data in the Pinot cluster. Head over to [Query Console](http://localhost:9000/#/query) to see the querying interface.
 
 We can see our `baseballStats` table listed on the left \(you will see `meetupRSVP` or `airlineStats` if you used the streaming or the hybrid quick start\).  Click on the table name to display all the names along with the data types of the columns of the table.  
-You can also execute a sample query `select * from baseballStats limit 10`  by typing it in the text box and clicking the `Run Query` button.
+You can also execute a sample query `select * from baseballStats limit 10`  by typing it in the text box and clicking the `Run Query` button. 
+
+`Cmd + Enter` can also be used to run the query when focused on the console.
 
 ![](../../.gitbook/assets/pinot_query_console_cropped.png)
 


### PR DESCRIPTION
Just adding docs about the cmd + enter shortcut I want to add as part of https://github.com/apache/pinot/pull/7359