### PR TITLE
Add info on specifying avro schema location

### DIFF
--- a/basics/data-import/pinot-stream-ingestion/import-from-apache-kafka.md
+++ b/basics/data-import/pinot-stream-ingestion/import-from-apache-kafka.md
@@ -355,3 +355,21 @@ Once the schema is updated, these columns are similar to any other pinot column.
 {% hint style="info" %}
 Remember to follow the [schema evolution guidelines](../../../users/tutorials/schema-evolution.md) when updating schema of an existing table!
 {% endhint %}
+
+#### Tell Pinot where to find an Avro schema
+
+To avoid errors like `The Avro schema must be provided`, designate the location of the schema in your `streamConfigs` section. For example, if your current section contains the following:
+
+```
+"streamConfigs": {
+  "streamType": "kafka",
+  "stream.kafka.consumer.type": "lowlevel",
+  "stream.kafka.topic.name": "",
+  "stream.kafka.decoder.class.name": "org.apache.pinot.plugin.inputformat.avro.SimpleAvroMessageDecoder",
+  "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory",
+  "stream.kafka.broker.list": "",
+  "stream.kafka.consumer.prop.auto.offset.reset": "largest"
+}
+```
+
+Then add this key: `"stream.kafka.decoder.prop.schema"`followed by a value that denotes the location of your schema.

--- a/basics/data-import/pinot-stream-ingestion/import-from-apache-kafka.md
+++ b/basics/data-import/pinot-stream-ingestion/import-from-apache-kafka.md
@@ -360,7 +360,8 @@ Remember to follow the [schema evolution guidelines](../../../users/tutorials/sc
 
 To avoid errors like `The Avro schema must be provided`, designate the location of the schema in your `streamConfigs` section. For example, if your current section contains the following:
 
-```
+```json
+...
 "streamConfigs": {
   "streamType": "kafka",
   "stream.kafka.consumer.type": "lowlevel",
@@ -369,6 +370,7 @@ To avoid errors like `The Avro schema must be provided`, designate the location 
   "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory",
   "stream.kafka.broker.list": "",
   "stream.kafka.consumer.prop.auto.offset.reset": "largest"
+  ...
 }
 ```
 


### PR DESCRIPTION
This fixes https://github.com/apache/pinot/issues/9990

This is not an ideal fix, but it is adequate as a MVP en route to future intended work on cleaning up this section of the documentation. So, I'm pushing a kludge in lieu of retaining a gap, but I consider this is a temporary fix.