### PR TITLE
Update package naming when creating a Scalar Function

### DIFF
--- a/users/user-guide-query/scalar-functions.md
+++ b/users/user-guide-query/scalar-functions.md
@@ -75,7 +75,7 @@ Only Java methods are supported.
 
 You can add new scalar functions as follows:
 
-* Create a new java project. Make sure you keep the package name as `org.apache.pinot.scalar.XXXX`
+* Create a new java project. Make sure the package name begins with `org.apache.pinot` and has `.function.` somewhere in it
 * In your java project include the dependency
 
 {% tabs %}


### PR DESCRIPTION
This is currently out of date based on the following code:

- [FunctionRegistry filters for packages containing function](https://github.com/apache/pinot/blob/release-1.2.0/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionRegistry.java#L64)