### PR TITLE
Add Missing Port 8098 to Pinot Server Container in Docker Compose File

### DIFF
--- a/basics/getting-started/running-pinot-in-docker.md
+++ b/basics/getting-started/running-pinot-in-docker.md
@@ -197,6 +197,8 @@ services:
     command: "StartServer -zkAddress zookeeper:2181"
     restart: unless-stopped
     container_name: "pinot-server" 
+    ports:
+      - "8098:8098"
     environment:
       JAVA_OPTS: "-Dplugins.dir=/opt/pinot/plugins -Xms4G -Xmx16G -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -Xloggc:gc-pinot-server.log"
     depends_on:


### PR DESCRIPTION
Add the missing port 8098 to the Apache Pinot Server container in Docker Compose File. Prevents timeout errors from Apache Pinot Query Console UI when executing SQL queries on tables.