### PR TITLE
Fix broken link to docker deployment

### DIFF
--- a/basics/getting-started/pushing-your-data-to-pinot.md
+++ b/basics/getting-started/pushing-your-data-to-pinot.md
@@ -4,7 +4,7 @@ description: Step-by-step guide for pushing your own data into the Pinot cluster
 
 # Batch import example
 
-This example assumes you have set up your cluster using [Pinot in Docker](https://docs.pinot.apache.org/basics/getting-started/advanced-pinot-setup).
+This example assumes you have set up your cluster using [Pinot in Docker](running-pinot-in-docker).
 
 ### Preparing your data
 


### PR DESCRIPTION
It was reported in [Slack](https://apache-pinot.slack.com/archives/C013WKLT5T7/p1703176134267269) that the linked page wasn't working. In fact the link is what was broken given we have now a dedicated page explaining how to deploy in docker.