### PR TITLE
Mark the OPTION keyword as deprecated.

### DIFF
--- a/users/user-guide-query/query-options.md
+++ b/users/user-guide-query/query-options.md
@@ -24,17 +24,7 @@ description: This document contains all the available query options
 
 ## Set Query Options
 
-### Before release 0.11.0
-
-Before release 0.11.0, query options can be appended to the query with the `OPTION` keyword:
-
-```sql
-SELECT * FROM myTable OPTION(key1=value1, key2=123)
-SELECT * FROM myTable OPTION(key1=value1) OPTION(key2=123)
-SELECT * FROM myTable OPTION(timeoutMs=30000)
-```
-
-### After release 0.11.0
+### SET statement
 
 After release 0.11.0, query options can be set using the `SET` statement:
 
@@ -42,4 +32,14 @@ After release 0.11.0, query options can be set using the `SET` statement:
 SET key1 = 'value1';
 SET key2 = 123;
 SELECT * FROM myTable
+```
+
+### OPTION keyword (**deprecated**)
+
+Before release 0.11.0, query options can be appended to the query with the `OPTION` keyword:
+
+```sql
+SELECT * FROM myTable OPTION(key1=value1, key2=123)
+SELECT * FROM myTable OPTION(key1=value1) OPTION(key2=123)
+SELECT * FROM myTable OPTION(timeoutMs=30000)
 ```

--- a/users/user-guide-query/query-options.md
+++ b/users/user-guide-query/query-options.md
@@ -34,7 +34,7 @@ SET key2 = 123;
 SELECT * FROM myTable
 ```
 
-### OPTION keyword (**deprecated**)
+### OPTION keyword (deprecated)
 
 Before release 0.11.0, query options can be appended to the query with the `OPTION` keyword:
 


### PR DESCRIPTION
There is a bug that the OPTION keyword does not honor the "--" comment delimiter. Instead of fixing the bug, we mark the OPTION keyword as deprecated and encourage the users to use the SET keyword.