### PR TITLE
document: fix some commands when setup pinot and kafka by docker

### DIFF
--- a/basics/getting-started/pushing-your-data-to-pinot.md
+++ b/basics/getting-started/pushing-your-data-to-pinot.md
@@ -132,7 +132,7 @@ Upload the table config using the following command
 {% tab title="Docker" %}
 ```bash
 docker run --rm -ti \
-    --network=pinot-demo_default \
+    --network=pinot-demo \
     -v /tmp/pinot-quick-start:/tmp/pinot-quick-start \
     --name pinot-batch-table-creation \
     apachepinot/pinot:latest AddTable \
@@ -230,7 +230,7 @@ Use the following command to generate a segment and upload it
 {% tab title="Docker" %}
 ```
 docker run --rm -ti \
-    --network=pinot-demo_default \
+    --network=pinot-demo \
     -v /tmp/pinot-quick-start:/tmp/pinot-quick-start \
     --name pinot-data-ingestion-job \
     apachepinot/pinot:latest LaunchDataIngestionJob \

--- a/basics/getting-started/pushing-your-streaming-data-to-pinot.md
+++ b/basics/getting-started/pushing-your-streaming-data-to-pinot.md
@@ -20,7 +20,7 @@ Let's setup a demo Kafka cluster locally, and create a sample topic `transcript-
 
 ```
 docker run \
-    --network pinot-demo_default --name=kafka \
+    --network pinot-demo --name=kafka \
     -e KAFKA_ZOOKEEPER_CONNECT=manual-zookeeper:2181/kafka \
     -e KAFKA_BROKER_ID=0 \
     -e KAFKA_ADVERTISED_HOST_NAME=kafka \
@@ -108,7 +108,7 @@ Now that we have our table and schema, let's upload them to the cluster. As soon
 {% tab title="Docker" %}
 ```bash
 docker run \
-    --network=pinot-demo_default \
+    --network=pinot-demo \
     -v /tmp/pinot-quick-start:/tmp/pinot-quick-start \
     --name pinot-streaming-table-creation \
     apachepinot/pinot:latest AddTable \

--- a/basics/getting-started/running-pinot-in-docker.md
+++ b/basics/getting-started/running-pinot-in-docker.md
@@ -171,15 +171,15 @@ services:
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
       ZOOKEEPER_TICK_TIME: 2000
-  pinot-quickstart:
+  pinot-controller:
     image: apachepinot/pinot:0.9.3
     command: "StartController -zkAddress pinot-zookeeper:2181"
-    container_name: pinot-quickstart
+    container_name: pinot-controller
     restart: unless-stopped
     ports:
       - "9000:9000"
     environment:
-      JAVA_OPTS: "-Dplugins.dir=/opt/pinot/plugins -Xms1G -Xmx4G -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -Xloggc:gc-pinot-quickstart.log"
+      JAVA_OPTS: "-Dplugins.dir=/opt/pinot/plugins -Xms1G -Xmx4G -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -Xloggc:gc-pinot-controller.log"
     depends_on:
       - pinot-zookeeper
   pinot-broker:
@@ -192,7 +192,7 @@ services:
     environment:
       JAVA_OPTS: "-Dplugins.dir=/opt/pinot/plugins -Xms4G -Xmx4G -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -Xloggc:gc-pinot-broker.log"
     depends_on:
-      - pinot-quickstart
+      - pinot-controller
   pinot-server:
     image: apachepinot/pinot:0.9.3
     command: "StartServer -zkAddress pinot-zookeeper:2181"
@@ -225,7 +225,7 @@ docker container ls
 CONTAINER ID   IMAGE                     COMMAND                  CREATED              STATUS              PORTS                                                                     NAMES
 ba5cb0868350   apachepinot/pinot:0.9.3   "./bin/pinot-admin.s…"   About a minute ago   Up About a minute   8096-8099/tcp, 9000/tcp                                                   pinot-server
 698f160852f9   apachepinot/pinot:0.9.3   "./bin/pinot-admin.s…"   About a minute ago   Up About a minute   8096-8098/tcp, 9000/tcp, 0.0.0.0:8099->8099/tcp, :::8099->8099/tcp        pinot-broker
-b1ba8cf60d69   apachepinot/pinot:0.9.3   "./bin/pinot-admin.s…"   About a minute ago   Up About a minute   8096-8099/tcp, 0.0.0.0:9000->9000/tcp, :::9000->9000/tcp                  pinot-quickstart
+b1ba8cf60d69   apachepinot/pinot:0.9.3   "./bin/pinot-admin.s…"   About a minute ago   Up About a minute   8096-8099/tcp, 0.0.0.0:9000->9000/tcp, :::9000->9000/tcp                  pinot-controller
 54e7e114cd53   zookeeper:3.5.6           "/docker-entrypoint.…"   About a minute ago   Up About a minute   2888/tcp, 3888/tcp, 0.0.0.0:2181->2181/tcp, :::2181->2181/tcp, 8080/tcp   pinot-zookeeper
 ```
 


### PR DESCRIPTION
Hey team, I recently practiced with Pinot and wish to contribute some documentation. 

Update some descriptions for the Pinot and Kafka docker setup. 

Includes: 
- consistent docker network setting name to `pinot-demo`
- consistent kafka port to 9092 and add some docker run command with export port
- consistent zookeeper name to pinot-zookeeper and controller name to pinot-controller

I tested Kafka to pinot end to end from my local desktop.