### PR TITLE
Update JSON queries doc to use json_extract_scalar function

### DIFF
--- a/users/user-guide-query/json-queries.md
+++ b/users/user-guide-query/json-queries.md
@@ -19,9 +19,9 @@ Table data:
 
 We also assume that "jsoncolumn" has a [Json Index](https://docs.pinot.apache.org/basics/indexing/json-index) on it. Note that the last two rows in the table have different structure than the rest of the rows. In keeping with JSON specification, a JSON column can contain any valid JSON data and doesn't need to adhere to a predefined schema. To pull out the entire JSON document for each row, we can run the query below:
 
-```json
+```text
 SELECT id, jsoncolumn 
-FROM myTable
+  FROM myTable
 ```
 
 | id | jsoncolumn |
@@ -37,46 +37,53 @@ FROM myTable
 To drill down and pull out specific keys within the JSON column, we simply append the JsonPath expression of those keys to the end of the column name.
 
 
-```json
-SELECT id, jsoncolumn.name.last, jsoncolumn.name.first, jsoncolumn.data[1] 
-FROM myTable
+```text
+SELECT id,
+       json_extract_scalar(jsoncolumn, '$.name.last', 'STRING', 'null') last_name,
+       json_extract_scalar(jsoncolumn, '$.name.first', 'STRING', 'null') first_name
+       json_extract_scalar(jsoncolumn, '$.data[1]', 'STRING', 'null') value
+  FROM myTable
 ```
 
-|id|jsoncolumn.name.last|jsoncolumn.name.first|jsoncolumn.data[1]
+|id|last_name|first_name|value|
 | ----------- | ----------- | ----------- | ----------- |
-|"101"|"duck"|"daffy"|"b"|
-|"102"|"duck"|"donald"|"b"|
-|"103"|"mouse"|"mickey"|"b"|
-|"104"|"mouse"|"minnie"|"b"|
-|"105"|"dwag"|"goofy"|"b"|
-|"106"|"null"|"null"|"null"|
-|"107"|"null"|"null"|"null"|
+|101|duck|daffy|b|
+|102|duck|donald|b|
+|103|mouse|mickey|b|
+|104|mouse|minnie|b|
+|105|dwag|goofy|b|
+|106|null|null|null|
+|107|null|null|null|
 
-Note that the third column \(jsoncolumn.data\[1\]\) is null for rows with id 106 and 107. This is because these rows have JSON documents that don't have a key with JsonPath jsoncolumn.data\[1\]. We can filter out these rows.
-
-```json
-SELECT id, jsoncolumn.name.last, jsoncolumn.name.first, jsoncolumn.data[1] 
-FROM myTable 
-WHERE jsoncolumn.data[1] IS NOT NULL
-```
-
-
-|id|jsoncolumn.name.last|jsoncolumn.name.first|jsoncolumn.data[1]
-| ----------- | ----------- | ----------- | ----------- |
-|"101"|"duck"|"daffy"|"b"|
-|"102"|"duck"|"donald"|"b"|
-|"103"|"mouse"|"mickey"|"b"|
-|"104"|"mouse"|"minnie"|"b"|
-|"105"|"dwag"|"goofy"|"b"|
-
-
-Notice that certain last names \(duck and mouse for example\) repeat in the data above. We can get a count of each last name by running a GROUP BY query on a JsonPath expression.
+Note that the third column \(value\) is null for rows with id 106 and 107. This is because these rows have JSON 
+documents that don't have a key with JsonPath $.data\[1\]. We can filter out these rows.
 
 ```text
-SELECT jsoncolumn.name.last, count(*) 
-FROM myTable 
-WHERE jsoncolumn.data[1] IS NOT NULL 
-GROUP BY jsoncolumn.name.last 
+SELECT id,
+       json_extract_scalar(jsoncolumn, '$.name.last', 'STRING', 'null') last_name,
+       json_extract_scalar(jsoncolumn, '$.name.first', 'STRING', 'null') first_name,
+       json_extract_scalar(jsoncolumn, '$.data[1]', 'STRING', 'null') value
+  FROM myTable
+ WHERE JSON_MATCH(jsoncolumn, '"$.data[1]" IS NOT NULL')
+```
+
+|id|last_name|first_name|value|
+| ----------- | ----------- | ----------- | ----------- |
+|101|duck|daffy|b|
+|102|duck|donald|b|
+|103|mouse|mickey|b|
+|104|mouse|minnie|b|
+|105|dwag|goofy|b|
+
+Certain last names \(duck and mouse for example\) repeat in the data above. We can get a count of each last name by 
+running a GROUP BY query on a JsonPath expression.
+
+```text
+  SELECT json_extract_scalar(jsoncolumn, '$.name.last', 'STRING', 'null') last_name,
+         count(*)
+    FROM myTable
+   WHERE JSON_MATCH(jsoncolumn, '"$.data[1]" IS NOT NULL')
+GROUP BY json_extract_scalar(jsoncolumn, '$.name.last', 'STRING', 'null')
 ORDER BY 2 DESC
 ```
 |jsoncolumn.name.last|count(*)|
@@ -86,19 +93,19 @@ ORDER BY 2 DESC
 |"dwag"|"1"|
 
 
-Also there is numerical information \(jsconcolumn.score\) embeded within the JSON document. We can extract those numerical values from JSON data into SQL and sum them up using the query below.
+Also there is numerical information \(jsconcolumn.$.id\) embeded within the JSON document. We can extract those 
+numerical values from JSON data into SQL and sum them up using the query below.
 
-```json
-SELECT jsoncolumn.name.last, sum(jsoncolumn.score) 
-FROM myTable 
-WHERE jsoncolumn.name.last IS NOT NULL 
-GROUP BY jsoncolumn.name.last
+```text
+  SELECT json_extract_scalar(jsoncolumn, '$.name.last', 'STRING', 'null') last_name,
+         sum(json_extract_scalar(jsoncolumn, '$.id', 'INT', 0)) total
+    FROM myTable
+   WHERE JSON_MATCH(jsoncolumn, '"$.name.last" IS NOT NULL')
+GROUP BY json_extract_scalar(jsoncolumn, '$.name.last', 'STRING', 'null')
 ```
 |jsoncolumn.name.last|sum(jsoncolumn.score)|
 | ----------- | ----------- |
 |"mouse"|"207"|
 |"dwag"|"104"|
 |"duck"|"203"|
-
-In short, JSON querying support in Pinot will allow you to use a JsonPath expression whereever you can use a column name with the only difference being that to query a column with data type JSON, you must append a JsonPath expression after the name of the column.
 


### PR DESCRIPTION
This is to update the JSON queries documentation to show usage of JSON_EXTRACT_SCALAR and JSON_MATCH function instead of the earlier unsupported dot notation.