### PR TITLE
Provide correct class name for segmentMetadataPushJobRunnerClassName …

### DIFF
--- a/users/tutorials/ingest-parquet-files-from-s3-using-spark.md
+++ b/users/tutorials/ingest-parquet-files-from-s3-using-spark.md
@@ -149,7 +149,7 @@ executionFrameworkSpec:
   segmentGenerationJobRunnerClassName: 'org.apache.pinot.plugin.ingestion.batch.spark.SparkSegmentGenerationJobRunner'
   segmentTarPushJobRunnerClassName: 'org.apache.pinot.plugin.ingestion.batch.spark.SparkSegmentTarPushJobRunner'
   segmentUriPushJobRunnerClassName: 'org.apache.pinot.plugin.ingestion.batch.spark.SparkSegmentUriPushJobRunner'
-  segmentMetadataPushJobRunnerClassName: 'org.apache.pinot.plugin.ingestion.batch.standalone.SegmentMetadataPushJobRunner'
+  segmentMetadataPushJobRunnerClassName: 'org.apache.pinot.plugin.ingestion.batch.spark.SparkSegmentMetadataPushJobRunner'
   extraConfigs:
       stagingDir: s3://my-bucket/spark/staging/
 # jobType: Pinot ingestion job type.


### PR DESCRIPTION
…when using Spark

When you run these jobs on Spark, you don't want `org.apache.pinot.plugin.ingestion.batch.standalone.SegmentMetadataPushJobRunner`, you want `org.apache.pinot.plugin.ingestion.batch.spark.SparkSegmentMetadataPushJobRunner`. 