### PR TITLE
Add Link to 1.2.0 in Main Release Notes Page

### DIFF
--- a/basics/releases/README.md
+++ b/basics/releases/README.md
@@ -10,6 +10,12 @@ description: >-
 
 Before upgrading from one version to another one, read the release notes. While the Pinot committers strive to keep releases backward-compatible and introduce new features in a compatible manner, your environment may have a unique combination of configurations/data/schema that may have been somehow overlooked. Before you roll out a new release of Pinot on your cluster, it is best that you run the [compatibility test suite](../../operators/operating-pinot/upgrading-pinot-cluster.md) that Pinot provides. The tests can be easily customized to suit the configurations and tables in your pinot cluster(s). As a good practice, you should build your own test suite, mirroring the table configurations, schema, sample data, and queries that are used in your cluster.
 
+## 1.2.0 (August 2024)
+
+{% content-ref url="1.1.0.md" %}
+[1.2.0.md](1.2.0.md)
+{% endcontent-ref %}
+
 ## 1.1.0 (March 2024)
 
 {% content-ref url="1.1.0.md" %}


### PR DESCRIPTION
Had forgotten to add this. After this 1.2.0 should start showing up here https://docs.pinot.apache.org/basics/releases