### PR TITLE
Add contributing guidelines and WIP style guide

### DIFF
--- a/basics/indexing/star-tree-index.md
+++ b/basics/indexing/star-tree-index.md
@@ -83,17 +83,15 @@ The star-tree data structure offers a configurable trade-off between space and t
 
 **Tree structure**
 
-Star tree is a tree data structure that consists of the following properties:
+The star-tree index stores data in a structure that consists of the following properties:
 
-![](../../.gitbook/assets/structure.png)
+![Star-tree index structure](../../.gitbook/assets/structure.png)
 
-Star tree Structure
-
-* **Root Node** (Orange): Single root node, from which the rest of the tree can be traversed.
-* **Leaf Node** (Blue): A leaf node can containing at most _T_ records, where _T_ is configurable.
-* **Non-leaf Node** (Green): Nodes with more than _T_ records are further split into children nodes.
-* **Star-Node** (Yellow): Non-leaf nodes can also have a special child node called the Star-Node. This node contains the pre-aggregated records after removing the dimension on which the data was split for this level.
-* **Dimensions Split Order** (\[D1, D2]): Nodes at a given level in the tree are split into children nodes on all values of a particular dimension. The dimensions split order is an ordered list of dimensions that is used to determine the dimension to split on for a given level in the tree.
+* **Root node** (Orange): Single root node, from which the rest of the tree can be traversed.
+* **Leaf node** (Blue): A leaf node can containing at most _T_ records, where _T_ is configurable.
+* **Non-leaf node** (Green): Nodes with more than _T_ records are further split into children nodes.
+* **Star-node** (Yellow): Non-leaf nodes can also have a special child node called the Star-Node. This node contains the pre-aggregated records after removing the dimension on which the data was split for this level.
+* **Dimensions split order** (\[D1, D2]): Nodes at a given level in the tree are split into children nodes on all values of a particular dimension. The dimensions split order is an ordered list of dimensions that is used to determine the dimension to split on for a given level in the tree.
 
 **Node properties**
 

--- a/contributing/contributing.md
+++ b/contributing/contributing.md
@@ -26,7 +26,7 @@ Use the GitHub web interface to create a pull request (PR) for review.
 ### Get and incorporate review 
 Wait. The Pinot documentation team will usually review pull requests within a few days. Suggestions or changes may be requested. You can make these by updating in your local branch and pushing those changes.
 
-Once the PR is approved, it will be merged by one of the code owners. When that happens, the changes will automatically applied to the corresponding GitBook pages.
+Once the PR is approved, one of the code owners will merge it. When that happens, the changes automatically appear on the corresponding GitBook pages.
 
 Note that all GitBook documentation follows [Markdown Syntax](https://www.markdownguide.org/basic-syntax/).
 

--- a/contributing/contributing.md
+++ b/contributing/contributing.md
@@ -21,7 +21,7 @@ Modify the documentation locally on your machine. When you commit, write a meani
 Then, push your changes to your fork on GitHub.
 
 ### Submit a pull request
-Use the GitHub web interface to create a pull request (PR) for review.
+Use the GitHub web interface to [create a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) (PR) for review.
 
 ### Get and incorporate review 
 Wait. The Pinot documentation team will usually review pull requests within a few days. Suggestions or changes may be requested. You can make these by updating in your local branch and pushing those changes.

--- a/contributing/contributing.md
+++ b/contributing/contributing.md
@@ -1,0 +1,45 @@
+# Contributing to the Pinot docs
+
+Pinot documentation is powered by [GitBook](https://www.gitbook.com/).
+
+A bidirectional GitHub integration exists as a back-up for content. You can find it at [https://github.com/pinot-contrib/pinot-docs](https://github.com/pinot-contrib/pinot-docs).
+
+To suggest updates to the documentation, follow the directions below.
+
+## Make suggested updates
+
+### Fork and clone the Pinot documentation repository
+If you are familiar with using Git and GitHub, you can [fork](https://docs.github.com/en/get-started/quickstart/fork-a-repo) the [pinot-docs](https://github.com/pinot-contrib/pinot-docs) repository. This will create your own version of the repository, which you can find at `https://github.com/{yourusername}/pinot-docs`, where `{yourusername}` is the username you created in GitHub. 
+
+[Clone from the fork](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository) to your local machine.
+
+### Make changes
+Modify the documentation locally on your machine. When you commit, write a meaningful and clear commit message, such as:
+
+`git commit -m 'Fixes a typo on the Update Documentation page'`
+
+Then, push your changes to your fork on GitHub.
+
+### Submit a pull request
+Use the GitHub web interface to create a pull request (PR) for review.
+
+### Get and incorporate review 
+Wait. The Pinot documentation team will usually review pull requests within a few days. Suggestions or changes may be requested. You can make these by updating in your local branch and pushing those changes.
+
+Once the PR is approved, it will be merged by one of the code owners. When that happens, the changes will automatically applied to the corresponding GitBook pages.
+
+Note that all GitBook documentation follows [Markdown Syntax](https://www.markdownguide.org/basic-syntax/).
+
+## Edit directly on GitBook
+
+If you're an active and trusted contributor, you can request access to edit the documentation directly with the [GitBook UI](https://app.gitbook.com/@apache-pinot/s/apache-pinot-cookbook/). 
+
+Contact the site admin by emailing [dev@pinot.apache.org](mailto:dev@pinot.apache.org) with your request for edit permission and a description of the content you would like to edit or add.
+
+Changes made using this method are automatically merged into the GitHub repo, as can be seen in [this commit](https://github.com/pinot-contrib/pinot-docs/commit/40184fd7563402a7527674991b6abbf9ae2ce7c3).
+
+## Style and formatting
+
+All of Pinot's documentation is written in [Markdown](https://en.wikipedia.org/wiki/Markdown). 
+
+For style guidelines, see the [Apache Pinot style guide](https://github.com/pinot-contrib/pinot-docs/blob/latest/contributing/style-guide.md).

--- a/contributing/contributing.md
+++ b/contributing/contributing.md
@@ -1,4 +1,4 @@
-# Contributing to the Pinot docs
+# Contributing to the Apache Pinot documentation
 
 Pinot documentation is powered by [GitBook](https://www.gitbook.com/).
 

--- a/contributing/style-guide.md
+++ b/contributing/style-guide.md
@@ -1,0 +1,12 @@
+# Pinot documentation style guide
+
+The guidelines below are specific to Apache Pinot's documentation. 
+ 
+ For general style questions or guidance on tpics not covered here, see the [Google style guide](https://developers.google.com/style) 
+
+## Star-tree index
+When describing the index type, use star-tree (adjective) or star tree (noun). StarTree refers to the company only. 
+
+
+
+

--- a/contributing/style-guide.md
+++ b/contributing/style-guide.md
@@ -2,7 +2,7 @@
 
 The guidelines below are specific to Apache Pinot's documentation. 
  
- For general style questions or guidance on tpics not covered here, see the [Google style guide](https://developers.google.com/style) 
+ For general style questions or guidance on topics not covered here, see the [Google developer documentation style guide](https://developers.google.com/style) 
 
 ## Star-tree index
 When describing the index type, use star-tree (adjective) or star tree (noun). StarTree refers to the company only. 

--- a/developers/developers-and-contributors/update-document.md
+++ b/developers/developers-and-contributors/update-document.md
@@ -1,35 +1,3 @@
-# Update Documentation
+# Update documentation
 
-Pinot documentation is powered by [GitBook](https://www.gitbook.com/).
-
-A bidirectional GitHub integration exists as a back up for content. You can find it at [https://github.com/pinot-contrib/pinot-docs](https://github.com/pinot-contrib/pinot-docs).
-
-If you would like to contribute changes or additions, two methods are available: you can submit a pull request or edit directly on GitBook.
-
-### Submit a Pull Request
-
-If you are familiar with using Git and GitHub, you can fork the [pinot-docs](https://github.com/pinot-contrib/pinot-docs) repo. This will create your own version of the repository, which you can find at `https://github.com/{yourusername}/pinot-docs`, where `{yourusername}` is the username you created in GitHub.
-
-Clone from the fork to your local machine.
-
-Then, modify the documentation locally on your machine. When you commit, please write a meaningful and clear commit message, such as:
-
-`git commit -m 'Fixes a typo on the Update Documentation page'`
-
-Then push your changes to your fork on GitHub.
-
-Use the GitHub web interface to create a pull request (PR) for review.
-
-Wait. The Pinot documentation team will usually review pull requests within a few days. Suggestions or changes may be requested. You can make these by updating in your local branch and pushing those changes.
-
-Once the PR is approved, it will be merged by one of the code owners. When that happens, the changes will automatically applied to the corresponding GitBook pages.
-
-Please note that all GitBook documentation follows [Markdown Syntax](https://www.markdownguide.org/basic-syntax/).
-
-### Edit Directly on GitBook
-
-Some trusted contributors are given the ability to edit any page via the [Pinot GitBook UI](https://app.gitbook.com/@apache-pinot/s/apache-pinot-cookbook/) and then save and merge the changes themselves. This permission is typically granted to active contributors and committers, by request (and review).
-
-Please contact the site admin by emailing [dev@pinot.apache.org](mailto:dev@pinot.apache.org) with your request for edit permission and a description of the content you would like to edit or add.
-
-Changes made using this method are automatically merged into the GitHub repo, such as can be seen in [this commit](https://github.com/pinot-contrib/pinot-docs/commit/40184fd7563402a7527674991b6abbf9ae2ce7c3).
+For documentation contribution guidelines, see [Contributing to the Apache Pinot documentation](https://github.com/pinot-contrib/pinot-docs/blob/latest/contributing/CONTRIBUTING.md)


### PR DESCRIPTION
I'm not 100% sure on how we keep this on GitHub and not in the live site/Gitbook--probably something with Gitbook configuration we need to figure out.