### PR TITLE
Add custom pinot timezone instruction

### DIFF
--- a/basics/getting-started/frequent-questions/general.md
+++ b/basics/getting-started/frequent-questions/general.md
@@ -24,7 +24,7 @@ Check the JDK version you are using. You may be getting this error if you are us
 
 ## How to change TimeZone when running Pinot?
 
-Local timezone is the default of Pinot. To change the timezone, you need to set the `pinot.timzone` value in the `.conf` config file. It will be set once for all Pinot's components (Controller, Broker, Server, Minion)
+Local timezone is the default of Pinot. To change the timezone, you need to set the `pinot.timezone` value in the `.conf` config file. It will be set once for all Pinot's components (Controller, Broker, Server, Minion)
 Below is a sample config
 ```
 pinot.timezone=UTC

--- a/basics/getting-started/frequent-questions/general.md
+++ b/basics/getting-started/frequent-questions/general.md
@@ -24,8 +24,8 @@ Check the JDK version you are using. You may be getting this error if you are us
 
 ## How to change TimeZone when running Pinot?
 
-Local timezone is the default of Pinot. To change the timezone, you need to set the `pinot.timezone` value in the `.conf` config file. It will be set once for all Pinot's components (Controller, Broker, Server, Minion)
-Below is a sample config
+Pinot uses the local timezone by default. To change the timezone, set the `pinot.timezone` value in the `.conf` config file. It is set once for all Pinot components (Controller, Broker, Server, Minion).
+See the following sample configuration:
 ```
 pinot.timezone=UTC
 ```

--- a/basics/getting-started/frequent-questions/general.md
+++ b/basics/getting-started/frequent-questions/general.md
@@ -24,22 +24,8 @@ Check the JDK version you are using. You may be getting this error if you are us
 
 ## How to change TimeZone when running Pinot?
 
-There are 2 ways to do it:
-
-1. Setting an environment variable: `TZ=UTC`.
-
-E.g.
-
+Local timezone is the default of Pinot. To change the timezone, you need to set the `pinot.timzone` value in the `.conf` config file. It will be set once for all Pinot's components (Controller, Broker, Server, Minion)
+Below is a sample config
 ```
-export TZ=UTC
+pinot.timezone=UTC
 ```
-
-2. Setting JVM argument: `user.timezone`
-
-```
--Duser.timezone=UTC
-```
-
-3. TODO: [https://github.com/apache/pinot/issues/12299](https://github.com/apache/pinot/issues/12299)
-
-Plan to add a configuration to change time zone using cluster config or pinot component config


### PR DESCRIPTION
Adding documentation to support custom pinot timezone setting.
Related to https://github.com/apache/pinot/pull/12386

@xiangfu0 let me know if you want to add a line `pinot.timezone` in each of the components in https://docs.pinot.apache.org/developers/advanced/advanced-pinot-setup 