### PR TITLE
Document additional Datasketches parameters

### DIFF
--- a/configuration-reference/functions/avgvalueintegersumtuplesketch.md
+++ b/configuration-reference/functions/avgvalueintegersumtuplesketch.md
@@ -14,7 +14,7 @@ The [Tuple Sketch](https://datasketches.apache.org/docs/Tuple/TupleOverview.html
 
 * `tupleSketchColumn` (required): Name of the column to aggregate on.  This must be an existing tuple sketch serialized as bytes.
 * `tupleSketchParams` (required): Semicolon-separated parameter string for constructing the intermediate tuple-sketches.
-  * Currently, the supported parameter are:
+  * The supported parameters are:
    * `nominalEntries`: The nominal entries used to create the sketch. (Default 65536)
    * `accumulatorThreshold`: How many sketches should be kept in memory before merging. (Default 2)
 

--- a/configuration-reference/functions/avgvalueintegersumtuplesketch.md
+++ b/configuration-reference/functions/avgvalueintegersumtuplesketch.md
@@ -10,10 +10,13 @@ The [Tuple Sketch](https://datasketches.apache.org/docs/Tuple/TupleOverview.html
 
 ## Signature
 
-> avgValueIntegerSumTupleSketch(**\<tupleSketchColumn>, \<tupleSketchLgK>**) -> Long
+> avgValueIntegerSumTupleSketch(**\<tupleSketchColumn>, \<tupleSketchParams>**) -> Long
 
 * `tupleSketchColumn` (required): Name of the column to aggregate on.  This must be an existing tuple sketch serialized as bytes.
-* `tupleSketchLgK` (optional): lgK which is the the log2 of K, which controls both the size and accuracy of the sketch.  If not supplied, the Helix default is used.
+* `tupleSketchParams` (required): Semicolon-separated parameter string for constructing the intermediate tuple-sketches.
+  * Currently, the supported parameter are:
+   * `nominalEntries`: The nominal entries used to create the sketch. (Default 65536)
+   * `accumulatorThreshold`: How many sketches should be kept in memory before merging. (Default 2)
 
 These examples are based on the [Batch Quick Start](../../basics/getting-started/quick-start.md#batch).  A new Tuple Sketch metric called `playerHomeRuns` was created during ingestion by updating the ingestion config as follows:
 
@@ -40,7 +43,7 @@ from baseballStats
 | 16    |
 
 ```sql
-select avgValueIntegerSumTupleSketch(playerHomeRuns, 16) as value
+select avgValueIntegerSumTupleSketch(playerHomeRuns, 'nominalEntries=4096;accumulatorThreshold=10') as value
 from baseballStats 
 ```
 

--- a/configuration-reference/functions/distinctcountcpcsketch.md
+++ b/configuration-reference/functions/distinctcountcpcsketch.md
@@ -12,10 +12,13 @@ For exact distinct counting, see [DISTINCTCOUNT](distinctcount.md).
 
 ## Signature
 
-> distinctCountCpcSketch(**\<cpcSketchColumn>, \<cpcSketchLgK>**) -> Long
+> distinctCountCpcSketch(**\<cpcSketchColumn>, \<cpcSketchParams>**) -> Long
 
 * `cpcSketchColumn` (required): Name of the column to aggregate on.
-* `cpcSketchLgK` (optional): lgK which is the the log2 of K, which controls both the size and accuracy of the sketch.  If not supplied, the Helix default is used.
+* `cpcSketchParams` (required): Semicolon-separated parameter string for constructing the intermediate CPC sketches.
+  * Currently, the supported parameter are:
+   * `nominalEntries`: The nominal entries used to create the sketch. (Default 4096)
+   * `accumulatorThreshold`: How many sketches should be kept in memory before merging. (Default 2)
 
 ## Usage Examples
 
@@ -31,7 +34,7 @@ from baseballStats
 | 150   |
 
 ```sql
-select distinctCountCpcSketch(teamID, 8) AS value
+select distinctCountCpcSketch(teamID, 'nominalEntries=256;accumulatorThreshold=10') AS value
 from baseballStats 
 ```
 

--- a/configuration-reference/functions/distinctcountcpcsketch.md
+++ b/configuration-reference/functions/distinctcountcpcsketch.md
@@ -16,7 +16,7 @@ For exact distinct counting, see [DISTINCTCOUNT](distinctcount.md).
 
 * `cpcSketchColumn` (required): Name of the column to aggregate on.
 * `cpcSketchParams` (required): Semicolon-separated parameter string for constructing the intermediate CPC sketches.
-  * Currently, the supported parameter are:
+  * The supported parameters are:
    * `nominalEntries`: The nominal entries used to create the sketch. (Default 4096)
    * `accumulatorThreshold`: How many sketches should be kept in memory before merging. (Default 2)
 

--- a/configuration-reference/functions/distinctcountrawcpcsketch.md
+++ b/configuration-reference/functions/distinctcountrawcpcsketch.md
@@ -14,7 +14,7 @@ The [Compressed Probability Counting(CPC) Sketch](https://datasketches.apache.or
 
 * `cpcSketchColumn` (required): Name of the column to aggregate on.
 * `cpcSketchParams` (required): Semicolon-separated parameter string for constructing the intermediate CPC sketches.
-  * Currently, the supported parameter are:
+  * The supported parameters are:
    * `nominalEntries`: The nominal entries used to create the sketch. (Default 4096)
    * `accumulatorThreshold`: How many sketches should be kept in memory before merging. (Default 2)
 

--- a/configuration-reference/functions/distinctcountrawcpcsketch.md
+++ b/configuration-reference/functions/distinctcountrawcpcsketch.md
@@ -10,10 +10,13 @@ The [Compressed Probability Counting(CPC) Sketch](https://datasketches.apache.or
 
 ## Signature
 
-> distinctCountRawCpcSketch(**\<cpcSketchColumn>, \<cpcSketchLgK>**) -> HexEncoded
+> distinctCountRawCpcSketch(**\<cpcSketchColumn>, \<cpcSketchParams>**) -> HexEncoded
 
 * `cpcSketchColumn` (required): Name of the column to aggregate on.
-* `cpcSketchLgK` (optional): lgK which is the the log2 of K, which controls both the size and accuracy of the sketch.  If not supplied, the Helix default is used.
+* `cpcSketchParams` (required): Semicolon-separated parameter string for constructing the intermediate CPC sketches.
+  * Currently, the supported parameter are:
+   * `nominalEntries`: The nominal entries used to create the sketch. (Default 4096)
+   * `accumulatorThreshold`: How many sketches should be kept in memory before merging. (Default 2)
 
 ## Usage Examples
 
@@ -29,7 +32,7 @@ from baseballStats
 | CAEQDAAOzJOVAAAAJwAAAAAAAAAMm69Al... |
 
 ```sql
-select distinctCountRawCpcSketch(teamID, 8) AS value
+select distinctCountRawCpcSketch(teamID, 'nominalEntries=256;accumulatorThreshold=10') AS value
 from baseballStats 
 ```
 

--- a/configuration-reference/functions/distinctcountrawintegersumtuplesketch.md
+++ b/configuration-reference/functions/distinctcountrawintegersumtuplesketch.md
@@ -10,10 +10,13 @@ The [Tuple Sketch](https://datasketches.apache.org/docs/Tuple/TupleOverview.html
 
 ## Signature
 
-> distinctCountRawIntegerSumTupleSketch(**\<tupleSketchColumn>, \<tupleSketchLgK>**) -> HexEncoded
+> distinctCountRawIntegerSumTupleSketch(**\<tupleSketchColumn>, \<tupleSketchParams>**) -> HexEncoded
 
 * `tupleSketchColumn` (required): Name of the column to aggregate on.  This must be an existing tuple sketch serialized as bytes.
-* `tupleSketchLgK` (optional): lgK which is the the log2 of K, which controls both the size and accuracy of the sketch.  If not supplied, the Helix default is used.
+* `tupleSketchParams` (required): Semicolon-separated parameter string for constructing the intermediate tuple-sketches.
+  * Currently, the supported parameter are:
+   * `nominalEntries`: The nominal entries used to create the sketch. (Default 65536)
+   * `accumulatorThreshold`: How many sketches should be kept in memory before merging. (Default 2)
 
 These examples are based on the [Batch Quick Start](../../basics/getting-started/quick-start.md#batch).  A new Tuple Sketch metric called `playerHomeRuns` was created during ingestion by updating the ingestion config as follows:
 
@@ -40,7 +43,7 @@ from baseballStats
 | AgMJAQAKzJONRAAAAAAAAAcADPv9ido0XwAAAAAP... |
 
 ```sql
-select distinctCountRawIntegerSumTupleSketch(playerHomeRuns, 16) as value
+select distinctCountRawIntegerSumTupleSketch(playerHomeRuns, 'nominalEntries=4096;accumulatorThreshold=10') as value
 from baseballStats 
 ```
 

--- a/configuration-reference/functions/distinctcountrawintegersumtuplesketch.md
+++ b/configuration-reference/functions/distinctcountrawintegersumtuplesketch.md
@@ -14,7 +14,7 @@ The [Tuple Sketch](https://datasketches.apache.org/docs/Tuple/TupleOverview.html
 
 * `tupleSketchColumn` (required): Name of the column to aggregate on.  This must be an existing tuple sketch serialized as bytes.
 * `tupleSketchParams` (required): Semicolon-separated parameter string for constructing the intermediate tuple-sketches.
-  * Currently, the supported parameter are:
+  * The supported parameters are:
    * `nominalEntries`: The nominal entries used to create the sketch. (Default 65536)
    * `accumulatorThreshold`: How many sketches should be kept in memory before merging. (Default 2)
 

--- a/configuration-reference/functions/distinctcountrawthetasketch.md
+++ b/configuration-reference/functions/distinctcountrawthetasketch.md
@@ -14,7 +14,7 @@ The [Theta Sketch](https://datasketches.apache.org/docs/Theta/ThetaSketchFramewo
 
 * `thetaSketchColumn` (required): Name of the column to aggregate on.
 * `thetaSketchParams` (required): Semicolon-separated parameter string for constructing the intermediate theta-sketches.
-  * Currently, the supported parameter are:
+  * The supported parameters are:
    * `nominalEntries`: The nominal entries used to create the sketch. (Default 4096)
    * `samplingProbability`: Sets the upfront uniform sampling probability, p. (Default 1.0)
    * `accumulatorThreshold`: How many sketches should be kept in memory before merging. (Default 2)

--- a/configuration-reference/functions/distinctcountrawthetasketch.md
+++ b/configuration-reference/functions/distinctcountrawthetasketch.md
@@ -13,7 +13,11 @@ The [Theta Sketch](https://datasketches.apache.org/docs/Theta/ThetaSketchFramewo
 > distinctCountRawThetaSketch(**\<thetaSketchColumn>, \<thetaSketchParams>, predicate1, predicate2..., postAggregationExpressionToEvaluate**) -> HexEncoded
 
 * `thetaSketchColumn` (required): Name of the column to aggregate on.
-* `thetaSketchParams` (required): Parameters for constructing the intermediate theta-sketches.
+* `thetaSketchParams` (required): Semicolon-separated parameter string for constructing the intermediate theta-sketches.
+  * Currently, the supported parameter are:
+   * `nominalEntries`: The nominal entries used to create the sketch. (Default 4096)
+   * `samplingProbability`: Sets the upfront uniform sampling probability, p. (Default 1.0)
+   * `accumulatorThreshold`: How many sketches should be kept in memory before merging. (Default 2)
   * Currently, the only supported parameter is `nominalEntries` (defaults to 4096).
 * `predicates` (optional)\_: \_ These are individual predicates of form `lhs <op> rhs` which are applied on rows selected by the `where` clause. During intermediate sketch aggregation, sketches from the `thetaSketchColumn` that satisfies these predicates are unionized individually. For example, all filtered rows that match `country=USA` are unionized into a single sketch. Complex predicates that are created by combining (AND/OR) of individual predicates is supported.
 * `postAggregationExpressionToEvaluate` (required)_:_ The set operation to perform on the individual intermediate sketches for each of the predicates. Currently supported operations are `SET_DIFF, SET_UNION, SET_INTERSECT` , where DIFF requires two arguments and the UNION/INTERSECT allow more than two arguments.

--- a/configuration-reference/functions/distinctcountthetasketch.md
+++ b/configuration-reference/functions/distinctcountthetasketch.md
@@ -13,8 +13,11 @@ The [Theta Sketch](https://datasketches.apache.org/docs/Theta/ThetaSketchFramewo
 > distinctCountThetaSketch(**\<thetaSketchColumn>, \<thetaSketchParams>, predicate1, predicate2..., postAggregationExpressionToEvaluate**) -> Long
 
 * `thetaSketchColumn` (required): Name of the column to aggregate on.
-* `thetaSketchParams` (required): Parameters for constructing the intermediate theta-sketches.
-  * Currently, the only supported parameter is `nominalEntries` (defaults to 4096).
+* `thetaSketchParams` (required):  Semicolon-separated parameter string for constructing the intermediate theta-sketches.
+  * Currently, the supported parameter are:
+   * `nominalEntries`: The nominal entries used to create the sketch. (Default 4096)
+   * `samplingProbability`: Sets the upfront uniform sampling probability, p. (Default 1.0)
+   * `accumulatorThreshold`: How many sketches should be kept in memory before merging. (Default 2)
 * `predicates` (optional)\_: \_ These are individual predicates of form `lhs <op> rhs` which are applied on rows selected by the `where` clause. During intermediate sketch aggregation, sketches from the `thetaSketchColumn` that satisfies these predicates are unionized individually. For example, all filtered rows that match `country=USA` are unionized into a single sketch. Complex predicates that are created by combining (AND/OR) of individual predicates is supported.
 * `postAggregationExpressionToEvaluate` (required)_:_ The set operation to perform on the individual intermediate sketches for each of the predicates. Currently supported operations are `SET_DIFF, SET_UNION, SET_INTERSECT` , where DIFF requires two arguments and the UNION/INTERSECT allow more than two arguments.
 

--- a/configuration-reference/functions/distinctcountthetasketch.md
+++ b/configuration-reference/functions/distinctcountthetasketch.md
@@ -14,7 +14,7 @@ The [Theta Sketch](https://datasketches.apache.org/docs/Theta/ThetaSketchFramewo
 
 * `thetaSketchColumn` (required): Name of the column to aggregate on.
 * `thetaSketchParams` (required):  Semicolon-separated parameter string for constructing the intermediate theta-sketches.
-  * Currently, the supported parameter are:
+  * The supported parameters are:
    * `nominalEntries`: The nominal entries used to create the sketch. (Default 4096)
    * `samplingProbability`: Sets the upfront uniform sampling probability, p. (Default 1.0)
    * `accumulatorThreshold`: How many sketches should be kept in memory before merging. (Default 2)

--- a/configuration-reference/functions/distinctcounttuplesketch.md
+++ b/configuration-reference/functions/distinctcounttuplesketch.md
@@ -10,10 +10,13 @@ The [Tuple Sketch](https://datasketches.apache.org/docs/Tuple/TupleOverview.html
 
 ## Signature
 
-> distinctCountTupleSketch(**\<tupleSketchColumn>, \<tupleSketchLgK>**) -> Long
+> distinctCountTupleSketch(**\<tupleSketchColumn>, \<tupleSketchParams>**) -> Long
 
 * `tupleSketchColumn` (required): Name of the column to aggregate on.  This must be an existing tuple sketch serialized as bytes.
-* `tupleSketchLgK` (optional): lgK which is the the log2 of K, which controls both the size and accuracy of the sketch.  If not supplied, the Helix default is used.
+* `tupleSketchParams` (required):  Semicolon-separated parameter string for constructing the intermediate tuple-sketches.
+  * Currently, the supported parameter are:
+   * `nominalEntries`: The nominal entries used to create the sketch. (Default 65536)
+   * `accumulatorThreshold`: How many sketches should be kept in memory before merging. (Default 2)
 
 These examples are based on the [Batch Quick Start](../../basics/getting-started/quick-start.md#batch).  A new Tuple Sketch metric called `playerHomeRuns` was created during ingestion by updating the ingestion config as follows:
 
@@ -40,7 +43,7 @@ from baseballStats
 | 17549 |
 
 ```sql
-select distinctCountTupleSketch(playerHomeRuns, 16) as value
+select distinctCountTupleSketch(playerHomeRuns, 'nominalEntries=65536;accumulatorThreshold=10) as value
 from baseballStats 
 ```
 

--- a/configuration-reference/functions/distinctcounttuplesketch.md
+++ b/configuration-reference/functions/distinctcounttuplesketch.md
@@ -14,7 +14,7 @@ The [Tuple Sketch](https://datasketches.apache.org/docs/Tuple/TupleOverview.html
 
 * `tupleSketchColumn` (required): Name of the column to aggregate on.  This must be an existing tuple sketch serialized as bytes.
 * `tupleSketchParams` (required):  Semicolon-separated parameter string for constructing the intermediate tuple-sketches.
-  * Currently, the supported parameter are:
+  * The supported parameters are:
    * `nominalEntries`: The nominal entries used to create the sketch. (Default 65536)
    * `accumulatorThreshold`: How many sketches should be kept in memory before merging. (Default 2)
 

--- a/configuration-reference/functions/sumvaluesintegersumtuplesketch.md
+++ b/configuration-reference/functions/sumvaluesintegersumtuplesketch.md
@@ -14,7 +14,7 @@ The [Tuple Sketch](https://datasketches.apache.org/docs/Tuple/TupleOverview.html
 
 * `tupleSketchColumn` (required): Name of the column to aggregate on.  This must be an existing tuple sketch serialized as bytes.
 * `tupleSketchParams` (required): Semicolon-separated parameter string for constructing the intermediate tuple-sketches.
-  * Currently, the supported parameter are:
+  * The supported parameters are:
    * `nominalEntries`: The nominal entries used to create the sketch. (Default 65536)
    * `accumulatorThreshold`: How many sketches should be kept in memory before merging. (Default 2)
 

--- a/configuration-reference/functions/sumvaluesintegersumtuplesketch.md
+++ b/configuration-reference/functions/sumvaluesintegersumtuplesketch.md
@@ -10,10 +10,13 @@ The [Tuple Sketch](https://datasketches.apache.org/docs/Tuple/TupleOverview.html
 
 ## Signature
 
-> sumValuesIntegerSumTupleSketch(**\<tupleSketchColumn>, \<tupleSketchLgK>**) -> Long
+> sumValuesIntegerSumTupleSketch(**\<tupleSketchColumn>, \<tupleSketchParams>**) -> Long
 
 * `tupleSketchColumn` (required): Name of the column to aggregate on.  This must be an existing tuple sketch serialized as bytes.
-* `tupleSketchLgK` (optional): lgK which is the the log2 of K, which controls both the size and accuracy of the sketch.  If not supplied, the Helix default is used.
+* `tupleSketchParams` (required): Semicolon-separated parameter string for constructing the intermediate tuple-sketches.
+  * Currently, the supported parameter are:
+   * `nominalEntries`: The nominal entries used to create the sketch. (Default 65536)
+   * `accumulatorThreshold`: How many sketches should be kept in memory before merging. (Default 2)
 
 These examples are based on the [Batch Quick Start](../../basics/getting-started/quick-start.md#batch).  A new Tuple Sketch metric called `playerHomeRuns` was created during ingestion by updating the ingestion config as follows:
 
@@ -40,7 +43,7 @@ from baseballStats
 | 276152 |
 
 ```sql
-select sumValuesIntegerSumTupleSketch(playerHomeRuns, 16) as value
+select sumValuesIntegerSumTupleSketch(playerHomeRuns, 'nominalEntries=65536;accumulatorThreshold=10') as value
 from baseballStats 
 ```
 

--- a/users/user-guide-query/how-to-handle-unique-counting.md
+++ b/users/user-guide-query/how-to-handle-unique-counting.md
@@ -82,7 +82,7 @@ This returns the cardinality estimate for a column where the values are already 
 
 This is the same as the previous function, except it returns the byte serialized sketch instead of the cardinality sketch. Since Pinot returns responses as JSON strings, bytes are returned as hex encoded strings. The hex encoded string can be deserialized into sketch by using the library `org.apache.commons.codec.binary`as `Hex.decodeHex(stringValue.toCharArray())`.
 
-* **sumValueIntegerSumTupleSketch(**\<tupleSketchColumn>, \<tupleSketchLgK>**) -> Long
+* **sumValuesIntegerSumTupleSketch(**\<tupleSketchColumn>, \<tupleSketchLgK>**) -> Long
   * tupleSketchColumn (required): Name of the column to aggregate on.
   * tupleSketchLgK (optional): lgK which is the the log2 of K, which controls both the size and accuracy of the sketch.
 


### PR DESCRIPTION
Update documentation for query aggregation functions for datasketches that now take a semicolon-separated string parameter that contains a some or all of the following:
 * nominalEntries: The nominal entries used to create the sketch.
 * samplingProbability: Sets the upfront uniform sampling probability, p. (Default 1.0)
 * accumulatorThreshold: How many sketches should be kept in memory before merging. (Default 2)