### PR TITLE
Add docs for UTF8 and Base64 functions

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -207,6 +207,7 @@
   * [arrayUnionInt](configuration-reference/functions/arrayunionint.md)
   * [arrayUnionString](configuration-reference/functions/arrayunionstring.md)
   * [AVGMV](configuration-reference/functions/avgmv.md)
+  * [Base64](configuration-reference/functions/base64.md)
   * [ceil](configuration-reference/functions/ceil.md)
   * [CHR](configuration-reference/functions/chr.md)
   * [codepoint](configuration-reference/functions/codepoint.md)

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -317,6 +317,7 @@
   * [trim](configuration-reference/functions/trim.md)
   * [upper](configuration-reference/functions/upper.md)
   * [Url](configuration-reference/functions/url.md)
+  * [UTF8](configuration-reference/functions/utf8.md)
   * [VALUEIN](configuration-reference/functions/valuein.md)
   * [week](configuration-reference/functions/week.md)
   * [year](configuration-reference/functions/year.md)

--- a/configuration-reference/functions/README.md
+++ b/configuration-reference/functions/README.md
@@ -134,6 +134,7 @@ This page contains reference documentation for functions in Apache Pinot.
 {% page-ref page="trim.md" %}
 {% page-ref page="upper.md" %}
 {% page-ref page="url.md" %}
+{% page-ref page="utf8.md" %}
 {% page-ref page="valuein.md" %}
 {% page-ref page="week.md" %}
 {% page-ref page="year.md" %}

--- a/configuration-reference/functions/README.md
+++ b/configuration-reference/functions/README.md
@@ -26,6 +26,7 @@ This page contains reference documentation for functions in Apache Pinot.
 {% page-ref page="arrayunionint.md" %}
 {% page-ref page="arrayunionstring.md" %}
 {% page-ref page="avgmv.md" %}
+{% page-ref page="base64.md" %}
 {% page-ref page="ceil.md" %}
 {% page-ref page="chr.md" %}
 {% page-ref page="codepoint.md" %}

--- a/configuration-reference/functions/base64.md
+++ b/configuration-reference/functions/base64.md
@@ -6,8 +6,8 @@ description: This section contains reference documentation for base64 encode and
 
 Encoding scheme follows [java.util.Base64.Encoder](https://docs.oracle.com/javase/8/docs/api/java/util/Base64.Encoder.html)
 
-`toBase64` returns Base64-encoded string of input binary data (`bytes` type). 
-`fromBase64` returns binary data (represented as a Hex string) from Base64-encoded string.
+* `toBase64` returns Base64 encoded string of input binary data (`bytes` type). 
+* `fromBase64` returns binary data (represented as a Hex string) from Base64-encoded string.
 
 ## Signature
 
@@ -18,8 +18,8 @@ Encoding scheme follows [java.util.Base64.Encoder](https://docs.oracle.com/javas
 ## Usage Examples
 
 {% hint style="info" %}
-For better readability, the following examples converts string `hello!` into BYTES using [toUtf8]() function 
-and converts the decoded BYTES into string using [fromUtf8]().
+For better readability, the following examples converts string `hello!` into BYTES using [toUtf8](https://docs.pinot.apache.org/configuration-reference/functions/utf8) function 
+and converts the decoded BYTES into string using [fromUtf8](https://docs.pinot.apache.org/configuration-reference/functions/utf8).
 {% endhint %}
 
 ```sql

--- a/configuration-reference/functions/base64.md
+++ b/configuration-reference/functions/base64.md
@@ -1,0 +1,65 @@
+---
+description: This section contains reference documentation for base64 encode and decode functions.
+---
+
+# Base64
+
+Encoding scheme follows [java.util.Base64.Encoder](https://docs.oracle.com/javase/8/docs/api/java/util/Base64.Encoder.html)
+
+`toBase64` returns Base64-encoded string of input binary data (`bytes` type). 
+`fromBase64` returns binary data (represented as a Hex string) from Base64-encoded string.
+
+## Signature
+
+> toBase64(bytesCol)
+>
+> fromBase64(stringCol)
+
+## Usage Examples
+
+{% hint style="info" %}
+For better readability, the following examples converts string `hello!` into BYTES using [toUtf8]() function 
+and converts the decoded BYTES into string using [fromUtf8]().
+{% endhint %}
+
+```sql
+SELECT toBase64(toUtf8('hello!')) AS encoded
+FROM ignoreMe
+```
+
+| encoded  |
+|----------|
+| aGVsbG8h |
+
+```sql
+SELECT fromUtf8(fromBase64('aGVsbG8h')) AS decoded
+FROM ignoreMe
+```
+
+| decoded |
+|---------|
+| hello!  |
+
+{% hint style="info" %}
+Note that without UTF8 string conversion, returned BYTES will be represented as 
+a Hex string following Pinot's [BYTES column representation](https://docs.pinot.apache.org/users/user-guide-query/querying-pinot#bytes-column).
+See the example below.
+{% endhint %}
+
+```sql
+SELECT fromBase64('aGVsbG8h') AS decoded
+FROM ignoreMe
+```
+
+| decoded       |
+|---------------|
+| 68656c6c6f21  |
+
+{% hint style="warning" %}
+Note that the following query will throw compilation error as string is not a valid input type for `toBase64`.
+{% endhint %}
+
+```sql
+SELECT toBase64('hello!') AS encoded
+FROM ignoreMe
+```

--- a/configuration-reference/functions/utf8.md
+++ b/configuration-reference/functions/utf8.md
@@ -1,0 +1,34 @@
+---
+description: This section contains reference documentation for UTF8 encode/decode functions.
+---
+
+# UTF8
+
+* `fromUtf8` returns UTF8 encoded string of input binary data (`bytes` type).
+* `toUtf8` returns binary data (represented as a Hex string) from a UTF8 encoded string.
+
+## Signature
+
+> fromUtf8(bytesCol)
+>
+> toUtf8(string)
+
+## Usage Examples
+
+```sql
+SELECT bytesCol1, fromUtf8(bytesCol1) AS utf8Str
+FROM testTable
+LIMIT 1
+```
+| bytesCol1   | utf8Str|
+|-------------|--------| 
+| 68656c6c6f21| hello! |
+
+```sql
+SELECT toUtf8('hello!') AS binaryOutput
+FROM ignoreMe
+```
+
+| binaryOutput |
+|--------------|
+| 68656c6c6f21 |

--- a/users/user-guide-query/supported-transformations.md
+++ b/users/user-guide-query/supported-transformations.md
@@ -48,8 +48,8 @@ Multiple string functions are supported out of the box from release-0.5.0 .
 | <p><a href="../../configuration-reference/functions/remove.md"><strong>remove(input, search)</strong></a><br>removes all instances of search from string</p>                                                                                                                     |
 | <p><a href="../../configuration-reference/functions/url.md"><strong>urlEncoding(string)</strong></a><br>url-encode a string with UTF-8 format</p>                                                                                                                                |
 | <p><a href="../../configuration-reference/functions/url.md"><strong>urlDecoding(string)</strong></a><br>decode a url to plaintext string</p>                                                                                                                                     |
-| <p><a href="../../configuration-reference/functions/base64.md"><strong>fromBase64(string)</strong></a><br>decode a Base64-encoded to bytes represented as a hex string</p>                                                                                                       |
-
+| <p><a href="../../configuration-reference/functions/base64.md"><strong>fromBase64(string)</strong></a><br>decode a Base64-encoded string to bytes represented as a hex string</p>                                                                                                |
+| <p><a href="../../configuration-reference/functions/utf8.md"><strong>toUtf8(string)</strong></a><br>decode a UTF8-encoded string to bytes represented as a hex string</p>                                                                                                        |
 ## DateTime Functions
 
 Date time functions allow you to perform transformations on columns that contain timestamps or dates.
@@ -131,6 +131,7 @@ These functions can be used for column transformation in table ingestion configs
 | <p><a href="../../configuration-reference/functions/sha512.md"><strong>SHA512(bytesCol)</strong></a><br>Return SHA-512 digest of binary column(<code>bytes</code> type) as hex string</p> |
 | <p><a href="../../configuration-reference/functions/md5.md"><strong>MD5(bytesCol)</strong></a><br>Return MD5 digest of binary column(<code>bytes</code> type) as hex string</p>           |
 | <p><a href="../../configuration-reference/functions/base64.md"><strong>toBase64(bytesCol)</strong></a><br>Return the Base64-encoded string of binary column(<code>bytes</code> type)</p>  |
+| <p><a href="../../configuration-reference/functions/utf8.md"><strong>fromUtf8(bytesCol)</strong></a><br>Return the UTF8-encoded string of binary column(<code>bytes</code> type)</p>      |
 
 ## Multi-value Column Functions
 

--- a/users/user-guide-query/supported-transformations.md
+++ b/users/user-guide-query/supported-transformations.md
@@ -48,6 +48,7 @@ Multiple string functions are supported out of the box from release-0.5.0 .
 | <p><a href="../../configuration-reference/functions/remove.md"><strong>remove(input, search)</strong></a><br>removes all instances of search from string</p>                                                                                                                     |
 | <p><a href="../../configuration-reference/functions/url.md"><strong>urlEncoding(string)</strong></a><br>url-encode a string with UTF-8 format</p>                                                                                                                                |
 | <p><a href="../../configuration-reference/functions/url.md"><strong>urlDecoding(string)</strong></a><br>decode a url to plaintext string</p>                                                                                                                                     |
+| <p><a href="../../configuration-reference/functions/base64.md"><strong>fromBase64(string)</strong></a><br>decode a Base64-encoded to bytes represented as a hex string</p>                                                                                                       |
 
 ## DateTime Functions
 
@@ -124,11 +125,12 @@ These functions can be used for column transformation in table ingestion configs
 ## Binary Functions
 
 | Function                                                                                                                                                                                  |
-| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | <p><a href="../../configuration-reference/functions/sha.md"><strong>SHA(bytesCol)</strong></a><br>Return SHA-1 digest of binary column(<code>bytes</code> type) as hex string</p>         |
 | <p><a href="../../configuration-reference/functions/sha256.md"><strong>SHA256(bytesCol)</strong></a><br>Return SHA-256 digest of binary column(<code>bytes</code> type) as hex string</p> |
 | <p><a href="../../configuration-reference/functions/sha512.md"><strong>SHA512(bytesCol)</strong></a><br>Return SHA-512 digest of binary column(<code>bytes</code> type) as hex string</p> |
 | <p><a href="../../configuration-reference/functions/md5.md"><strong>MD5(bytesCol)</strong></a><br>Return MD5 digest of binary column(<code>bytes</code> type) as hex string</p>           |
+| <p><a href="../../configuration-reference/functions/base64.md"><strong>toBase64(bytesCol)</strong></a><br>Return the Base64-encoded string of binary column(<code>bytes</code> type)</p>  |
 
 ## Multi-value Column Functions
 


### PR DESCRIPTION
This PR adds user docs for `toUtf8`, `fromUtf8`, `toBase64`, `fromBase64` functions.