### PR TITLE
Fixing the 'Raw value forward index' doc to be more explict on how to  enable it

### DIFF
--- a/basics/indexing/forward-index.md
+++ b/basics/indexing/forward-index.md
@@ -120,10 +120,9 @@ Note: Raw value forward index currently does not support inverted index (all oth
 
 ![](../../.gitbook/assets/no-dictionary.png)
 
-The raw format is used in two scenarios:
+The raw format is applied when the dictionary is disabled for a column and the encoding is explicitly set to `RAW`. For more details, refer to the [dictionary documentation](dictionary-index.md) and the [field config list](../../configuration-reference/table.md#field-config-list).
 
-1. When the dictionary is disabled for a column, as specified in the [dictionary documentation](dictionary-index.md).
-2. When the encoding is set to `RAW` in the [field config list](../../configuration-reference/table.md#field-config-list).
+**Note:** Both configurations must be enabled together for the raw format to take effect. Setting only the `encodingType` to `RAW` in the field config is not sufficient.
 
 When using the raw format, you can configure the following parameters:
 


### PR DESCRIPTION
I tried enabling the raw index writer for one of the table by adding the encodingType as `RAW` in the fieldConfigList as the doc suggested that Pinot uses rawIndexWriter in two scenarios (dictionary is disabled or encoding is set to `RAW`) but we have a check in the [ForwardIndexCreatorFactory.java](https://github.com/apache/pinot/blob/fc8c770fcd809b3b37842631a8e73b43c6ea9a9c/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/forward/ForwardIndexCreatorFactory.java#L55) that checks if the column has dictionary enabled or not before applying the rawIndexWriter. 
Since by default, the dictionary is enabled for all columns, we need to add the column in the 'noDictionaryColumns' as well to pick up rawIndexWriter config inside fieldConfigList. 

I am suggesting a change in the documentation to include both condition as mandatory so that the doc is clearer on how to use raw index writer. 

cc @itschrispeck 