### PR TITLE
Fix description for JSONFORMAT function

### DIFF
--- a/configuration-reference/functions/jsonformat.md
+++ b/configuration-reference/functions/jsonformat.md
@@ -4,7 +4,7 @@ description: This section contains reference documentation for the JSONFORMAT fu
 
 # JSONFORMAT
 
-Extracts the object value from jsonField based on 'jsonPath', the result type is inferred based on JSON value. This function can only be used in an [ingestion transformation function](../../developers/advanced/ingestion-level-transformations.md).
+Converts a JSON/AVRO complex object to a string. This function can only be used in an [ingestion transformation function](../../developers/advanced/ingestion-level-transformations.md).
 
 ## Signature
 


### PR DESCRIPTION
- Looks like the existing description was simply a copy from [JSONPATH](https://github.com/pinot-contrib/pinot-docs/blob/latest/configuration-reference/functions/jsonpath.md) and wasn't accurate for the `JSONFORMAT` function.
- The new description is copied from https://docs.pinot.apache.org/developers/advanced/ingestion-level-transformations#json-functions.