### PR TITLE
Edits to the remaining index pages as part of site review

### DIFF
--- a/basics/indexing/geospatial-support.md
+++ b/basics/indexing/geospatial-support.md
@@ -2,7 +2,7 @@
 description: This page talks about geospatial support in Pinot.
 ---
 
-# Geospatial
+# Geospatial 
 
 Pinot supports SQL/MM geospatial data and is compliant with the [Open Geospatial Consortium’s (OGC) OpenGIS Specifications](https://www.ogc.org/standards/sfs/). This includes:
 
@@ -12,7 +12,7 @@ Pinot supports SQL/MM geospatial data and is compliant with the [Open Geospatial
 
 ## Geospatial data types
 
-Geospatial data types abstract and encapsulate spatial structures such as boundary and dimension. In many respects, spatial data types can be understood simply as shapes. Pinot supports the Well-Known Text (WKT) and Well-Known Binary (WKB) form of geospatial objects, for example:
+Geospatial data types abstract and encapsulate spatial structures such as boundary and dimension. In many respects, spatial data types can be understood simply as shapes. Pinot supports the Well-Known Text (WKT) and Well-Known Binary (WKB) forms of geospatial objects, for example:
 
 * `POINT (0, 0)`
 * `LINESTRING (0 0, 1 1, 2 1, 2 2)`
@@ -22,7 +22,7 @@ Geospatial data types abstract and encapsulate spatial structures such as bounda
 * `MULTIPOLYGON (((0 0, 4 0, 4 4, 0 4, 0 0), (1 1, 2 1, 2 2, 1 2, 1 1)), ((-1 -1, -1 -2, -2 -2, -2 -1, -1 -1)))`
 * `GEOMETRYCOLLECTION(POINT(2 0),POLYGON((0 0, 1 0, 1 1, 0 1, 0 0)))`
 
-### Geometry vs Geography
+## Geometry vs geography
 
 It is common to have data in which the coordinates are `geographics` or `latitude/longitude.` Unlike coordinates in Mercator or UTM, geographic coordinates are not Cartesian coordinates.
 
@@ -37,7 +37,7 @@ Pinot supports both geometry and geography types, which can be constructed by th
 
 For manipulating geospatial data, Pinot provides a set of functions for analyzing geometric components, determining spatial relationships, and manipulating geometries. In particular, geospatial functions that begin with the `ST_` prefix support the SQL/MM specification.
 
-Following geospatial functions are available out of the box in Pinot-
+Following geospatial functions are available out of the box in Pinot:
 
 ### Aggregations
 
@@ -50,7 +50,7 @@ Following geospatial functions are available out of the box in Pinot-
 * [**ST\_Point(double x, double y) → Point**](../../configuration-reference/functions/stpoint.md) Returns a geometry type point object with the given coordinate values.
 * [**ST\_Polygon(String wkt) → Polygon**](../../configuration-reference/functions/stpolygon.md) Returns a geometry type polygon object from [WKT representation](https://en.wikipedia.org/wiki/Well-known\_text\_representation\_of\_geometry).
 * [**ST\_GeogFromWKB(bytes wkb) → Geography**](../../configuration-reference/functions/stgeogfromwkb.md) Creates a geography instance from a [Well-Known Binary geometry representation (WKB)](https://en.wikipedia.org/wiki/Well-known\_text\_representation\_of\_geometry#Well-known\_binary)
-* [**ST\_GeogFromText(String wkt) → Geography**](../../configuration-reference/functions/stgeogfromtext.md) Return a specified geography value from [Well-Known Text representation or extended (WKT)](https://en.wikipedia.org/wiki/Well-known\_text\_representation\_of\_geometry).
+* [**ST\_GeogFromText(String wkt) → Geography**](../../configuration-reference/functions/stgeogfromtext.md) Returns a specified geography value from [Well-Known Text representation or extended (WKT)](https://en.wikipedia.org/wiki/Well-known\_text\_representation\_of\_geometry).
 
 ### Measurements
 
@@ -84,7 +84,7 @@ For example, in the diagram below, the red hexagons are within the 1 distance of
 
 ![Hexagonal grid in H3](../../.gitbook/assets/geoindex-h3.png)
 
-### How to use Geoindex
+### How to use geoindex
 
 To use the geoindex, first declare the geolocation field as bytes in the schema, as in the example of the [QuickStart example](https://github.com/apache/pinot/blob/master/pinot-tools/src/main/resources/examples/batch/starbucksStores/starbucksStores\_schema.json#L25).
 
@@ -134,7 +134,7 @@ WHERE ST_DISTANCE(location_st_point, ST_Point(-122, 37, 1)) < 5000
 limit 1000
 ```
 
-### How Geoindex works
+### How geoindex works
 
 Geoindex in Pinot accelerates the query evaluation without compromising the correctness of the query result. Currently, geoindex supports the `ST_Distance` function used in the range predicates in the `WHERE` clause, as shown in the query example in the previous section.
 
@@ -144,6 +144,6 @@ At the high level, geoindex is used for retrieving the records within the nearby
 
 As in the example diagram above, if we want to find all relevant points within a given distance at San Francisco (represented in the area within the red circle), then the algorithm with geoindex works as the following:
 
-* Find the H3 distance `x` that contains the range (i.e. red circle)
+* Find the H3 distance `x` that contains the range (such as, within a red circle)
 * For the points within the H3 distance (i.e. covered by the hexagons within [`kRing(x)`](https://h3geo.org/docs/api/traversal)), we can directly take those points without filtering
 * For the points falling into the H3 distance (i.e. in the hexagons of `kRing(x)`), we do filtering on them by evaluating the condition `ST_Distance(loc1, loc2) < x`

--- a/basics/indexing/geospatial-support.md
+++ b/basics/indexing/geospatial-support.md
@@ -86,7 +86,8 @@ For example, in the diagram below, the red hexagons are within the 1 distance of
 
 ### How to use geoindex
 
-To use the geoindex, first declare the geolocation field as bytes in the schema, as in the example of the [QuickStart example](https://github.com/apache/pinot/blob/master/pinot-tools/src/main/resources/examples/batch/starbucksStores/starbucksStores\_schema.json#L25).
+To use the geoindex, first declare the geolocation field as bytes in the schema, as in the example of the [QuickStart example](https://github.com/apache/pinot/blob/master/pinot-tools/src/main/resources/examples/batch/starbucksStores/starbucksStores\_schema.json).
+
 
 {% code title="geoindex schema" %}
 ```javascript
@@ -100,7 +101,7 @@ To use the geoindex, first declare the geolocation field as bytes in the schema,
 
 Note the use of `transformFunction` that converts the created point into `SphericalGeography` format, which is needed by the `ST_Distance` function.
 
-Next, declare the geospatial index in the [table config](../../configuration-reference/table.md):
+Next, declare the geospatial index in the [table configuration](../../configuration-reference/table.md):
 
 {% code title="geoindex tableConfig" %}
 ```javascript

--- a/basics/indexing/geospatial-support.md
+++ b/basics/indexing/geospatial-support.md
@@ -136,14 +136,14 @@ limit 1000
 
 ### How geoindex works
 
-Geoindex in Pinot accelerates the query evaluation without compromising the correctness of the query result. Currently, geoindex supports the `ST_Distance` function used in the range predicates in the `WHERE` clause, as shown in the query example in the previous section.
+The Pinot geoindex accelerates query evaluation while maintaining accuracy. Currently, geoindex supports the `ST_Distance` function in the `WHERE` clause.
 
 At the high level, geoindex is used for retrieving the records within the nearby hexagons of the given location, and then use `ST_Distance` to accurately filter the matched results.
 
 ![Geoindex example](../../.gitbook/assets/geoindex-example.png)
 
-As in the example diagram above, if we want to find all relevant points within a given distance at San Francisco (represented in the area within the red circle), then the algorithm with geoindex works as the following:
+As in the example diagram above, if we want to find all relevant points within a given distance around San Francisco (area within the red circle), then the algorithm with geoindex will:
 
-* Find the H3 distance `x` that contains the range (such as, within a red circle)
-* For the points within the H3 distance (i.e. covered by the hexagons within [`kRing(x)`](https://h3geo.org/docs/api/traversal)), we can directly take those points without filtering
-* For the points falling into the H3 distance (i.e. in the hexagons of `kRing(x)`), we do filtering on them by evaluating the condition `ST_Distance(loc1, loc2) < x`
+* First find the H3 distance `x` that contains the range (for example, within a red circle).
+* Then, for the points within the H3 distance (those covered by the hexagons completely within [`kRing(x)`](https://h3geo.org/docs/api/traversal)), directly accept those points without filtering.
+* Finally, for the points contained in the hexagons of `kRing(x)` at the outer edge of the red circle H3 distance, the algorithm will filter them by evaluating the condition `ST_Distance(loc1, loc2) < x` to find only those that are within the circle.

--- a/basics/indexing/json-index.md
+++ b/basics/indexing/json-index.md
@@ -8,7 +8,7 @@ The JSON index can be applied to JSON string columns to accelerate value lookups
 
 ## When to use JSON index
 
-JSON string can be used to represent array, map, and nested fields without forcing a fixed schema. It is flexible, but the flexibility comes with a cost - filtering on JSON string columns is very expensive.
+Use the JSON string can be used to represent array, map, and nested fields without forcing a fixed schema. While JSON strings are flexible, filtering on JSON string columns is expensive, so consider the use case.
 
 Suppose we have some JSON records similar to the following sample record stored in the `person` column:
 
@@ -38,7 +38,7 @@ Suppose we have some JSON records similar to the following sample record stored 
 }
 ```
 
-Without an index, in order to look up key and filter records based on the value, we need to scan and reconstruct the JSON object from the JSON string for every record, look up the key and then compare the value.
+Without an index, to look up the key and filter records based on the value, Pinot must scan and reconstruct the JSON object from the JSON string for every record, look up the key and then compare the value.
 
 For example, in order to find all persons whose name is "adam", the query will look like:
 
@@ -289,7 +289,7 @@ With **excludeFields** set to \["age", "street"]:
 Note that the JSON index can only be applied to `STRING/JSON` columns whose values are JSON strings.
 
 {% hint style="info" %}
-When you're using a JSON index, it is recommended that you add the indexed column to the `noDictionaryColumns` columns list to reduce unnecessary storage overhead.
+To reduce unnecessary storage overhead when using a JSON index, we recommend that you add the indexed column to the `noDictionaryColumns` columns list.
 
 For instructions on that configuration property, see the [Raw value forward index](forward-index.md#raw-value-forward-index) documentation.
 {% endhint %}

--- a/basics/indexing/json-index.md
+++ b/basics/indexing/json-index.md
@@ -1,3 +1,7 @@
+---
+description:  This page describes configuring the JSON index for Apache Pinot.
+---
+
 # JSON Index
 
 JSON index can be applied to JSON string columns to accelerate the value lookup and filtering for the column.

--- a/basics/indexing/json-index.md
+++ b/basics/indexing/json-index.md
@@ -4,15 +4,15 @@ description:  This page describes configuring the JSON index for Apache Pinot.
 
 # JSON Index
 
-JSON index can be applied to JSON string columns to accelerate the value lookup and filtering for the column.
+The JSON index can be applied to JSON string columns to accelerate value lookups and filtering for the column.
 
 ## When to use JSON index
 
-JSON string can be used to represent the array, map, nested field without forcing a fixed schema. It is very flexible, but the flexibility comes with a cost - filtering on JSON string columns is very expensive.
+JSON string can be used to represent array, map, and nested fields without forcing a fixed schema. It is flexible, but the flexibility comes with a cost - filtering on JSON string columns is very expensive.
 
 Suppose we have some JSON records similar to the following sample record stored in the `person` column:
 
-```javascript
+```json
 {
   "name": "adam",
   "age": 30,
@@ -38,7 +38,7 @@ Suppose we have some JSON records similar to the following sample record stored 
 }
 ```
 
-Without an index, in order to look up a key and filter records based on the value, we need to scan and reconstruct the JSON object from the JSON string for every record, look up the key and then compare the value.
+Without an index, in order to look up key and filter records based on the value, we need to scan and reconstruct the JSON object from the JSON string for every record, look up the key and then compare the value.
 
 For example, in order to find all persons whose name is "adam", the query will look like:
 
@@ -48,13 +48,11 @@ FROM mytable
 WHERE JSON_EXTRACT_SCALAR(person, '$.name', 'STRING') = 'adam'
 ```
 
-JSON index is designed to accelerate the filtering on JSON string columns without scanning and reconstructing all the JSON objects.
+The JSON index is designed to accelerate the filtering on JSON string columns without scanning and reconstructing all the JSON objects.
 
-## Configure JSON index
+## Enable and configure a JSON index
 
-To enable the JSON index, set the following config in the table config:
-
-### Config since release `0.12.0`:
+To enable the JSON index, set the following configuration in the table configuration:
 
 ```json
 {
@@ -104,7 +102,7 @@ With the following JSON document:
 }
 ```
 
-With the default setting, we will flatten the document into the following records:
+Using the default setting, we will flatten the document into the following records:
 
 ```json
 {
@@ -288,19 +286,17 @@ With **excludeFields** set to \["age", "street"]:
 }
 ```
 
-The legacy config has the same behavior as the default settings in the new config.
-
-Note that JSON index can only be applied to `STRING/JSON` columns whose values are JSON strings.
+Note that the JSON index can only be applied to `STRING/JSON` columns whose values are JSON strings.
 
 {% hint style="info" %}
-When you're using a JSON index, we would recommend that you add the indexed column to the `noDictionaryColumns` columns list to reduce unnecessary storage overhead.&#x20;
+When you're using a JSON index, it is recommended that you add the indexed column to the `noDictionaryColumns` columns list to reduce unnecessary storage overhead.
 
-For instructions on that config property, see the [Raw value forward index](forward-index.md#raw-value-forward-index) documentation.
+For instructions on that configuration property, see the [Raw value forward index](forward-index.md#raw-value-forward-index) documentation.
 {% endhint %}
 
-## How to use JSON index
+## How to use the JSON index
 
-JSON index can be used via the `JSON_MATCH` predicate: `JSON_MATCH(<column>, '<filterExpression>')`. For example, to find all persons whose name is "adam", the query will look like:
+The JSON index can be used via the `JSON_MATCH` predicate: `JSON_MATCH(<column>, '<filterExpression>')`. For example, to find every entry with the name "adam":
 
 ```sql
 SELECT ... 
@@ -309,10 +305,6 @@ WHERE JSON_MATCH(person, '"$.name"=''adam''')
 ```
 
 Note that the quotes within the filter expression need to be escaped.
-
-{% hint style="info" %}
-In release `0.7.1`, we use the old syntax for `filterExpression`: `'name=''adam'''`
-{% endhint %}
 
 ## Supported filter expressions
 
@@ -326,10 +318,6 @@ FROM mytable
 WHERE JSON_MATCH(person, '"$.name"=''adam''')
 ```
 
-{% hint style="info" %}
-In release `0.7.1`, we use the old syntax for filterExpression: `'name=''adam'''`
-{% endhint %}
-
 ### Chained key lookup
 
 Find all persons who have an address (one of the addresses) with number 112:
@@ -339,10 +327,6 @@ SELECT ...
 FROM mytable 
 WHERE JSON_MATCH(person, '"$.addresses[*].number"=112')
 ```
-
-{% hint style="info" %}
-In release `0.7.1`, we use the old syntax for filterExpression: `'addresses.number=112'`
-{% endhint %}
 
 ### Nested filter expression
 
@@ -354,10 +338,6 @@ FROM mytable
 WHERE JSON_MATCH(person, '"$.name"=''adam'' AND "$.addresses[*].number"=112')
 ```
 
-{% hint style="info" %}
-In release `0.7.1`, we use the old syntax for filterExpression: `'name=''adam'' AND addresses.number=112'`
-{% endhint %}
-
 ### Array access
 
 Find all persons whose first address has number 112:
@@ -367,10 +347,6 @@ SELECT ...
 FROM mytable 
 WHERE JSON_MATCH(person, '"$.addresses[0].number"=112')
 ```
-
-{% hint style="info" %}
-In release `0.7.1`, we use the old syntax for filterExpression: `'"addresses[0].number"=112'`
-{% endhint %}
 
 ### Existence check
 
@@ -382,10 +358,6 @@ FROM mytable
 WHERE JSON_MATCH(person, '"$.phone" IS NOT NULL')
 ```
 
-{% hint style="info" %}
-In release `0.7.1`, we use the old syntax for filterExpression: `'phone IS NOT NULL'`
-{% endhint %}
-
 Find all persons whose first address does not contain floor field within the JSON:
 
 ```sql
@@ -394,13 +366,9 @@ FROM mytable
 WHERE JSON_MATCH(person, '"$.addresses[0].floor" IS NULL')
 ```
 
-{% hint style="info" %}
-In release `0.7.1`, we use the old syntax for filterExpression: `'"addresses[0].floor" IS NULL'`
-{% endhint %}
-
 ## JSON context is maintained
 
-The JSON context is maintained for object elements within an array, i.e. the filter won't cross-match different objects in the array.
+The JSON context is maintained for object elements within an array, meaning the filter won't cross-match different objects in the array.
 
 To find all persons who live on "main st" in "ca":
 
@@ -412,7 +380,7 @@ WHERE JSON_MATCH(person, '"$.addresses[*].street"=''main st'' AND "$.addresses[*
 
 This query won't match "adam" because none of his addresses matches both the street and the country.
 
-If JSON context is not desired, use multiple separate `JSON_MATCH` predicates. E.g. to find all persons who have addresses on "main st" and have addressed in "ca" (doesn't have to be the same address):
+If JSON context is not desired, use multiple separate `JSON_MATCH` predicates. For example, to find all persons who have addresses on "main st" and have addresses in "ca" (matches need not have the same address):
 
 ```sql
 SELECT ... 
@@ -422,7 +390,7 @@ WHERE JSON_MATCH(person, '"$.addresses[*].street"=''main st''') AND JSON_MATCH(p
 
 This query will match "adam" because one of his addresses matches the street and another one matches the country.
 
-Note that the array index is maintained as a separate entry within the element, so in order to query different elements within an array, multiple `JSON_MATCH` predicates are required. E.g. to find all persons who have first address on "main st" and second address on "second st":
+The array index is maintained as a separate entry within the element, so in order to query different elements within an array, multiple `JSON_MATCH` predicates are required. For example, to find all persons who have first address on "main st" and second address on "second st":
 
 ```sql
 SELECT ... 
@@ -488,10 +456,6 @@ FROM mytable
 WHERE JSON_MATCH(nullableCol, '"$" IS NULL')
 ```
 
-{% hint style="warning" %}
-In release `0.7.1`, json string must be object (cannot be `null`, value or array); multi-dimensional array is not supported.
-{% endhint %}
-
 ## Limitations
 
-1. The key (left-hand side) of the filter expression must be the leaf level of the JSON object, e.g. `"$.addresses[*]"='main st'` won't work.
+1. The key (left-hand side) of the filter expression must be the leaf level of the JSON object, for example, `"$.addresses[*]"='main st'` won't work.

--- a/basics/indexing/text-search-support.md
+++ b/basics/indexing/text-search-support.md
@@ -37,11 +37,11 @@ where `<column_name>` is the column text index is created on and `<search_expres
 
 ## Current restrictions
 
-Currently we support text search in a restricted manner. More specifically, we have the following constraints:
+Pinot supports text search with the following requirements:
 
 * The column type should be STRING.
 * The column should be single-valued.
-* Co-existence of text index with other Pinot indexes is currently not supported.
+* Using a text index in coexistence with other Pinot indexes is not supported.
 
 ## Sample Datasets
 
@@ -216,14 +216,14 @@ Each column that has a text index should also be specified as `noDictionaryColum
  ]}
 ```
 
-You can configure text indexes when:
+You can configure text indexes in the following scenarios:
 
 * Adding a new table with text index enabled on one or more columns.
 * Adding a new column with text index enabled to an existing table.
 * Enabling a text index on an existing column.
 
 {% hint style="info" %}
-When you're using a text index, you should add the indexed column to the `noDictionaryColumns` columns list to reduce unnecessary storage overhead.
+When you're using a text index, add the indexed column to the `noDictionaryColumns` columns list to reduce unnecessary storage overhead.
 
 For instructions on that configuration property, see the [Raw value forward index](forward-index.md#raw-value-forward-index) documentation.
 {% endhint %}
@@ -248,7 +248,7 @@ There is a default set of "stop words" built in Pinot's text index. This is a se
 "they", "this", "to", "was", "will", "with", "those"
 ```
 
-Any occurrence of these words in will be ignored by the tokenizer during index creation and search.
+Any occurrence of these words will be ignored by the tokenizer during index creation and search.
 
 In some cases, users might want to customize the set. A good example would be when `IT` (Information Technology) appears in the text that collides with "it", or some context-specific words that are not informative in the search. To do this, one can config the words in `fieldConfig` to include/exclude from the default stop words:
 
@@ -508,7 +508,7 @@ The above query will match any text document containing "exception".
 
 ### Deciding Query Types
 
-Combining phrase and term queries using Boolean operators and grouping allows you to build a complex text search query expression.
+Combining phrase and term queries using Boolean operators and grouping lets you build a complex text search query expression.
 
 The key thing to remember is that phrases should be used when the order of terms in the document is important and when separating the phrase into individual terms doesn't make sense from end user's perspective.
 

--- a/basics/indexing/text-search-support.md
+++ b/basics/indexing/text-search-support.md
@@ -1,5 +1,5 @@
 ---
-description: This page talks about support for text search functionality in Pinot.
+description: This page talks about support for text search in Pinot.
 ---
 
 # Text search support
@@ -8,7 +8,7 @@ description: This page talks about support for text search functionality in Pino
 
 Pinot supports super-fast query processing through its indexes on non-BLOB like columns. Queries with exact match filters are run efficiently through a combination of dictionary encoding, inverted index, and sorted index.
 
-It would be useful for a query like the following:
+This is useful for a query like the following, which looks for exact matches on two columns of type STRING and INT respectively:
 
 ```sql
 SELECT COUNT(*) 
@@ -17,11 +17,7 @@ WHERE STRING_COL = 'ABCDCD'
 AND INT_COL > 2000
 ```
 
-This query does exact matches on two columns of type STRING and INT respectively.
-
-For arbitrary text data that falls into the BLOB/CLOB territory, we need more than exact matches. Users are interested in doing regex, phrase, fuzzy queries on BLOB like data. Before 0.3.0, one had to use [regexp\_like](https://apache-pinot.gitbook.io/apache-pinot-cookbook/pinot-user-guide/pinot-query-language#wild-card-match-in-where-clause-only) to achieve this. However, this was scan based which was not performant and features like fuzzy search (edit distance search) were not possible.
-
-In version 0.3.0, we added support for text indexes to efficiently do arbitrary search on STRING columns where each column value is a large BLOB of text. This can be achieved by using the new built-in function TEXT\_MATCH.
+For arbitrary text data that falls into the BLOB/CLOB territory, we need more than exact matches. This often involves using regex, phrase, fuzzy queries on BLOB like data. Text indexes can efficiently perform arbitrary search on STRING columns where each column value is a large BLOB of text using the `TEXT\_MATCH` function, like this:
 
 ```sql
 SELECT COUNT(*) 
@@ -29,7 +25,7 @@ FROM Foo
 WHERE TEXT_MATCH (<column_name>, '<search_expression>')
 ```
 
-where \<column\_name> is the column text index is created on and **\<search\_expression>** can be:
+where `<column_name>` is the column text index is created on and `<search_expression>` conforms to one of the following:
 
 | **Search Expression Type** | **Example**                                           |
 | -------------------------- | ----------------------------------------------------- |
@@ -39,17 +35,25 @@ where \<column\_name> is the column text index is created on and **\<search\_exp
 | Prefix Query               | TEXT\_MATCH (\<column\_name>, 'stream\*')             |
 | Regex Query                | TEXT\_MATCH (\<column\_name>, '/Exception.\*/')       |
 
+## Current restrictions
+
+Currently we support text search in a restricted manner. More specifically, we have the following constraints:
+
+* The column type should be STRING.
+* The column should be single-valued.
+* Co-existence of text index with other Pinot indexes is currently not supported.
+
 ## Sample Datasets
 
 Text search should ideally be used on STRING columns where doing standard filter operations (EQUALITY, RANGE, BETWEEN) doesn't fit the bill because each column value is a reasonably large blob of text.
 
 ### Apache Access Log
 
-Consider the following snippet from Apache access log. Each line in the log consists of arbitrary data (IP addresses, URLs, timestamps, symbols etc) and represents a column value. Data like this is a good candidate for doing text search.
+Consider the following snippet from an Apache access log. Each line in the log consists of arbitrary data (IP addresses, URLs, timestamps, symbols etc) and represents a column value. Data like this is a good candidate for doing text search.
 
-Let's say the following snippet of data is stored in ACCESS\_LOG\_COL column in Pinot table.
+Let's say the following snippet of data is stored in the `ACCESS\_LOG\_COL` column in a Pinot table.
 
-```
+```log
 109.169.248.247 - - [12/Dec/2015:18:25:11 +0100] "GET /administrator/ HTTP/1.1" 200 4263 "-" "Mozilla/5.0 (Windows NT 6.0; rv:34.0) Gecko/20100101 Firefox/34.0" "-
 109.169.248.247 - - [12/Dec/2015:18:25:11 +0100] "POST /administrator/index.php HTTP/1.1" 200 4494 "http://almhuette-raith.at/administrator/" "Mozilla/5.0 (Windows NT 6.0; rv:34.0) Gecko/20100101 Firefox/34.0" "-"
 46.72.177.4 - - [12/Dec/2015:18:31:08 +0100] "GET /administrator/ HTTP/1.1" 200 4263 "-" "Mozilla/5.0 (Windows NT 6.0; rv:34.0) Gecko/20100101 Firefox/34.0" "-"
@@ -63,7 +67,7 @@ Let's say the following snippet of data is stored in ACCESS\_LOG\_COL column in 
 91.227.29.79 - - [12/Dec/2015:18:33:51 +0100] "GET /administrator/ HTTP/1.1" 200 4263 "-" "Mozilla/5.0 (Windows NT 6.0; rv:34.0) Gecko/20100101 Firefox/34.0" "-"
 ```
 
-Few examples of search queries on this data:
+Here are some examples of search queries on this data:
 
 **Count the number of GET requests.**
 
@@ -91,11 +95,11 @@ WHERE TEXT_MATCH(ACCESS_LOG_COL, 'post AND administrator AND index AND firefox')
 
 ### Resume text
 
-Consider another example of simple resume text. Each line in the file represents skill-data from resumes of different candidates
+Let's consider another example using text from job candidate resumes. Each line in this file represents skill-data from resumes of different candidates.
 
-Let's say the following snippet of data is stored in _SKILLS\_COL_ column in Pinot table. Each line in the input text represents a column value.
+This data is stored in the `SKILLS\_COL` column in a Pinot table. Each line in the input text represents a column value.
 
-```
+```csv
 Distributed systems, Java, C++, Go, distributed query engines for analytics and data warehouses, Machine learning, spark, Kubernetes, transaction processing
 Java, Python, C++, Machine learning, building and deploying large scale production systems, concurrency, multi-threading, CPU processing
 C++, Python, Tensor flow, database kernel, storage, indexing and transaction processing, building large scale systems, Machine learning
@@ -112,9 +116,9 @@ Distributed systems, Apache Kafka, publish-subscribe, building and deploying lar
 Realtime stream processing, publish subscribe, columnar processing for data warehouses, concurrency, Java, multi-threading, C++,
 ```
 
-Few examples of search queries on this data:
+Here are some examples of search queries on this data:
 
-**Count the number of candidates that have "machine learning" and "gpu processing"** - a phrase search (more on this further in the document) where we are looking for exact match of phrases "machine learning" and "gpu processing" not necessarily in the same order in original data.
+**Count the number of candidates that have "machine learning" and "gpu processing"**: This is a phrase search (more on this further in the document) where we are looking for exact match of phrases "machine learning" and "gpu processing", not necessarily in the same order in the original data.
 
 ```sql
 SELECT SKILLS_COL 
@@ -122,7 +126,7 @@ FROM MyTable
 WHERE TEXT_MATCH(SKILLS_COL, '"Machine learning" AND "gpu processing"')
 ```
 
-**Count the number of candidates that have "distributed systems" and either 'Java' or 'C++'** - a combination of searching for exact phrase "distributed systems" along with other terms.
+**Count the number of candidates that have "distributed systems" and either 'Java' or 'C++'**: This is a combination of searching for exact phrase "distributed systems" along with other terms.
 
 ```sql
 SELECT SKILLS_COL 
@@ -132,7 +136,7 @@ WHERE TEXT_MATCH(SKILLS_COL, '"distributed systems" AND (Java C++)')
 
 ### Query Log
 
-Consider a snippet from a log file containing SQL queries handled by a database. Each line (query) in the file represents a column value in QUERY\_LOG\_COL column in Pinot table.
+Next, consider a snippet from a log file containing SQL queries handled by a database. Each line (query) in the file represents a column value in the `QUERY\_LOG\_COL` column in a Pinot table.
 
 ```sql
 SELECT count(dimensionCol2) FROM FOO WHERE dimensionCol1 = 18616904 AND timestamp BETWEEN 1560988800000 AND 1568764800000 GROUP BY dimensionCol3 TOP 2500
@@ -149,7 +153,7 @@ SELECT count(dimensionCol2) FROM FOO WHERE dimensionCol1 = 18616904 AND timestam
 SELECT count(dimensionCol2) FROM FOO WHERE dimensionCol1 = 18616904 AND timestamp BETWEEN 1560873600000 AND 1560877199999 AND dimensionCol3 = 2019061816 LIMIT 0
 ```
 
-Few examples of search queries on this data:
+Here are some examples of search queries on this data:
 
 **Count the number of queries that have GROUP BY**
 
@@ -175,29 +179,19 @@ FROM MyTable
 WHERE TEXT_MATCH(QUERY_LOG_COL, '"timestamp between" AND "group by"')
 ```
 
-[Further sections](https://apache-pinot.gitbook.io/apache-pinot-cookbook/text-search-support#writing-text-search-queries) in the document cover several concrete examples on each kind of query and step-by-step guide on how to write text search queries in Pinot.
+Read on for concrete examples on each kind of query and step-by-step guides covering how to write text search queries in Pinot.
 
-## Current restrictions
+{% hint style="info" %}
+A column in Pinot can be dictionary-encoded or stored RAW. In addition, we can create an inverted index and/or a sorted index on a dictionary-encoded column.
 
-Currently we support text search in a restricted manner. More specifically, we have the following constraints:
+The text index is an addition to the type of **per-column indexes** users can create in Pinot. However, it only supports text index on a RAW column, not a dictionary-encoded column.
+{% endhint %}
 
-* The column type should be STRING.
-* The column should be single-valued.
-* Co-existence of text index with other Pinot indexes is currently not supported.
+## Enable a text index
 
-The last two restrictions are going to be relaxed very soon in the upcoming releases.
+Enable a text index on a column in the [table configuration](../../configuration-reference/table.md) by adding a new section with the name "fieldConfigList".
 
-### Co-existence with other indexes
-
-Currently, a column in Pinot can be dictionary encoded or stored RAW. Furthermore, we can create inverted index on the dictionary encoded column. We can also create a sorted index on the dictionary encoded column.
-
-Text index is an addition to the type of **per-column indexes** users can create in Pinot. However, the current implementation supports text index on RAW column. In other words, the column should not be dictionary encoded. As we **relax this constraint in upcoming releases**, text index can be created on a dictionary encoded column that also has other indexes (inverted, sorted etc).
-
-## How to enable text index?
-
-Similar to other indexes, users can enable text index on a column through table config. As part of text-search feature, we have also introduced a new generic way of specifying the per-column encoding and index information. In the [table config](../../configuration-reference/table.md), there will be a new section with the name "fieldConfigList".
-
-```javascript
+```json
 "fieldConfigList":[
   {
      "name":"text_col_1",
@@ -212,9 +206,9 @@ Similar to other indexes, users can enable text index on a column through table 
 ]
 ```
 
-Since we haven't yet removed the old way of specifying the index info, each column that has a text index should also be specified as `noDictionaryColumns` in `tableIndexConfig`:
+Each column that has a text index should also be specified as `noDictionaryColumns` in `tableIndexConfig`:
 
-```javascript
+```json
 "tableIndexConfig": {
    "noDictionaryColumns": [
      "text_col_1",
@@ -222,43 +216,43 @@ Since we haven't yet removed the old way of specifying the index info, each colu
  ]}
 ```
 
-The above mechanism can be used to configure text indexes in the following scenarios:
+You can configure text indexes when:
 
 * Adding a new table with text index enabled on one or more columns.
 * Adding a new column with text index enabled to an existing table.
-* Enabling text index on an existing column.
+* Enabling a text index on an existing column.
 
 {% hint style="info" %}
-When you're using a Text index, we would recommend that you add the indexed column to the `noDictionaryColumns` columns list to reduce unnecessary storage overhead.&#x20;
+When you're using a text index, you should add the indexed column to the `noDictionaryColumns` columns list to reduce unnecessary storage overhead.
 
-For instructions on that config property, see the [Raw value forward index](forward-index.md#raw-value-forward-index) documentation.
+For instructions on that configuration property, see the [Raw value forward index](forward-index.md#raw-value-forward-index) documentation.
 {% endhint %}
 
-## Text Index Creation
+## Text index creation
 
-Once the text index is enabled on one or more columns through table config, our segment generation code will pick up the config and automatically create text index (per column). This is exactly how other indexes in Pinot are created.
+Once the text index is enabled on one or more columns through a table configuration, segment generation code will automatically create the text index (per column).
 
 Text index is supported for both offline and real-time segments.
 
 ### Text parsing and tokenization
 
-The original text document (a value in the column with text index enabled) is parsed, tokenized and individual "indexable" terms are extracted. These terms are inserted into the index.
+The original text document (denoted by a value in the column that has text index enabled) is parsed, tokenized and individual "indexable" terms are extracted. These terms are inserted into the index.
 
-Pinot's text index is built on top of Lucene. Lucene's **standard english text tokenizer** generally works well for most classes of text. We might want to build custom text parser and tokenizer to suit particular user requirements. Accordingly, we can make this configurable for the user to specify on per column text index basis.
+Pinot's text index is built on top of Lucene. Lucene's **standard english text tokenizer** generally works well for most classes of text. Since it can be desirable to build a custom text parser and tokenizer to suit particular user requirements this can be made configurable for the user to specify on per column text index basis.
 
 There is a default set of "stop words" built in Pinot's text index. This is a set of high frequency words in English that are excluded for search efficiency and index size, including:
 
-```
+```csv
 "a", "an", "and", "are", "as", "at", "be", "but", "by", "for", "if", "in", "into", "is", "it",
 "no", "not", "of", "on", "or", "such", "that", "the", "their", "then", "than", "there", "these", 
 "they", "this", "to", "was", "will", "with", "those"
 ```
 
-Any occurrence of these words in will be ignored by the tokenizer during index creation and search.&#x20;
+Any occurrence of these words in will be ignored by the tokenizer during index creation and search.
 
 In some cases, users might want to customize the set. A good example would be when `IT` (Information Technology) appears in the text that collides with "it", or some context-specific words that are not informative in the search. To do this, one can config the words in `fieldConfig` to include/exclude from the default stop words:
 
-```
+```json
 "fieldConfigList":[
   {
      "name":"text_col_1",
@@ -272,53 +266,53 @@ In some cases, users might want to customize the set. A good example would be wh
 ]
 ```
 
-The words should be **comma separated** and in **lowercase**. Duplicated words in both list will end up get excluded.
+The words should be **comma separated** and in **lowercase**. Words appearing in both lists will be excluded as expected.
 
-## Writing Text Search Queries
+## Writing text search queries
 
-A new built-in function TEXT\_MATCH has been introduced for using text search in SQL/PQL.
+The `TEXT\_MATCH` function enables using text search in SQL/PQL.
 
 TEXT\_MATCH(text\_column\_name, search\_expression)
 
 * text\_column\_name - name of the column to do text search on.
 * search\_expression - search query
 
-We can use TEXT\_MATCH function as part of our queries in the WHERE clause. Examples:
+You can use TEXT\_MATCH function as part of queries in the WHERE clause, like this:
 
 ```sql
 SELECT COUNT(*) FROM Foo WHERE TEXT_MATCH(...)
 SELECT * FROM Foo WHERE TEXT_MATCH(...)
 ```
 
-We can also use the TEXT\_MATCH filter clause with other filter operators. For example:
+You can also use the `TEXT\_MATCH` filter clause with other filter operators. For example:
 
 ```sql
 SELECT COUNT(*) FROM Foo WHERE TEXT_MATCH(...) AND some_other_column_1 > 20000
 SELECT COUNT(*) FROM Foo WHERE TEXT_MATCH(...) AND some_other_column_1 > 20000 AND some_other_column_2 < 100000
 ```
 
-Combining multiple TEXT\_MATCH filter clauses
+You can combine multiple `TEXT\_MATCH` filter clauses:
 
 ```sql
 SELECT COUNT(*) FROM Foo WHERE TEXT_MATCH(text_col_1, ....) AND TEXT_MATCH(text_col_2, ...)
 ```
 
-TEXT\_MATCH can be used in WHERE clause of all kinds of queries supported by Pinot
+`TEXT\_MATCH` can be used in WHERE clause of all kinds of queries supported by Pinot.
 
 * Selection query which projects one or more columns
   * User can also include the text column name in select list
 * Aggregation query
 * Aggregation GROUP BY query
 
-The search expression (second argument to TEXT\_MATCH function) is the query string that Pinot will use to perform text search on the column's text index. \_\*\*\_Following expression types are supported
+The search expression (the second argument to `TEXT\_MATCH` function) is the query string that Pinot will use to perform text search on the column's text index.
 
-### **Phrase Query**
+### Phrase query
 
-This query is used to do exact match of a given phrase. Exact match implies that terms in the user-specified phrase should appear in the exact same order in the original text document. Note that document is referred to as the column value.
+This query is used to seek out an exact match of a given phrase, where terms in the user-specified phrase appear in the same order in the original text document.
 
-Let's take the example of resume text data containing 14 documents to walk through queries. The data is stored in column named SKILLS\_COL and we have created a text index on this column.
+The following example reuses the earlier example of resume text data containing 14 documents to walk through queries. In this sentence, "document" means the column value. The data is stored in the `SKILLS\_COL` column and we have created a text index on this column.
 
-```
+```csv
 Java, C++, worked on open source projects, coursera machine learning
 Machine learning, Tensor flow, Java, Stanford university,
 Distributed systems, Java, C++, Go, distributed query engines for analytics and data warehouses, Machine learning, spark, Kubernetes, transaction processing
@@ -340,7 +334,7 @@ Databases, columnar query processing, Apache Arrow, distributed systems, Machine
 Database engine, OLAP systems, OLTP transaction processing at large scale, concurrency, multi-threading, GO, building large scale systems
 ```
 
-**Example 1 -** Search in SKILL\_COL column to look for documents where each matching document MUST contain phrase "distributed systems" as is
+This example queries the `SKILL\_COL` column to look for documents where each matching document MUST contain phrase "Distributed systems":
 
 ```sql
 SELECT SKILLS_COL 
@@ -350,13 +344,13 @@ WHERE TEXT_MATCH(SKILLS_COL, '"Distributed systems"')
 
 The search expression is '\\"Distributed systems\\"'
 
-* The search expression is **always specified within single quotes** '\<your expression>'
+* The search expression is **always specified within single quotes** \'\<your expression>\'
 * Since we are doing a phrase search, the **phrase should be specified within double quotes** inside the single quotes and the **double quotes should be escaped**
-  * '\\"\<your phrase>\\"'
+  * \'\\"\<your phrase>\\"\'
 
 The above query will match the following documents:
 
-```
+```csv
 Distributed systems, Java, C++, Go, distributed query engines for analytics and data warehouses, Machine learning, spark, Kubernetes, transaction processing
 Distributed systems, database development, columnar query engine, database kernel, storage, indexing and transaction processing, building large scale systems
 Distributed systems, Java, realtime streaming systems, Machine learning, spark, Kubernetes, distributed storage, concurrency, multi-threading
@@ -367,7 +361,7 @@ Databases, columnar query processing, Apache Arrow, distributed systems, Machine
 
 But it won't match the following document:
 
-```
+```csv
 Distributed data processing, systems design experience
 ```
 
@@ -375,7 +369,7 @@ This is because the phrase query looks for the phrase occurring in the original 
 
 **NOTE:** Matching is always done in a case-insensitive manner.
 
-**Example 2 -** Search in SKILL\_COL column to look for documents where each matching document MUST contain phrase "query processing" as is
+The next example queries the `SKILL\_COL` column to look for documents where each matching document MUST contain phrase "query processing":
 
 ```sql
 SELECT SKILLS_COL 
@@ -385,16 +379,16 @@ WHERE TEXT_MATCH(SKILLS_COL, '"query processing"')
 
 The above query will match the following documents:
 
-```
+```csv
 Apache spark, Java, C++, query processing, transaction processing, distributed storage, concurrency, multi-threading, apache airflow
 Databases, columnar query processing, Apache Arrow, distributed systems, Machine learning, cluster management, docker image building and distribution"
 ```
 
-### **Term Query**
+### Term query
 
-Term queries are used to search for individual terms
+Term queries are used to search for individual terms.
 
-**Example 3 -** Search in SKILL\_COL column to look for documents where each matching document MUST contain the term 'java'
+This example will query the `SKILL\_COL` column to look for documents where each matching document MUST contain the term 'Java'.
 
 As mentioned earlier, the search expression is always within single quotes. However, since this is a term query, we don't have to use double quotes within single quotes.
 
@@ -404,11 +398,11 @@ FROM MyTable
 WHERE TEXT_MATCH(SKILLS_COL, 'Java')
 ```
 
-### Composite Query using Boolean Operators
+### Composite query using Boolean operators
 
-Boolean operators AND, OR are supported and we can use them to build a composite query. Boolean operators can be used to combine phrase and term queries in any arbitrary manner
+The Boolean operators `AND` and `OR` are supported and we can use them to build a composite query. Boolean operators can be used to combine phrase and term queries in any arbitrary manner
 
-**Example 4 -** Search in SKILL\_COL column to look for documents where each matching document MUST contain phrases "distributed systems" and "tensor flow". This combines two phrases using AND boolean operator
+This example queries the `SKILL\_COL` column to look for documents where each matching document MUST contain the phrases "distributed systems" and "tensor flow". This combines two phrases using the `AND` Boolean operator.
 
 ```sql
 SELECT SKILLS_COL 
@@ -418,13 +412,13 @@ WHERE TEXT_MATCH(SKILLS_COL, '"Machine learning" AND "Tensor Flow"')
 
 The above query will match the following documents:
 
-```
+```csv
 Machine learning, Tensor flow, Java, Stanford university,
 C++, Python, Tensor flow, database kernel, storage, indexing and transaction processing, building large scale systems, Machine learning
 CUDA, GPU processing, Tensor flow, Pandas, Python, Jupyter notebook, spark, Machine learning, building high performance scalable systems
 ```
 
-**Example 5 -** Search in SKILL\_COL column to look for documents where each document MUST contain phrase "machine learning" and term 'gpu' and term 'python'. This combines a phrase and two terms using boolean operator
+This example queries the `SKILL\_COL` column to look for documents where each document MUST contain the phrase "machine learning" and the terms 'gpu' and 'python'. This combines a phrase and two terms using Boolean operators.
 
 ```sql
 SELECT SKILLS_COL 
@@ -434,7 +428,7 @@ WHERE TEXT_MATCH(SKILLS_COL, '"Machine learning" AND gpu AND python')
 
 The above query will match the following documents:
 
-```
+```csv
 CUDA, GPU, Python, Machine learning, database kernel, storage, indexing and transaction processing, building large scale systems
 CUDA, GPU processing, Tensor flow, Pandas, Python, Jupyter notebook, spark, Machine learning, building high performance scalable systems
 ```
@@ -442,11 +436,11 @@ CUDA, GPU processing, Tensor flow, Pandas, Python, Jupyter notebook, spark, Mach
 When using Boolean operators to combine term(s) and phrase(s) or both, please note that:
 
 * The matching document can contain the terms and phrases in any order.
-* The matching document may not have the terms adjacent to each other (if this is needed, please use appropriate phrase query for the concerned terms).
+* The matching document may not have the terms adjacent to each other (if this is needed, use appropriate phrase query).
 
-Use of OR operator is implicit. In other words, if phrase(s) and term(s) are not combined using AND operator in the search expression, OR operator is used by default:
+Use of the OR operator is implicit. In other words, if phrase(s) and term(s) are not combined using AND operator in the search expression, the OR operator is used by default:
 
-**Example 6 -** Search in SKILL\_COL column to look for documents where each document MUST contain ANY one of:
+This example queries the `SKILL\_COL` column to look for documents where each document MUST contain ANY one of:
 
 * phrase "distributed systems" OR
 * term 'java' OR
@@ -458,14 +452,14 @@ FROM MyTable
 WHERE TEXT_MATCH(SKILLS_COL, '"distributed systems" Java C++')
 ```
 
-We can also do grouping using parentheses:
+Grouping using parentheses is supported:
 
-**Example 7 -** Search in SKILL\_COL column to look for documents where each document MUST contain
+This example queries the `SKILL\_COL` column to look for documents where each document MUST contain
 
 * phrase "distributed systems" AND
 * at least one of the terms Java or C++
 
-In the below query, we group terms Java and C++ without any operator which implies the use of OR. The root operator AND is used to combine this with phrase "distributed systems"
+Here the terms Java and C++ are grouped without any operator, which implies the use of OR. The root operator AND is used to combine this with phrase "distributed systems"
 
 ```sql
 SELECT SKILLS_COL 
@@ -473,11 +467,11 @@ FROM MyTable
 WHERE TEXT_MATCH(SKILLS_COL, '"distributed systems" AND (Java C++)')
 ```
 
-### Prefix Query
+### Prefix query
 
-Prefix searches can also be done in the context of a single term. We can't use prefix matches for phrases.
+Prefix queries can be done in the context of a single term. We can't use prefix matches for phrases.
 
-**Example 8 -** Search in SKILL\_COL column to look for documents where each document MUST contain text like stream, streaming, streams etc
+This example queries the `SKILL\_COL` column to look for documents where each document MUST contain text like stream, streaming, streams etc
 
 ```sql
 SELECT SKILLS_COL 
@@ -487,7 +481,7 @@ WHERE TEXT_MATCH(SKILLS_COL, 'stream*')
 
 The above query will match the following documents:
 
-```
+```csv
 Distributed systems, Java, realtime streaming systems, Machine learning, spark, Kubernetes, distributed storage, concurrency, multi-threading
 Big data stream processing, Apache Flink, Apache Beam, database kernel, distributed query engines for analytics and data warehouses
 Realtime stream processing, publish subscribe, columnar processing for data warehouses, concurrency, Java, multi-threading, C++,
@@ -496,11 +490,11 @@ C++, Java, Python, realtime streaming systems, Machine learning, spark, Kubernet
 
 ### Regular Expression Query
 
-Phrase and term queries work on the fundamental logic of looking up the terms (aka tokens) in the text index. The original text document (a value in the column with text index enabled) is parsed, tokenized and individual "indexable" terms are extracted. These terms are inserted into the index.
+Phrase and term queries work on the fundamental logic of looking up the terms in the text index. The original text document (a value in the column with text index enabled) is parsed, tokenized, and individual "indexable" terms are extracted. These terms are inserted into the index.
 
-Based on the nature of original text and how the text is segmented into tokens, it is possible that some terms don't get indexed individually. In such cases, it is better to use regular expression queries on the text index.
+Based on the nature of the original text and how the text is segmented into tokens, it is possible that some terms don't get indexed individually. In such cases, it is better to use regular expression queries on the text index.
 
-Consider server log as an example and we want to look for exceptions. A regex query is suitable for this scenario as it is unlikely that 'exception' is present as an individual indexed token.
+Consider a server log as an example where we want to look for exceptions. A regex query is suitable here as it is unlikely that 'exception' is present as an individual indexed token.
 
 Syntax of a regex query is slightly different from queries mentioned earlier. The regular expression is written between a pair of forward slashes (/).
 
@@ -510,13 +504,13 @@ FROM MyTable
 WHERE text_match(SKILLS_COL, '/.*Exception/')
 ```
 
-The above query will match any text document containing exception.
+The above query will match any text document containing "exception".
 
 ### Deciding Query Types
 
-Generally, a combination of phrase and term queries using boolean operators and grouping should allow us to build a complex text search query expression.
+Combining phrase and term queries using Boolean operators and grouping allows you to build a complex text search query expression.
 
-The key thing to remember is that phrases should be used when the order of terms in the document is important and if separating the phrase into individual terms doesn't make sense from end user's perspective.
+The key thing to remember is that phrases should be used when the order of terms in the document is important and when separating the phrase into individual terms doesn't make sense from end user's perspective.
 
 An example would be phrase "machine learning".
 
@@ -530,7 +524,7 @@ However, if we are searching for documents matching Java and C++ terms, using ph
 TEXT_MATCH(column, '"Java C++"')
 ```
 
-Term query using boolean AND operator is more appropriate for such cases
+Term query using Boolean AND operator is more appropriate for such cases
 
 ```sql
 TEXT_MATCH(column, 'Java AND C++')

--- a/basics/indexing/text-search-support.md
+++ b/basics/indexing/text-search-support.md
@@ -230,7 +230,7 @@ For instructions on that configuration property, see the [Raw value forward inde
 
 ## Text index creation
 
-Once the text index is enabled on one or more columns through a table configuration, segment generation code will automatically create the text index (per column).
+Once the text index is enabled on one or more columns through a [table configuration](../../configuration-reference/table.md), segment generation code will automatically create the text index (per column).
 
 Text index is supported for both offline and real-time segments.
 

--- a/basics/indexing/text-search-support.md
+++ b/basics/indexing/text-search-support.md
@@ -238,7 +238,7 @@ Text index is supported for both offline and real-time segments.
 
 The original text document (denoted by a value in the column that has text index enabled) is parsed, tokenized and individual "indexable" terms are extracted. These terms are inserted into the index.
 
-Pinot's text index is built on top of Lucene. Lucene's **standard english text tokenizer** generally works well for most classes of text. Since it can be desirable to build a custom text parser and tokenizer to suit particular user requirements this can be made configurable for the user to specify on per column text index basis.
+Pinot's text index is built on top of Lucene. Lucene's **standard english text tokenizer** generally works well for most classes of text. To build a custom text parser and tokenizer to suit particular user requirements, this can be made configurable for the user to specify on a per-column text-index basis.
 
 There is a default set of "stop words" built in Pinot's text index. This is a set of high frequency words in English that are excluded for search efficiency and index size, including:
 


### PR DESCRIPTION
This PR contains simple edits to the following indexing pages:

- JSON index
- Geospatial support
- Text search support

This is an ongoing project from the documentation team and there will be many related PRs with edits to different sections to help with consistency, clarity, and manner of expression in the docs.

Note to reviewer: As with most of the pages in the indexing section, all these pages should ultimately be split into tutorials and simple procedures. It's still too difficult to quickly find a command or configuration info without sifting through a plethora of contextual content. That contextual content is good, but it needs it's own space.