### PR TITLE
Fix hyperlink to Pulsar official docs on metadata fields.

### DIFF
--- a/basics/data-import/pinot-stream-ingestion/apache-pulsar.md
+++ b/basics/data-import/pinot-stream-ingestion/apache-pulsar.md
@@ -89,7 +89,7 @@ Pinot currently relies on Pulsar client version 2.7.2. Make sure the Pulsar brok
 
 #### Extract record headers as Pinot table columns
 
-Pinot's Pulsar connector supports automatically extracting record headers and metadata into the Pinot table columns. Pulsar supports a large amount of per-record metadata. Please reference the Pulsar documentation for the meaning of the metadata fields: https://pulsar.apache.org/docs/en/concepts-messaging/#message-properties
+Pinot's Pulsar connector supports automatically extracting record headers and metadata into the Pinot table columns. Pulsar supports a large amount of per-record metadata. Please reference the [official Pulsar documentation](https://pulsar.apache.org/docs/en/concepts-messaging/#message-properties) for the meaning of the metadata fields.
 
 The following table shows the mapping for record header/metadata to Pinot table column names:
 


### PR DESCRIPTION
Corrects a malformed link to the Pulsar metadata field reference.

@navina 