### PR TITLE
Add ingestion options to streaming and batch ingestion configs

### DIFF
--- a/basics/data-import/batch-ingestion/README.md
+++ b/basics/data-import/batch-ingestion/README.md
@@ -1,21 +1,21 @@
-# Batch Ingestion
+# Batch ingestion
 
-Batch ingestion allows users to create a table using data already present in a file system such as S3. This is particularly useful for the cases where the user wants to utilize Pinot's ability to query large data with minimal latency or test out new features using a simple data file.
+Batch ingestion lets you create a table using data already present in a file system such as S3. This is particularly useful for the cases where you want to use Pinot's ability to query large data with minimal latency or test out new features using a simple data file.
 
-Ingesting data from a filesystem involves the following steps -
+Ingesting data from a filesystem involves the following steps:
 
-1. Define Schema
-2. Define Table Config
-3. Upload Schema and Table configs
+1. Create schema configuration
+2. Create table configuration
+3. Upload schema and table configs
 4. Upload data
 
-Batch Ingestion currently supports the following mechanisms to upload the data -
+Batch ingestion currently supports the following mechanisms to upload the data:
 
 * Standalone
 * [Hadoop](hadoop.md)
 * [Spark](spark.md)
 
-Here we'll take a look at the standalone local processing to get you started.
+Here, we'll take a look at the standalone local processing to get you started.
 
 Let's create a table for the following CSV data source.
 
@@ -27,9 +27,9 @@ studentID,firstName,lastName,gender,subject,score,timestampInEpoch
 202,Nick,Young,Male,Physics,3.6,1572418800000
 ```
 
-## Create Schema Configuration
+## Create schema configuration
 
-In our data, the only column on which aggregations can be performed is score. Secondly, timestampInEpoch is the only timestamp column. So, on our schema, we keep score as metric and timestampInEpoch as timestamp column.
+In our data, the only column on which aggregations can be performed is `score`. Secondly, `timestampInEpoch` is the only timestamp column. So, on our schema, we keep `score` as metric and `timestampInEpoch` as timestamp column.
 
 ```
 {
@@ -71,11 +71,11 @@ In our data, the only column on which aggregations can be performed is score. Se
 }
 ```
 
-Here, we have also defined two extra fields - format and granularity. The format specifies the formatting of our timestamp column in the data source. Currently, it is in milliseconds hence we have specified `1:MILLISECONDS:EPOCH`
+Here, we have also defined two extra fields: format and granularity. The format specifies the formatting of our timestamp column in the data source. Currently, it's in milliseconds, so we've specified `1:MILLISECONDS:EPOCH`.
 
-## **Create Table Configuration**
+## **Create table configuration**
 
-We define a table`transcript`and map the schema created in the previous step to the table. For batch data, we keep the `tableType` as `OFFLINE`
+We define a table `transcript` and map the schema created in the previous step to the table. For batch data, we keep the `tableType` as `OFFLINE`.
 
 ```
 {
@@ -99,15 +99,19 @@ We define a table`transcript`and map the schema created in the previous step to 
     "batchIngestionConfig": {
       "segmentIngestionType": "APPEND",
       "segmentIngestionFrequency": "DAILY"
-    }
+    },
+    "continueOnError": true,
+    "rowTimeValueCheck": true,
+    "segmentTimeValueCheck": false
+
   },
   "metadata": {}
 }
 ```
 
-## Upload Schema and Table
+## Upload schema and table configs
 
-Now that we have both the configs, we can simply upload them and create a table. To achieve that, just run the command -
+Now that we have both the configs, we can upload them and create a table by running the following command:
 
 ```
 bin/pinot-admin.sh AddTable \\
@@ -115,25 +119,25 @@ bin/pinot-admin.sh AddTable \\
   -schemaFile /path/to/table-schema.json -exec
 ```
 
-Check out the table config and schema in the \[Rest API] to make sure it was successfully uploaded.
+Check out the table config and schema in the `\[Rest API]` to make sure it was successfully uploaded.
 
-## **Upload data**
+## Upload data
 
-We now have an empty table in pinot. So as the next step we will upload our CSV file to this table.&#x20;
+We now have an empty table in Pinot. Next, we'll upload our CSV file to this empty table.
 
-A table is composed of multiple segments. The segments can be created using three ways
+A table is composed of multiple segments. The segments can be created in the following three ways:
 
-1\) Minion based ingestion\
-2\) Upload API\
-3\) Ingestion jobs
+- Minion based ingestion\
+- Upload API\
+- Ingestion jobs
 
-### Minion Based Ingestion
+### Minion-based ingestion
 
 Refer to [SegmentGenerationAndPushTask](../../components/minion.md#segmentgenerationandpushtask)
 
 ### Upload API
 
-There are 2 Controller APIs that can be used for a quick ingestion test using a small file.&#x20;
+There are 2 controller APIs that can be used for a quick ingestion test using a small file.&#x20;
 
 {% hint style="danger" %}
 **When these APIs are invoked, the controller has to download the file and build the segment locally.**
@@ -185,11 +189,11 @@ curl -X POST "http://localhost:9000/ingestFromURI?tableNameWithType=foo_OFFLINE
 &sourceURIStr=s3://test.bucket/path/to/json/data/data.json"
 ```
 
-### Ingestion Jobs
+### Ingestion jobs
 
-Segments can be created and uploaded using tasks known as DataIngestionJobs. A job also needs a config of its own. We call this config the JobSpec.
+Segments can be created and uploaded using tasks known as `DataIngestionJobs`. A job also needs a config of its own. We call this config the `JobSpec`.
 
-For our CSV file and table, the job spec should look like below.
+For our CSV file and table, the `JobSpec` should look like this:
 
 ```
 executionFrameworkSpec:
@@ -222,22 +226,26 @@ pushJobSpec:
   pushRetryIntervalMillis: 1000
 ```
 
-You can refer to [Ingestion Job Spec](../../../configuration-reference/job-specification.md) for more details.
+For more detail, refer to [Ingestion job spec](../../../configuration-reference/job-specification.md).
 
-Now that we have the job spec for our table `transcript` , we can trigger the job using the following command
+Now that we have the job spec for our table `transcript`, we can trigger the job using the following command:
 
 ```
 bin/pinot-admin.sh LaunchDataIngestionJob \\
     -jobSpecFile /tmp/pinot-quick-start/batch-job-spec.yaml
 ```
 
-Once the job has successfully finished, you can head over to the \[query console] and start playing with the data.
+Once the job successfully finishes, head over to the `\[query console]` and start playing with the data.
 
-### Segment Push Job Type
+### Segment push job type
 
 There are 3 ways to upload a Pinot segment:
 
-#### 1. Segment Tar Push
+- Segment tar push
+- Segment URI push
+- Segment metadata push
+
+#### Segment tar push
 
 This is the original and default push mechanism.
 
@@ -253,25 +261,25 @@ Tar push requires the segment to be stored locally or can be opened as an InputS
 2. Extract segment metadata.
 3. Add the segment to the table.
 
-#### 2. Segment URI Push
+#### Segment URI push
 
-This push mechanism requires the segment Tar file stored on a deep store with a globally accessible segment tar URI.
+This push mechanism requires the segment tar file stored on a deep store with a globally accessible segment tar URI.
 
-URI push is light-weight on the client-side, and the controller side requires equivalent work as the Tar push.
+URI push is light-weight on the client-side, and the controller side requires equivalent work as the tar push.
 
 **The push job will:**
 
-1. POST this segment Tar URI to the Pinot controller.&#x20;
+1. POST this segment tar URI to the Pinot controller.&#x20;
 
 **Pinot controller will:**
 
-1. Download segment from the URI and save it to controller segment directory(Local or any PinotFS).
+1. Download segment from the URI and save it to controller segment directory (local or any PinotFS).
 2. Extract segment metadata.
 3. Add the segment to the table.
 
-#### 3. Segment Metadata Push
+#### Segment metadata push
 
-This push mechanism also requires the segment Tar file stored on a deep store with a globally accessible segment tar URI.
+This push mechanism also requires the segment tar file stored on a deep store with a globally accessible segment tar URI.
 
 Metadata push is light-weight on the controller side, there is no deep store download involves from the controller side.
 
@@ -291,7 +299,7 @@ This extends the original Segment Metadata Push for cases, where the segments ar
 
 NOTE: the staging location and deep store have to use same storage scheme, like both on s3. This is because the copy is done via PinotFS.copyDir interface that assumes so; but also because this does copy at storage system side, so segments don't need to go through Pinot Controller at all.
 
-To make this work, firstly, grant Pinot controllers access to the staging location. e.g. on AWS, this may be to add access policy like below for the controller EC2 instances
+To make this work, firstly, grant Pinot controllers access to the staging location. For example on AWS, this may be to add an access policy like below for the controller EC2 instances:
 
 ```
 {
@@ -327,22 +335,22 @@ pushJobSpec:
 ...
 ```
 
-### Consistent Data Push and Rollback
+### Consistent data push and rollback
 
-Pinot supports atomic update on segment level, which means that when data consisting of multiple segments are pushed to a table, as segments are replaced one at a time, queries to the broker during this upload phase may produce inconsistent result due to interleaving of old and new data.
+Pinot supports atomic update on segment level, which means that when data consisting of multiple segments are pushed to a table, as segments are replaced one at a time, queries to the broker during this upload phase may produce inconsistent results due to interleaving of old and new data.
 
 See [consistent-push-and-rollback.md](../../../operators/operating-pinot/consistent-push-and-rollback.md "mention") for how to enable this feature.&#x20;
 
-### Segment Fetchers
+### Segment fetchers
 
-When pinot segment files are created in external systems (Hadoop/spark/etc), there are several ways to push those data to the Pinot Controller and Server:
+When Pinot segment files are created in external systems (Hadoop/spark/etc), there are several ways to push those data to the Pinot controller and server:
 
 1. Push segment to shared NFS and let pinot pull segment files from the location of that NFS. See [Segment URI Push](https://docs.pinot.apache.org/basics/data-import/batch-ingestion#2-segment-uri-push).
 2. Push segment to a Web server and let pinot pull segment files from the Web server with HTTP/HTTPS link. See [Segment URI Push](https://docs.pinot.apache.org/basics/data-import/batch-ingestion#2-segment-uri-push).
 3. Push segment to PinotFS(HDFS/S3/GCS/ADLS) and let pinot pull segment files from PinotFS URI. See [Segment URI Push](https://docs.pinot.apache.org/basics/data-import/batch-ingestion#2-segment-uri-push) and [Segment Metadata Push](https://docs.pinot.apache.org/basics/data-import/batch-ingestion#3-segment-metadata-push).
 4. Push segment to other systems and implement your own segment fetcher to pull data from those systems.
 
-The first three options are supported out of the box within the Pinot package. As long your remote jobs send Pinot controller with the corresponding URI to the files it will pick up the file and allocate it to proper Pinot Servers and brokers. To enable Pinot support for PinotFS, you will need to provide [PinotFS](../pinot-file-system/) configuration and proper Hadoop dependencies.
+The first three options are supported out of the box within the Pinot package. As long your remote jobs send Pinot controller with the corresponding URI to the files, it will pick up the file and allocate it to proper Pinot servers and brokers. To enable Pinot support for PinotFS, you'll need to provide [PinotFS](../pinot-file-system/) configuration and proper Hadoop dependencies.
 
 ### Persistence
 

--- a/basics/data-import/pinot-stream-ingestion/README.md
+++ b/basics/data-import/pinot-stream-ingestion/README.md
@@ -105,12 +105,12 @@ The ingestion configuration (`ingestionConfig`) specifies how to ingest streamin
 
 #### Additional ingestion configurations
 
-| **Config key**   | **Description** |
+| **Config key**    | **Description** |
                                                                                                                  
-|------------------|-----------------------------------------------------------------------------------------------------------------------------------|
-| `_continueOnError`| Set to true to skip any row indexing error and move on to the next row. Otherwise, an error when evaluating a transform or filter function may block ingestion (realtime or offline), and segment generation would fail. Note, setting this value to true may result in data loss or corruption. Consider your use case to determine if it may be more appropriate to fail the ingestion to maintain data integrity.|                                                                                                                                    |
-| `rowTimeValueCheck`| Set to true to validate the time column values being ingested during segment upload. Validates whether the value can be parsed with the given time format and falls within a valid time range between 1971 and 2071, and if not, replaces invalid values with null.  
-| `_segmentTimeValueCheck`| Set to true to validate the time range of the segment falls between 1971 and 2071. |
+|-------------------|-----------------------------------------------------------------------------------------------------------------------------------|
+| `_continueOnError`| Set to `true` to skip any row indexing error and move on to the next row. Otherwise, an error evaluating a transform or filter function may block ingestion (realtime or offline), and result in data loss or corruption. Consider your use case to determine if it's preferable to set this option to `false`, and fail the ingestion if an error occurs to maintain data integrity. |
+| `rowTimeValueCheck`| Set to `true` to validate the time column values ingested during segment upload. Validates each row of data in a segment matches the specified time format, and falls within a valid time range (1971-2071). If the value doesn't meet both criteria, Pinot replaces the value with null. This option ensures that the time values are strictly increasing and that there are no duplicates or gaps in the data. |
+| `_segmentTimeValueCheck`| Set to `true` to validate the time range of the segment falls between 1971 and 2071. This option ensures data segments stored in the system are correct and consistent.|
 
 #### Example table config with `ingestionConfig`
 


### PR DESCRIPTION
- Document usage of `rowTimeValueCheck`, `segmentTimeValueCheck` and `continueOnError` in streaming and batch ingestion configs; addresses [DOCS-61](https://cortexdata.atlassian.net/jira/software/c/projects/DOCS/issues/DOCS-61?jql=project%20%3D%20%22DOCS%22%20AND%20status%20IN%20%28%22To%20Do%22%2C%22In%20Progress%22%29%20AND%20priority%20IN%20%28%22High%22%2C%22Highest%22%29%20ORDER%20BY%20created%20DESC)
- misc edits