### PR TITLE
Update running-pinot-in-docker.md typo white space removed

### DIFF
--- a/basics/getting-started/running-pinot-in-docker.md
+++ b/basics/getting-started/running-pinot-in-docker.md
@@ -91,7 +91,7 @@ Export the necessary docker image tags for Pinot, Zookeeper, and Kafka.
 ```
 export PINOT_IMAGE=apachepinot/pinot:1.2.0
 export ZK_IMAGE=zookeeper:3.9.2
-export KAFKA_IMAGE= bitnami/kafka:3.6
+export KAFKA_IMAGE=bitnami/kafka:3.6
 ```
 
 #### Start Zookeeper


### PR DESCRIPTION
export KAFKA_IMAGE= bitnami/kafka:3.6
bash: export: `bitnami/kafka:3.6': not a valid identifier

So proud for this correction ;-)