### PR TITLE
Update invalid URL on the Running in Kubernetes page

### DIFF
--- a/basics/getting-started/kubernetes-quickstart.md
+++ b/basics/getting-started/kubernetes-quickstart.md
@@ -45,7 +45,7 @@ cd pinot/kubernetes/helm/pinot
 
 {% tabs %}
 {% tab title="Run Helm with pre-installed package" %}
-The Pinot repository has pre-packaged Helm charts for Pinot and Presto. The Helm repository index file is [here](https://github.com/apache/pinot/blob/master/kubernetes/helm/index.yaml).
+The Pinot repository has pre-packaged Helm charts for Pinot and Presto. The Helm repository index file is [here](https://github.com/apache/pinot/blob/master/helm/index.yaml).
 
 ```bash
 helm repo add pinot https://raw.githubusercontent.com/apache/pinot/master/helm


### PR DESCRIPTION
Update on page: https://docs.pinot.apache.org/basics/getting-started/kubernetes-quickstart#set-up-a-pinot-cluster-in-kubernetes


 Helm repository index file seems to be moved to a new directory.
