### PR TITLE
Fix dead link jsonpath.md

### DIFF
--- a/configuration-reference/functions/jsonpath.md
+++ b/configuration-reference/functions/jsonpath.md
@@ -18,7 +18,7 @@ Extracts the object value from jsonField based on 'jsonPath', the result type is
 {% hint style="warning" %}
 **`'jsonPath'`**\` is a literal. Pinot uses single quotes to distinguish them from **identifiers.** \
 \
-You can use the [Jayway JsonPath Evaluator Tool](https://jsonpath.herokuapp.com/) to test JSON expressions before you import any data.
+You can use the [JsonPath tester tool](https://jsoning.com/jsonpath/) to test JSON expressions before you import any data.
 {% endhint %}
 
 ## Usage Examples


### PR DESCRIPTION
Replace dead link https://jsonpath.herokuapp.com/ by another jsonpath tester https://jsoning.com/jsonpath/