### PR TITLE
Correction in native text index config exmaple

### DIFF
--- a/basics/indexing/native-text-index.md
+++ b/basics/indexing/native-text-index.md
@@ -72,7 +72,7 @@ Native text indices are a type of text search index that Pinot supports, hence a
      "name":"text_col_1",
      "encodingType":"RAW",
      "indexType":"TEXT",
-     "properties":[{"fstType":"native"}]
+     "properties":{"fstType":"native"}
   }
 ]
 ```


### PR DESCRIPTION
The properties field in `fieldConfigList` is a map and not an array. The given config causes the following error:
```Invalid table config: test_table_REALTIME with error: Cannot deserialize instance of `java.util.LinkedHashMap<java.lang.Object,java.lang.Object>` out of START_ARRAY token
 at [Source: (String)"{"tableName":"rta_mob_analytics_ry_REALTIME","tableType":"REALTIME","segmentsConfig":{"segmentAssignmentStrategy":"BalanceNumSegmentAssignmentStrategy","timeColumnName":"secondsSinceEpoch","timeType":"SECONDS","retentionTimeUnit":"DAYS","retentionTimeValue":"2","deletedSegmentsRetentionPeriod":"0d","schemaName":"rta_mob_analytics_ry","replicasPerPartition":"2","peerSegmentDownloadScheme":"http","minimizeDataMovement":false,"segmentPushType":"APPEND","replication":"2"},"tenants":{"broker":"broker"[truncated 1139 chars]; line: 1, column: 1596] (through reference chain: org.apache.pinot.spi.config.table.TableConfig["fieldConfigList"]->java.util.ArrayList[0]->org.apache.pinot.spi.config.table.FieldConfig["properties"])```

Java representation of `properties` field as Map in code: https://github.com/apache/pinot/blob/master/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/FieldConfig.java