### PR TITLE
Add datatypes table to schema page

### DIFF
--- a/configuration-reference/schema.md
+++ b/configuration-reference/schema.md
@@ -60,6 +60,29 @@ The Pinot schema is composed of:
 
 The above json configuration is the example of Pinot schema derived from the flight data. As seen in the example, the schema is composed of 4 parts: `schemaName`, `dimensionFieldSpec`, `metricFieldSpec`, and `dateTimeFieldSpec`. Below is a detailed description of each type of field spec.
 
+
+### Data Types
+Data types determine the operations that can be performed on a column. Pinot supports the following data types:
+
+| Data Type    | Default Dimension Value                                                                                         | Default Metric Value   |
+| ------------ | --------------------------------------------------------------------------------------------------------------- | ---------------------- |
+| INT          | [Integer.MIN\_VALUE](https://docs.oracle.com/javase/7/docs/api/java/lang/Integer.html#MIN\_VALUE)               | 0                      |
+| LONG         | [Long.MIN\_VALUE](https://docs.oracle.com/javase/7/docs/api/java/lang/Long.html#MIN\_VALUE)                     | 0                      |
+| FLOAT        | [Float.NEGATIVE\_INFINITY](https://docs.oracle.com/javase/7/docs/api/java/lang/Float.html#NEGATIVE\_INFINITY)   | 0.0                    |
+| DOUBLE       | [Double.NEGATIVE\_INFINITY](https://docs.oracle.com/javase/7/docs/api/java/lang/Double.html#NEGATIVE\_INFINITY) | 0.0                    |
+| BIG\_DECIMAL | Not supported                                                                                                   | 0.0                    |
+| BOOLEAN      | 0 (false)                                                                                                       | N/A                    |
+| TIMESTAMP    | 0 (1970-01-01 00:00:00 UTC)                                                                                     | N/A                    |
+| STRING       | "null"                                                                                                          | N/A                    |
+| JSON         | "null"                                                                                                          | N/A                    |
+| BYTES        | byte array of length 0                                                                                          | byte array of length 0 |
+
+{% hint style="warning" %}
+The lowest granularity TIMESTAMP type supports is milliseconds epoch, nanoseconds is not supported.
+{% endhint %}
+
+Read the following sections for details on how data types are used in various parts of a schema.
+
 ### DimensionFieldSpec
 
 A dimensionFieldSpec is defined for each dimension column. Here's a list of the fields in the dimensionFieldSpec:

--- a/developers/advanced/null-value-support.md
+++ b/developers/advanced/null-value-support.md
@@ -3,7 +3,7 @@
 {% hint style="danger" %}
 **Multi-stage engine warning**
 
-This document describes null handling for the [single-stage query engine](../../reference/single-stage-engine.md). At this time, the [**multi-stage query engine**](../../reference/multi-stage-engine.md) **(v2) does not support null handling**. Queries involving null values in a multi-stage environment may return unexpected results.
+This document describes null handling for the [single-stage query engine](../../reference/single-stage-engine.md). At this time, the [multi-stage query engine](../../reference/multi-stage-engine.md) (v2) does not support null handling. Queries involving null values in a multi-stage environment may return unexpected results.
 {% endhint %}
 
 Null handling is defined in two different parts: at ingestion and at query time.
@@ -19,7 +19,7 @@ By default, null handling is disabled (`nullHandlingEnabled=false`) in the Table
 
 ### Enable basic null support
 
-To enable basic null support (`IS NULL` and `IS NOT NULL`) and generate the null index, in the Table index configuration ([tableIndexConfig](https://docs.pinot.apache.org/configuration-reference/table#tableindexconfig-1)), set **`nullHandlingEnabled=true`**.
+To enable basic null support (`IS NULL` and `IS NOT NULL`) and generate the null index, in the Table index configuration ([tableIndexConfig](https://docs.pinot.apache.org/configuration-reference/table#tableindexconfig-1)), set `nullHandlingEnabled=true`.
 
 When null support is enabled, `IS NOT NULL` and `IS NULL` evaluate to `true` or `false` according to whether a null is detected.
 
@@ -72,8 +72,8 @@ Pinot provides advanced null handling support similar to standard SQL null handl
 
 To enable `NULL` handling, do the following:
 
-1. `To enable` null handling during ingestion, in [tableIndexConfig](https://docs.pinot.apache.org/configuration-reference/table#tableindexconfig-1), set**`nullHandlingEnabled=true`**.
-2. To enable null handling for queries, set the**`enableNullHandling`** [query option](https://docs.pinot.apache.org/users/user-guide-query/query-options).
+1. `To enable` null handling during ingestion, in [tableIndexConfig](https://docs.pinot.apache.org/configuration-reference/table#tableindexconfig-1), set `nullHandlingEnabled=true`.
+2. To enable null handling for queries, set the `enableNullHandling` [query option](https://docs.pinot.apache.org/users/user-guide-query/query-options).
 
 {% hint style="info" %}
 **Important**
@@ -81,7 +81,7 @@ To enable `NULL` handling, do the following:
 You MUST `SET enableNullHandling=true;` before you query. Just having `"nullHandlingEnabled: true,"` set in your table config does not automatically provide `enableNullHandling=true` when you execute a query. Basic null handling supports `IS NOT NULL` and `IS NULL` predicates. Advanced null handling adds SQL compatibility.
 {% endhint %}
 
-#### **Ingestion time**
+#### Ingestion time
 
 To store the null values in a segment, you must enable the `nullHandlingEnabled` in [tableIndexConfig section](https://docs.pinot.apache.org/configuration-reference/table#tableindexconfig-1) before ingesting the data.
 


### PR DESCRIPTION
This table used to exist in the docs, [see the 0.10.0 version](https://docs.pinot.apache.org/v/release-0.10.0/basics/components/schema). It has been requested.

HOWEVER, it needs a serious review as this is old information. What I _suspect_ is that the table was removed as the other sections of the page were fleshed out and the information was spread across those sections. But, it would be useful to have a master list, especially for support and sales/marketing. So, let's figure out who can help with a review and get this updated.