### PR TITLE
Update ingestion-level-transformations.md with better column rename example

### DIFF
--- a/developers/advanced/ingestion-level-transformations.md
+++ b/developers/advanced/ingestion-level-transformations.md
@@ -247,7 +247,7 @@ Change name of the column from `user_id` to `userId`
 "ingestionConfig": {
     "transformConfigs": [{
       "columnName": "userId",
-      "transformFunction": "Groovy({user_id}, user_id)"
+      "transformFunction": "user_id"
     }]
 }
 ```


### PR DESCRIPTION
I noticed that it's possible to rename columns without Groovy by simply using the source event name as the transformation function. The very next example in the docs ("Extract value from a column containing space") demonstrates this. As it seems more straightforward to do than calling a custom function (and some organizations disable Groovy transformations entirely) I'm updating this example.

I can confirm on Pinot 1.2 this transformation works as expected.

FFT close if this example is written this way for another reason I don't understand!