### PR TITLE
Fix references for distinctCountHLLMv and distinctCountBitmapMv

### DIFF
--- a/configuration-reference/functions/distinctcountbitmapmv.md
+++ b/configuration-reference/functions/distinctcountbitmapmv.md
@@ -1,23 +1,23 @@
 ---
 description: >-
-  This section contains reference documentation for the DISTINCTCOUNTHLLMV
-  function.
+This section contains reference documentation for the DISTINCTCOUNTBITMAPMV
+function.
 ---
 
 # DISTINCTCOUNTBITMAPMV
 
-Returns an approximate distinct count using HyperLogLog in a group
+Returns the count of distinct row values in a group. This function is accurate for INT or dictionary encoded column, but approximate for other cases where hash codes are used in distinct counting and there may be hash collision.
 
 ## Signature
 
-> DISTINCTCOUNTHLLMV(colName)
+> DISTINCTCOUNTBITMAPMV(colName)
 
 ## Usage Examples
 
 These examples are based on the [Hybrid Quick Start](../../basics/getting-started/quick-start.md#hybrid).
 
 ```sql
-select DISTINCTCOUNTHLLMV(DivLongestGTimes) AS value
+select DISTINCTCOUNTBITMAPMV(DivLongestGTimes) AS value
 from airlineStats 
 where arraylength(DivLongestGTimes) > 1
 ```
@@ -25,3 +25,13 @@ where arraylength(DivLongestGTimes) > 1
 | value |
 | ----- |
 | 34    |
+
+```sql
+select DISTINCTCOUNTBITMAPMV(DivTailNums) AS value
+from airlineStats 
+where arraylength(DivTailNums) > 1
+```
+
+| value |
+| ----- |
+| 2     |

--- a/configuration-reference/functions/distinctcountbitmapmv.md
+++ b/configuration-reference/functions/distinctcountbitmapmv.md
@@ -6,7 +6,7 @@ function.
 
 # DISTINCTCOUNTBITMAPMV
 
-Returns the count of distinct row values in a group. This function is accurate for INT or dictionary encoded column, but approximate for other cases where hash codes are used in distinct counting and there may be hash collision.
+Returns the count of distinct row values in a group. This function is accurate for an INT or dictionary encoded column, but approximate for other cases where hash codes are used in distinct counting and there may be hash collision.
 
 ## Signature
 

--- a/configuration-reference/functions/distinctcounthllmv.md
+++ b/configuration-reference/functions/distinctcounthllmv.md
@@ -6,7 +6,7 @@ function.
 
 # DISTINCTCOUNTHLLMV
 
-Returns an approximate distinct count using HyperLogLog in a group
+Returns an approximate distinct count using HyperLogLog in a group.
 
 ## Signature
 

--- a/configuration-reference/functions/distinctcounthllmv.md
+++ b/configuration-reference/functions/distinctcounthllmv.md
@@ -1,23 +1,23 @@
 ---
 description: >-
-  This section contains reference documentation for the DISTINCTCOUNTBITMAPMV
-  function.
+This section contains reference documentation for the DISTINCTCOUNTHLLMV
+function.
 ---
 
 # DISTINCTCOUNTHLLMV
 
-Returns the count of distinct row values in a group. This function is accurate for INT or dictionary encoded column, but approximate for other cases where hash codes are used in distinct counting and there may be hash collision.
+Returns an approximate distinct count using HyperLogLog in a group
 
 ## Signature
 
-> DISTINCTCOUNTBITMAPMV(colName)
+> DISTINCTCOUNTHLLMV(colName)
 
 ## Usage Examples
 
 These examples are based on the [Hybrid Quick Start](../../basics/getting-started/quick-start.md#hybrid).
 
 ```sql
-select DISTINCTCOUNTBITMAPMV(DivLongestGTimes) AS value
+select DISTINCTCOUNTHLLMV(DivLongestGTimes) AS value
 from airlineStats 
 where arraylength(DivLongestGTimes) > 1
 ```
@@ -25,13 +25,3 @@ where arraylength(DivLongestGTimes) > 1
 | value |
 | ----- |
 | 34    |
-
-```sql
-select DISTINCTCOUNTBITMAPMV(DivTailNums) AS value
-from airlineStats 
-where arraylength(DivTailNums) > 1
-```
-
-| value |
-| ----- |
-| 2     |


### PR DESCRIPTION
Fix the content of the following pinot-docs
configuration-reference/functions/distinctcountbitmapmv.md: the content is pointing to distinctcounthllmv
configuration-reference/functions/distinctcounthllmv.md: the content is pointing to distinctcountbitmapmv.md
