### PR TITLE
Correcting time interval format for controller.task.frequencyPeriod

### DIFF
--- a/operators/operating-pinot/minion-merge-rollup-task.md
+++ b/operators/operating-pinot/minion-merge-rollup-task.md
@@ -58,7 +58,7 @@ The PinotTaskManager periodic task is disabled by default. Enable it by adding t
 
 ```
 controller.task.scheduler.enabled=true
-controller.task.frequencyPeriod=3600
+controller.task.frequencyPeriod=1h
 ```
 
 **Step 3**: Advanced configs


### PR DESCRIPTION
Avoid exception on startup: Change unqualified "3600" to qualified "1h"