### PR TITLE
Update realtime agg function docs - sumprecision and distinctcounthll is supported + missing funcs from function reference page

### DIFF
--- a/configuration-reference/functions/README.md
+++ b/configuration-reference/functions/README.md
@@ -190,6 +190,14 @@ This page contains reference documentation for functions in Apache Pinot.
 [distinctcounthllmv.md](distinctcounthllmv.md)
 {% endcontent-ref %}
 
+{% content-ref url="distinctcounthllplus.md" %}
+[distinctcounthllplus.md](distinctcounthllplus.md)
+{% endcontent-ref %}
+
+{% content-ref url="distinctcounthllplusmv.md" %}
+[distinctcounthllplusmv.md](distinctcounthllplusmv.md)
+{% endcontent-ref %}
+
 {% content-ref url="distinctcountmv.md" %}
 [distinctcountmv.md](distinctcountmv.md)
 {% endcontent-ref %}
@@ -198,9 +206,18 @@ This page contains reference documentation for functions in Apache Pinot.
 [distinctcountrawhll.md](distinctcountrawhll.md)
 {% endcontent-ref %}
 
+{% content-ref url="distinctcountrawhllplus.md" %}
+[distinctcountrawhllplus.md](distinctcountrawhllplus.md)
+{% endcontent-ref %}
+
 {% content-ref url="distinctcountrawhllmv.md" %}
 [distinctcountrawhllmv.md](distinctcountrawhllmv.md)
 {% endcontent-ref %}
+
+{% content-ref url="distinctcountrawhllplusmv.md" %}
+[distinctcountrawhllplusmv.md](distinctcountrawhllplusmv.md)
+{% endcontent-ref %}
+
 
 {% content-ref url="distinctcountrawcpcsketch.md" %}
 [distinctcountrawcpcsketch.md](distinctcountrawcpcsketch.md)

--- a/configuration-reference/functions/README.md
+++ b/configuration-reference/functions/README.md
@@ -218,7 +218,6 @@ This page contains reference documentation for functions in Apache Pinot.
 [distinctcountrawhllplusmv.md](distinctcountrawhllplusmv.md)
 {% endcontent-ref %}
 
-
 {% content-ref url="distinctcountrawcpcsketch.md" %}
 [distinctcountrawcpcsketch.md](distinctcountrawcpcsketch.md)
 {% endcontent-ref %}

--- a/developers/advanced/ingestion-level-aggregations.md
+++ b/developers/advanced/ingestion-level-aggregations.md
@@ -136,13 +136,15 @@ From the below aggregation config example, note that `price`  exists in the inpu
 
 ## Allowed Aggregation Functions
 
-| function name    | notes                              |
-| ---------------- | ---------------------------------- |
-| MAX              |                                    |
-| MIN              |                                    |
-| SUM              |                                    |
-| COUNT            | Specify as `COUNT(*)`              |
-| DISTINCTCOUNTHLL | Not available yet, but coming soon |
+| function name    | notes                                                                                                                                                                                                                                                                                    |
+| ---------------- |------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| MAX              |                                                                                                                                                                                                                                                                                          |
+| MIN              |                                                                                                                                                                                                                                                                                          |
+| SUM              |                                                                                                                                                                                                                                                                                          |
+| COUNT            | Specify as `COUNT(*)`                                                                                                                                                                                                                                                                    |
+| DISTINCTCOUNTHLL | Specify as `DISTINCTCOUNTHLL(field, log2m)`, default is 12.  See [function reference](../../configuration-reference/functions/distinctcounthll.md) for how to define `log2m`. Cannot be changed later, a new field must be used. The schema for the output field should be `BYTES` type. | 
+| DISTINCTCOUNTHLLPLUS | Specify as `DISTINCTCOUNTHLLPLUS(field, s, p)`. See [function reference](../../configuration-reference/functions/distinctcounthllplus.md) for how to define `s` and `p`, they cannot be changed later. The schema for the output field should be `BYTES` type.                           |                                                                  
+| SUMPRECISION | Specify as `SUMPRECISION(field, precision)`, precision must be defined. Used to compute the maximum possible size of the field. Cannot be changed later, a new field must be used. The schema for the output field should be `BIG_DECIMAL` type.                                         
 
 ## Frequently Asked Questions
 


### PR DESCRIPTION
Update realtime agg function docs - sumprecision and distinctcounthll is supported
Was added in https://github.com/apache/pinot/pull/10926

Also updated the function reference docs as they were missing the previously added functions: https://github.com/pinot-contrib/pinot-docs/pull/270/files did not add them to the readme

cc @Jackie-Jiang 