### PR TITLE
remove the dash from the docker compose command

### DIFF
--- a/basics/getting-started/running-pinot-in-docker.md
+++ b/basics/getting-started/running-pinot-in-docker.md
@@ -239,7 +239,7 @@ services:
 Run the following command to launch all the components:
 
 ```
-docker-compose --project-name pinot-demo up
+docker compose --project-name pinot-demo up
 ```
 
 Run the below command to check the container status:


### PR DESCRIPTION
compose is now a command inside docker, so removing the dash