### PR TITLE
add topic rate limit to list of streamConfig on Kafka page

### DIFF
--- a/basics/data-import/pinot-stream-ingestion/import-from-apache-kafka.md
+++ b/basics/data-import/pinot-stream-ingestion/import-from-apache-kafka.md
@@ -222,6 +222,7 @@ Here is an example config which uses SSL based authentication to talk with kafka
         "stream.kafka.zk.broker.url": "localhost:2191/kafka",
         "stream.kafka.broker.list": "localhost:9876",
         "schema.registry.url": "",
+        "topic.consumption.rate.limit": 10000,
         "security.protocol": "SSL",
         "ssl.truststore.location": "",
         "ssl.keystore.location": "",


### PR DESCRIPTION
I don't see a table explaining each config key's description and suggested values like other pages. but here is a start