### PR TITLE
Clean up 1.1.0 release notes

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -81,7 +81,7 @@
   * [Star-tree index](basics/indexing/star-tree-index.md)
   * [Text search support](basics/indexing/text-search-support.md)
   * [Timestamp index](basics/indexing/timestamp-index.md)
-* [Releases](basics/releases/README.md)
+* [Release notes](basics/releases/README.md)
   * [1.1.0](basics/releases/1.1.0.md)
   * [1.0.0](basics/releases/1.0.0.md)
   * [0.12.1](basics/releases/0.12.1.md)

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -99,7 +99,7 @@
   * [0.4.0](basics/releases/0.4.0.md)
   * [0.3.0](basics/releases/0.3.0.md)
   * [0.2.0](basics/releases/0.2.0.md)
-  * [0.1.0](basics/releases/1.0.md)
+  * [0.1.0](basics/releases/0.1.0.md)
 * [Recipes](basics/recipes/README.md)
   * [Connect to Streamlit](basics/recipes/streamlit.md)
   * [Connect to Dash](basics/recipes/dash.md)

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -83,7 +83,7 @@
   * [Timestamp index](basics/indexing/timestamp-index.md)
 * [Releases](basics/releases/README.md)
   * [1.1.0](basics/releases/1.1.0.md)
-  * [Apache Pinot™ 1.0.0 release notes](basics/releases/1.0.0.md)
+  * [1.0.0](basics/releases/1.0.0.md)
   * [0.12.1](basics/releases/0.12.1.md)
   * [0.12.0](basics/releases/0.12.0.md)
   * [0.11.0](basics/releases/0.11.0.md)

--- a/basics/releases/1.1.0.md
+++ b/basics/releases/1.1.0.md
@@ -6,7 +6,7 @@ description: Release Notes for 1.1.0
 
 ## Summary
 
-This release comes with several features, SQL /UI/Perf enhancements Bugfixes across areas ranging from Multistage Query Engine to Ingestion, Storage format, SQL support, etc.
+This release comes with several features, including SQL, UI, and performance enhancements. Also included are bug fixes across multiple features such as the V2 multi-stage query engine, ingestion, storage format, and SQL support.
 
 ### Multi-stage Query Engine
 
@@ -689,7 +689,7 @@ DISTINCTCOUNTHLLPLUS(some_id, 12)
 * Observibility enhancement to add CPU metrics for minion purge task ([#12337](https://github.com/apache/pinot/pull/12337))
 * Add HttpHeaders in broker event listener requestContext ([#12258](https://github.com/apache/pinot/pull/12258))
 
-### Bugfixes, Refactoring, Cleanups, Deprecations
+### Bug fixes, Refactoring, Cleanups, Deprecations
 
 * Upsert bugfix in "rewind()" for CompactedPinotSegmentRecordReader ([#12329](https://github.com/apache/pinot/pull/12329))
 * Fix error message format for Preconditions.checks failures([#12327](https://github.com/apache/pinot/pull/12327))
@@ -908,12 +908,12 @@ DISTINCTCOUNTHLLPLUS(some_id, 12)
 * Prevent NPE when attempt to fetch partition information fails ([#11769](https://github.com/apache/pinot/pull/11769))
 * Added UTs for null handling in `CaseTransform` function. ([#11721](https://github.com/apache/pinot/pull/11721))
 * Bugfix to disallow peer download when replication is < 2 ([#11469](https://github.com/apache/pinot/pull/11469))
-* Update s todocker image and github action scripts ([#12378](https://github.com/apache/pinot/pull/12378))
+* Updates to Docker image and GitHub action scripts ([#12378](https://github.com/apache/pinot/pull/12378))
 * Enhancements to queries test framework ([#12215](https://github.com/apache/pinot/pull/12215))
 
 ### Library Upgrades and dependencies
 
-* update maven-jar-plugin and maven-enforcer-plugin version (#11637)
+* Update maven-jar-plugin and maven-enforcer-plugin version (#11637)
 * Update testng as the test provider explicitly instead of relying on the classpath. ([#11612](https://github.com/apache/pinot/pull/11612))
 * Update compatibility verifier version ([#11684](https://github.com/apache/pinot/pull/11684))
 * Upgrade Avro dependency to 1.10.2 ([#11698](https://github.com/apache/pinot/pull/11698))

--- a/basics/releases/1.1.0.md
+++ b/basics/releases/1.1.0.md
@@ -201,8 +201,7 @@ LIMIT 10
 #### Support for retention on deleted keys of upsert tables ([#12037](https://github.com/apache/pinot/pull/12037))
 
 * Adds an upsert config `deletedKeysTTL` which will remove deleted keys from in-memory hashmap and mark the validDocID as invalid after the `deletedKeysTTL` threshold period.
-* Disabled by default. Enabled only if a valid value for `deletedKeysTTL` is set
-* More details in the [design document](https://docs.google.com/document/d/19odpbURBKALANBo1-bWQMVS9b\_Enyt3jWpdLKeVYMvU/edit)
+* Disabled by default. Enabled only if a valid value for `deletedKeysTTL` is set.
 
 #### Configurable Lucene analyzer ([#12027](https://github.com/apache/pinot/pull/12027))
 

--- a/basics/releases/1.1.0.md
+++ b/basics/releases/1.1.0.md
@@ -8,16 +8,16 @@ description: Release Notes for 1.1.0
 
 This release comes with several features, including SQL, UI, and performance enhancements. Also included are bug fixes across multiple features such as the V2 multi-stage query engine, ingestion, storage format, and SQL support.
 
-### Multi-stage Query Engine
+### Multi-stage query engine
 
 #### Features
 
-**Support RelDistribution-based trait Planning (**[**#11976**](https://github.com/apache/pinot/pull/11976)**,** [**#12079**](https://github.com/apache/pinot/pull/12079)**)**
+**Support RelDistribution-based trait planning (**[**#11976**](https://github.com/apache/pinot/pull/11976)**,** [**#12079**](https://github.com/apache/pinot/pull/12079)**)**
 
 * Adds support for RelDistribution optimization for more accurate leaf-stage direct exchange/shuffle. Also extends partition optimization beyond leaf stage to entire query plan.
 * Applies optimization based on distribution trait in the mailbox/worker assignment stage
   * Fixes previous direct exchange which was decided based on the table partition hint. Now direct exchange is decided via distribution trait: it will applied if-and-only-if the trait propagated matches the exchange requirement.
-  * As a side effect, `is_colocated_by_join_keys`query option is reintroduced to ensure dynamic broadcast which can also benefit from direct exchange optimization
+  * As a side effect, `is_colocated_by_join_keys` query option is reintroduced to ensure dynamic broadcast which can also benefit from direct exchange optimization
   * Allows propagation of partition distribution trait info across the tree to be used during Physical Planning phase. It can be used in the following scenarios (will follow up in separate PRs)
 * Note on backward incompatbility
   * `is_colocated_by_join_keys` hint is now required for making colocated joins
@@ -70,7 +70,7 @@ This release comes with several features, including SQL, UI, and performance enh
 * Optimizations in query dispatch ([#12358](https://github.com/apache/pinot/pull/12358))
 * Perf optimization for group-by and join for single key scenario ([#11630](https://github.com/apache/pinot/pull/11630))
 
-#### Bugfixes, Refactoring, Cleanups, Tests
+#### Bugfixes, refactoring, cleanups, tests
 
 * Bugfix for evaluation of chained literal functions ([#12248](https://github.com/apache/pinot/pull/12248))
 * Fixes to sort copy rule ([#12251](https://github.com/apache/pinot/pull/12251) and [#12237](https://github.com/apache/pinot/pull/12237))
@@ -105,7 +105,7 @@ This release comes with several features, including SQL, UI, and performance enh
 * Fix stage id in stage plan ([#12366](https://github.com/apache/pinot/pull/12366))
 * Bugfix for IN and NOT IN filters within case statements ([#12305](https://github.com/apache/pinot/pull/12305))
 
-### Notable Features
+### Notable features
 
 #### Server-level throttling for realtime consumption ([#12292](https://github.com/apache/pinot/pull/12292))
 
@@ -117,7 +117,7 @@ This release comes with several features, including SQL, UI, and performance enh
 * Supported in `MergeRollupTask` and `RealtimeToOfflineSegmentsTask` minion tasks
 * Use taskConfig `segmentMapperFileSizeThresholdInBytes` to specify the threshold size
 
-```
+```json
 "task": {
   "taskTypeConfigsMap": {
     "<task_name>": {
@@ -132,14 +132,14 @@ This release comes with several features, including SQL, UI, and performance enh
 * Security feature that makes the keystore/truststore swappable.
 * Auto-reloads keystore/truststore (without need for a restart) if they are local files
 
-#### Sticky Query Routing ([#12276](https://github.com/apache/pinot/pull/12276))
+#### Sticky query routing ([#12276](https://github.com/apache/pinot/pull/12276))
 
 * Adds support for deterministic and sticky routing for a query / table / broker. This setting would lead to same server / set of servers (for `MultiStageReplicaGroupSelector`) being used for all queries of a given table.
 * Query option (takes precedence over fixed routing setting at table / broker config level)\
   `SET "useFixedReplica"=true;`
 *   Table config (takes precedence over fixed routing setting at broker config level)
 
-    ```
+    ```json
     "routing": {
        ...          
        "useFixedReplica": true
@@ -152,7 +152,7 @@ This release comes with several features, including SQL, UI, and performance enh
 * Use tableConfig `dimensionTableConfig.errorOnDuplicatePrimaryKey=true` to enable this behavior
 * Disabled by default
 
-#### Partition-Level ForceCommit for realtime tables ([#12088](https://github.com/apache/pinot/pull/12088))
+#### Partition-level ForceCommit for realtime tables ([#12088](https://github.com/apache/pinot/pull/12088))
 
 * Support to force-commit specific partitions of a realtime table.
 * Partitions can be specified to the `forceCommit` API as a comma separated list of partition names or consuming segment names
@@ -163,7 +163,7 @@ This release comes with several features, including SQL, UI, and performance enh
 * Automatically updates brokerResource when broker joins the cluster for the first time
 * Broker tags are provided as comma-separated values in `pinot.broker.instance.tags`
 
-#### Support for StreamNative OAuth2 authentication for pulsar ([#12068](https://github.com/apache/pinot/pull/12068))
+#### Support for StreamNative OAuth2 authentication for Pulsar ([#12068](https://github.com/apache/pinot/pull/12068))
 
 * StreamNative (the cloud SAAS offering of Pulsar) uses OAuth2 to authenticate clients to their Pulsar clusters.
 * For more information, see how to [Configure OAuth2 authentication in Pulsar clients](https://pulsar.apache.org/docs/en/security-oauth2/#configure-oauth2-authentication-in-pulsar-clients)
@@ -171,7 +171,7 @@ This release comes with several features, including SQL, UI, and performance enh
 
 ```
 "stream.pulsar.issuerUrl": "https://auth.streamnative.cloud"
-"stream.pulsar.credsFilePath": "file:///path/to/private_creds_file
+"stream.pulsar.credsFilePath": "file:///path/to/private_creds_file"
 "stream.pulsar.audience": "urn:sn:pulsar:test:test-cluster"
 ```
 
@@ -182,12 +182,12 @@ This release comes with several features, including SQL, UI, and performance enh
 * When enabled, segments will first be offloaded from servers, then added to servers after offload is done. It may increase the total time of the rebalance, but can be useful when servers are low on disk space, and we want to scale up the cluster and rebalance the table to more servers.
 * [#12112](https://github.com/apache/pinot/pull/12112) adds the UI capability to toggle this option
 
-#### Support Vector index and Hierarchical Navigable Small Worlds (HNSW) ([#11977](https://github.com/apache/pinot/pull/11977))
+#### Support vector index and hierarchical navigable small worlds (HNSW) ([#11977](https://github.com/apache/pinot/pull/11977))
 
 * Supports Vector Index on float array/multi-value columnz
 * Add predicate and function to retrieve topK closest vector. Example query
 
-```
+```sql
 SELECT ProductId, UserId, l2_distance(embedding, ARRAY[-0.0013143676,-0.011042999,...]) AS l2_dist, n_tokens, combined
 FROM fineFoodReviews
 WHERE VECTOR_SIMILARITY(embedding, ARRAY[-0.0013143676,-0.011042999,...], 5)  
@@ -208,7 +208,7 @@ LIMIT 10
 * Introduces the capability to specify a custom Lucene analyzer used by text index for indexing and search on an individual column basis.
 * Sample usage
 
-```
+```json
 fieldConfigList: [
    {
         "name": "columnName",
@@ -231,7 +231,7 @@ fieldConfigList: [
 * Added support for 2 variants of `Murmur3`: `x86_32` and `x64_32` configurable using the `variant` field in `functionConfig`. If no variant is provided we choose to keep the `x86_32` variant as it was part of the original implementation.
 *   Examples of `functionConfig`;
 
-    ```
+    ```json
     "tableIndexConfig": {
           ..
           "segmentPartitionConfig": {
@@ -247,7 +247,7 @@ fieldConfigList: [
 
     Here there is no functionConfig configured, so the `seed` value will be `0` and variant will be `x86_32`.
 
-    ```
+    ```json
     "tableIndexConfig": {
           ..
           "segmentPartitionConfig": {
@@ -266,7 +266,7 @@ fieldConfigList: [
 
     Here the `seed` is configured as `9001` but as no variant is provided, `x86_32` will be picked up.
 
-    ```
+    ```json
      "tableIndexConfig": {
           ..
           "segmentPartitionConfig": {
@@ -296,7 +296,7 @@ fieldConfigList: [
 * The new index format can be enabled during index creation, derived column creation, and segment reload
 *   To enable the new index format, set the compression codec in the `FieldConfig`:
 
-    ```
+    ```json
     {
       "name": "myCol",
       "encodingType": "DICTIONARY",
@@ -306,7 +306,7 @@ fieldConfigList: [
 
     Or use the new index JSON:
 
-    ```
+    ```json
     {
       "name": "myCol",
       "encodingType": "DICTIONARY",
@@ -326,7 +326,7 @@ fieldConfigList: [
 * Column mode can be enabled by the below config.
 * The default value for `enableColumnBasedNullHandling` is false. When set to true, Pinot will ignore `TableConfig.IndexingConfig.nullHandlingEnabled` and columns will be nullable **if and only if** `FieldSpec.notNull` is false, which is also the default value.
 
-```
+```json
 {
   "schemaName": "blablabla",
   "dimensionFieldSpecs": [
@@ -361,7 +361,7 @@ fieldConfigList: [
 * Can be used to save space. For eg: when a `functionColumnPairs` has a output type of bytes, such as when you use `distinctcountrawhll.`
 * Sample config
 
-```
+```json
 "starTreeIndexConfigs": [
         {
           "dimensionsSplitOrder": [
@@ -395,7 +395,7 @@ fieldConfigList: [
 * More details [here](https://docs.google.com/document/d/1xxPkGPxyY21gAkFi9gtFDeSzEXjPjp-IQW70kHynsL8/edit#heading=h.nit8xkm24pdw)
 * Sample table config
 
-```
+```json
 "instanceAssignmentConfigMap": {
   "CONSUMING": {
     "partitionSelector": "MIRROR_SERVER_SET_PARTITION_SELECTOR",
@@ -421,7 +421,7 @@ fieldConfigList: [
  },
 ```
 
-#### Support for Listing Dimension Tables ([#11859](https://github.com/apache/pinot/pull/11859))
+#### Support for listing dimension tables ([#11859](https://github.com/apache/pinot/pull/11859))
 
 * Adds `dimension` as a valid option to table "type" in the /tables controller API
 
@@ -482,7 +482,7 @@ fieldConfigList: [
     6. BrokerConfig -> pinot.broker.max.query.response.size.bytes
     ```
 
-#### UI Support to Allow schema to be created with JSON config ([#11809](https://github.com/apache/pinot/pull/11809))
+#### UI support to allow schema to be created with JSON config ([#11809](https://github.com/apache/pinot/pull/11809))
 
 * This is helpful when user has the entire JSON handy
 * UI still keeps Form Way to add Schema along with JSON view
@@ -517,13 +517,13 @@ FREQUENTLONGSSKETCH(col, maxMapSize=256) -> Base64 encoded sketch object
 FREQUENTSTRINGSSKETCH(col, maxMapSize=256) -> Base64 encoded sketch object
 ```
 
-#### Controller API for Table Indexe ([#11576](https://github.com/apache/pinot/pull/11576))
+#### Controller API for table index ([#11576](https://github.com/apache/pinot/pull/11576))
 
 * Table index api to get the aggregate index details of all segments for a table.
   * `URL/tables/{tableName}/indexes`
 *   Response format
 
-    ```
+    ```json
     {
         "totalSegments": 31,
         "columnToIndexesCount":
@@ -557,7 +557,7 @@ FREQUENTSTRINGSSKETCH(col, maxMapSize=256) -> Base64 encoded sketch object
 * More details in issue: [#10651](https://github.com/apache/pinot/issues/10651)
 * Sample configs through ENV
 
-```
+```bash
 export PINOT_CONTROLLER_HOST=host
 export PINOT_SERVER_PROPERTY_WHATEVER=whatever_property
 export ANOTHER_VARIABLE=random
@@ -689,7 +689,7 @@ DISTINCTCOUNTHLLPLUS(some_id, 12)
 * Observibility enhancement to add CPU metrics for minion purge task ([#12337](https://github.com/apache/pinot/pull/12337))
 * Add HttpHeaders in broker event listener requestContext ([#12258](https://github.com/apache/pinot/pull/12258))
 
-### Bug fixes, Refactoring, Cleanups, Deprecations
+### Bug fixes, refactoring, cleanups, deprecations
 
 * Upsert bugfix in "rewind()" for CompactedPinotSegmentRecordReader ([#12329](https://github.com/apache/pinot/pull/12329))
 * Fix error message format for Preconditions.checks failures([#12327](https://github.com/apache/pinot/pull/12327))
@@ -858,7 +858,7 @@ DISTINCTCOUNTHLLPLUS(some_id, 12)
 
       We now enforce the `enableSnapshot=true` for UpsertCompactionTask if the advanced customer wants to run the compaction with the in-memory validDocId bitmap.
 
-      ```
+      ```json
       {
         "upsertConfig": {
           "mode": "FULL",
@@ -911,7 +911,7 @@ DISTINCTCOUNTHLLPLUS(some_id, 12)
 * Updates to Docker image and GitHub action scripts ([#12378](https://github.com/apache/pinot/pull/12378))
 * Enhancements to queries test framework ([#12215](https://github.com/apache/pinot/pull/12215))
 
-### Library Upgrades and dependencies
+### Library upgrades and dependencies
 
 * Update maven-jar-plugin and maven-enforcer-plugin version (#11637)
 * Update testng as the test provider explicitly instead of relying on the classpath. ([#11612](https://github.com/apache/pinot/pull/11612))

--- a/basics/releases/README.md
+++ b/basics/releases/README.md
@@ -10,6 +10,12 @@ description: >-
 
 Before upgrading from one version to another one, read the release notes. While the Pinot committers strive to keep releases backward-compatible and introduce new features in a compatible manner, your environment may have a unique combination of configurations/data/schema that may have been somehow overlooked. Before you roll out a new release of Pinot on your cluster, it is best that you run the [compatibility test suite](../../operators/operating-pinot/upgrading-pinot-cluster.md) that Pinot provides. The tests can be easily customized to suit the configurations and tables in your pinot cluster(s). As a good practice, you should build your own test suite, mirroring the table configurations, schema, sample data, and queries that are used in your cluster.
 
+## 1.1.0 (March 2024)
+
+{% content-ref url="1.1.0.md" %}
+[1.1.0.md](1.1.0.md)
+{% endcontent-ref %}
+
 ## 1.0.0 (September 2023)
 
 {% content-ref url="1.0.0.md" %}

--- a/basics/releases/README.md
+++ b/basics/releases/README.md
@@ -4,7 +4,7 @@ description: >-
   earliest one.
 ---
 
-# Releases
+# Release notes
 
 ## Note
 

--- a/basics/releases/README.md
+++ b/basics/releases/README.md
@@ -114,6 +114,6 @@ Before upgrading from one version to another one, read the release notes. While 
 
 ## 0.1.0 (March 2019, First release)
 
-{% content-ref url="1.0.md" %}
-[1.0.md](1.0.md)
+{% content-ref url="0.1.0.md" %}
+[0.1.0.md](0.1.0.md)
 {% endcontent-ref %}


### PR DESCRIPTION
This PR:
- Adds a menu entry for the new release version notes to the main Releases page
- Adjusts the title of the 1.0.0 release notes in the left hand menu to conform to the pattern of the other release notes
- Makes some edits to the 1.1.0 release notes, just to clean them up a little
- Changes the title of the section in the table of contents from "Releases" to the more-accurate "Release notes"
- Fixes the name of the initial release from 1.0 to the more-accurate 0.1.0, including changing the filename and links.