### PR TITLE
Fix invalid download page link in cli.md

### DIFF
--- a/operators/cli.md
+++ b/operators/cli.md
@@ -1,6 +1,6 @@
 # Command-Line Interface (CLI)
 
-Pinot provides a rich CLI to perform almost every operation on the cluster. You can execute all the commands using the `pinot-admin.sh`  . The script is located in the `bin/` directory of the [Pinot binary distribution](https://pinot.apache.org/download/) or `/opt/pinot/bin` in docker container.
+Pinot provides a rich CLI to perform almost every operation on the cluster. You can execute all the commands using the `pinot-admin.sh`  . The script is located in the `bin/` directory of the [Pinot binary distribution](https://pinot.apache.org/download) or `/opt/pinot/bin` in docker container.
 
 The following commands are supported by the admin script.
 

--- a/operators/cli.md
+++ b/operators/cli.md
@@ -1,6 +1,6 @@
 # Command-Line Interface (CLI)
 
-Pinot provides a rich CLI to perform almost every operation on the cluster. You can execute all the commands using the `pinot-admin.sh`  . The script is located in the `bin/` directory of the [Pinot binary distribution](https://pinot.apache.org/download) or `/opt/pinot/bin` in docker container.
+Pinot provides a rich CLI to perform almost every operation on the cluster. You can execute all the commands using the `pinot-admin.sh`. The script is located in the `bin/` directory of the [Pinot binary distribution](https://pinot.apache.org/download) or `/opt/pinot/bin` in docker container.
 
 The following commands are supported by the admin script.
 


### PR DESCRIPTION
The link <https://pinot.apache.org/download/> has an additional `/` at the end of the link, which gives users 404 and confusion when trying to download the cli tools. Change the link to <https://pinot.apache.org/download> can fix the problem.