### PR TITLE
Simple verbal correction

### DIFF
--- a/basics/concepts/pinot-storage-model.md
+++ b/basics/concepts/pinot-storage-model.md
@@ -55,7 +55,7 @@ A Pinot cluster consists of the following processes, which are typically deploye
 
 The simplest possible Pinot cluster consists of four components: a server, a broker, a controller, and a Zookeeper node. In production environments, these components typically run on separate server instances, and scale out as needed for data volume, load, availability, and latency. Pinot clusters in production range from fewer than ten total instances to more than 1,000.
 
-Pinot uses [Apache Zookeeper](https://zookeeper.apache.org/) as a distributed metadata store and and [Apache Helix](http://helix.apache.org/) for cluster management.
+Pinot uses [Apache Zookeeper](https://zookeeper.apache.org/) as a distributed metadata store and [Apache Helix](http://helix.apache.org/) for cluster management.
 
 Helix is a cluster management solution created by the authors of Pinot. Helix maintains a persistent, fault-tolerant map of the intended state of the Pinot cluster. It constantly monitors the cluster to ensure that the right hardware resources are allocated to implement the present configuration. When the configuration changes, Helix schedules or decommissions hardware resources to reflect the new configuration. When elements of the cluster change state catastrophically, Helix schedules hardware resources to keep the actual cluster consistent with the ideal represented in the metadata. From a physical perspective, Helix takes the form of a controller process plus agents running on servers and brokers.
 


### PR DESCRIPTION
In the phrase with two 'and's, remove only one.