### PR TITLE
Fix: Typo in Ingestion Transformation Wiki

### DIFF
--- a/developers/advanced/ingestion-level-transformations.md
+++ b/developers/advanced/ingestion-level-transformations.md
@@ -319,7 +319,7 @@ We can apply one transformation to extract the `userId` and then another one to 
 "ingestionConfig": {
     "transformConfigs": [
       {
-        "columnName": "userOid",
+        "columnName": "userId",
         "transformFunction": "jsonPathString(data, '$.userId')"
       },
       {


### PR DESCRIPTION
Under the 'chaining transformations' section, the "ingestion config" example text has a typo. In line 4 of the example,         _"columnName": "userOid",_ should be  _"columnName": "userId",_ to accurately reflect the example description.
