### PR TITLE
Add a warning that Kafka multi-stream ingestion is not ready in 1.3.0

### DIFF
--- a/basics/releases/1.3.0.md
+++ b/basics/releases/1.3.0.md
@@ -4,7 +4,7 @@ description: Release Notes for 1.3.0
 
 # 1.3.0
 
-This release brings significant improvements, including enhancements to the multistage query engine and the introduction of an experimental time series query engine for efficient analysis. Key features include database query quotas, cursor-based pagination for large result sets, multi-stream ingestion, and new function support for URL and GeoJson. Security vulnerabilities and several bug fixes and performance enhancements have been addressed, ensuring a more robust and versatile platform.
+This release brings significant improvements, including enhancements to the multistage query engine and the introduction of an experimental time series query engine for efficient analysis. Key features include database query quotas, cursor-based pagination for large result sets, and new function support for URL and GeoJson. Security vulnerabilities and several bug fixes and performance enhancements have been addressed, ensuring a more robust and versatile platform.
 
 ## Multistage Engine Improvements
 
@@ -238,6 +238,7 @@ Implemented various URL functions to handle multiple aspects of URL processing, 
 * `cutURLParameters(String url, String[] names)`: Removes multiple specific query parameters from a URL.
 
 ## Multi Stream Ingestion Support [#13790](https://github.com/apache/pinot/pull/13790), [Design Doc](https://docs.google.com/document/d/1Er2Tmtl5Pgwdapn5iOJ5qlCDU_2P67YMdpdsmL36MCk)
+Warning: This feature contains a bug for Kafka multi-stream ingestion and is not ready in 1.3.0. Please refer to [#15094](https://github.com/apache/pinot/pull/15094)
 
 * Add support to ingest from multiple source by a single table
 * Use existing interface (TableConfig) to define multiple streams


### PR DESCRIPTION
For multi-stream ingestion, there was a bug in KafkaConsumerFactory (incorrect use of partitionGroupId instead of streamPartitionGroupId). Since the fix [#15094](https://github.com/apache/pinot/pull/15094) wasn't released in 1.3.0, we need to explicitly flag that the kafka multi-stream ingestion is not ready in 1.3.0

Slack Thread: https://apache-pinot.slack.com/archives/CDRCA57FC/p1767833716499499?thread_ts=1767098468.140669&cid=CDRCA57FC