### PR TITLE
Add proper prefixes to authentication configuration properties

### DIFF
--- a/operators/tutorials/authentication/basic-auth-access-control.md
+++ b/operators/tutorials/authentication/basic-auth-access-control.md
@@ -36,7 +36,7 @@ For simplicity, we'll reuse the admin credentials as service tokens. In a produc
 {% tab title="Controller" %}
 ```
 # Enable the controller to fetch segments by providing the credentials as a token
-controller.segment.fetcher.auth.token=Basic YWRtaW46dmVyeXNlY3JldA
+pinot.controller.segment.fetcher.auth.token=Basic YWRtaW46dmVyeXNlY3JldA
 
 # "Basic " + base64encode("admin:verysecret")
 ```


### PR DESCRIPTION
- Updated Controller config: controller.segment.fetcher.auth.token -> pinot.controller.segment.fetcher.auth.token
- Updated Minion config: Added pinot.minion prefix to segment.fetcher.auth.token and task.auth.token
- Server config already had proper pinot.server prefix (no changes needed)

This ensures consistency across all Pinot component configurations.


@Jackie-Jiang @xiangfu0 please review 