### PR TITLE
Add notes about text indexes

### DIFF
--- a/basics/indexing/README.md
+++ b/basics/indexing/README.md
@@ -18,9 +18,7 @@ Apache Pinot supports the following indexing techniques:
 * [JSON index](json-index.md)
 * [Range index](range-index.md)
 * [Star-tree index](star-tree-index.md)
-* Text Index
-  * [Native text index](native-text-index.md)
-  * [Text search support](text-search-support.md)
+* [Text search support](text-search-support.md)
 * [Timestamp index](timestamp-index.md)
 
 By default, Pinot creates a dictionary-encoded forward index for each column.

--- a/basics/indexing/native-text-index.md
+++ b/basics/indexing/native-text-index.md
@@ -4,7 +4,15 @@ description: >-
   functionality in Apache Pinot.
 ---
 
-# Native Text Index
+# Native Text Index - Experimental
+
+{% hint style="warning" %}
+**Experimental**
+
+This index is experimental and should only be used for testing. It is not recommended for use in production.
+
+Instead, use [this text index](text-search-support.md#enable-a-text-index).
+{% endhint %}
 
 ## Native text index
 

--- a/basics/indexing/text-search-support.md
+++ b/basics/indexing/text-search-support.md
@@ -4,6 +4,12 @@ description: This page talks about support for text search in Pinot.
 
 # Text search support
 
+{% hint style="note" %}
+This text index method is recommended over the experimental [native text index](native-text-index.md).
+
+Click to skip the background info and go straight to the procedure [to enable this text index](#enable-a-text-index).
+{% endhint %}
+
 ## Why do we need text search?
 
 Pinot supports super-fast query processing through its indexes on non-BLOB like columns. Queries with exact match filters are run efficiently through a combination of dictionary encoding, inverted index, and sorted index.


### PR DESCRIPTION
This adds an EXPERIMENTAL label to the native text index with a link to the Lucene text index. Then, it renames the Lucene page to Text index with a note that this is preferred. Finally, it adds a link at the top of the Lucene page to help readers skip the background info and go straight to the procedure for enabling.