### PR TITLE
fix: update ZooKeeper port from 2191 to 2181 across documentation

### DIFF
--- a/basics/components/table/README.md
+++ b/basics/components/table/README.md
@@ -266,13 +266,13 @@ Sending request: http://pinot-controller:9000/schemas to controller: 8fbe601012f
 **Start Kafka-Zookeeper**
 
 ```
-bin/pinot-admin.sh StartZookeeper -zkPort 2191
+bin/pinot-admin.sh StartZookeeper -zkPort 2181
 ```
 
 **Start Kafka**
 
 ```
-bin/pinot-admin.sh  StartKafka -zkAddress=localhost:2191/kafka -port 19092
+bin/pinot-admin.sh  StartKafka -zkAddress=localhost:2181/kafka -port 19092
 ```
 
 **Create stream table**

--- a/basics/components/table/segment/README.md
+++ b/basics/components/table/segment/README.md
@@ -213,7 +213,7 @@ Run below command to stream JSON data into Kafka topic: **flights-realtime**
 ```
 bin/pinot-admin.sh StreamAvroIntoKafka \
   -avroFile examples/stream/airlineStats/sample_data/airlineStats_data.avro \
-  -kafkaTopic flights-realtime -kafkaBrokerList localhost:19092 -zkAddress localhost:2191/kafka
+  -kafkaTopic flights-realtime -kafkaBrokerList localhost:19092 -zkAddress localhost:2181/kafka
 ```
 {% endtab %}
 {% endtabs %}

--- a/basics/getting-started/running-pinot-locally.md
+++ b/basics/getting-started/running-pinot-locally.md
@@ -146,7 +146,7 @@ export JAVA_OPTS="-Xms4G -Xmx8G -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -Xloggc:gc
 
 ```
 ./bin/pinot-admin.sh StartZookeeper \
-  -zkPort 2191
+  -zkPort 2181
 ```
 
 You can use [Zooinspector](https://github.com/zzhang5/zooinspector) to browse the Zookeeper instance.
@@ -156,7 +156,7 @@ You can use [Zooinspector](https://github.com/zzhang5/zooinspector) to browse th
 ```
 export JAVA_OPTS="-Xms4G -Xmx8G"
 ./bin/pinot-admin.sh StartController \
-    -zkAddress localhost:2191 \
+    -zkAddress localhost:2181 \
     -controllerPort 9000
 ```
 
@@ -165,7 +165,7 @@ export JAVA_OPTS="-Xms4G -Xmx8G"
 ```
 export JAVA_OPTS="-Xms4G -Xmx4G"
 ./bin/pinot-admin.sh StartBroker \
-    -zkAddress localhost:2191
+    -zkAddress localhost:2181
 ```
 
 ### Start Pinot Server
@@ -173,7 +173,7 @@ export JAVA_OPTS="-Xms4G -Xmx4G"
 ```
 export JAVA_OPTS="-Xms4G -Xmx16G"
 ./bin/pinot-admin.sh StartServer \
-    -zkAddress localhost:2191
+    -zkAddress localhost:2181
 ```
 
 ### Start Pinot Minion
@@ -181,7 +181,7 @@ export JAVA_OPTS="-Xms4G -Xmx16G"
 ```
 export JAVA_OPTS="-Xms4G -Xmx4G"
 ./bin/pinot-admin.sh StartMinion \
-    -zkAddress localhost:2191
+    -zkAddress localhost:2181
 ```
 
 
@@ -189,8 +189,8 @@ export JAVA_OPTS="-Xms4G -Xmx4G"
 ### Start Kafka
 
 ```
-./bin/pinot-admin.sh  StartKafka \ 
-  -zkAddress=localhost:2191/kafka \
+./bin/pinot-admin.sh  StartKafka \
+  -zkAddress=localhost:2181/kafka \
   -port 19092
 ```
 

--- a/basics/recipes/github-events-stream.md
+++ b/basics/recipes/github-events-stream.md
@@ -547,7 +547,7 @@ If you're setting this up on a pre-configured cluster, set the properties `strea
       "stream.kafka.topic.name": "pullRequestMergedEvents",
       "stream.kafka.decoder.class.name": "org.apache.pinot.plugin.inputformat.json.JSONMessageDecoder",
       "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory",
-      "stream.kafka.zk.broker.url": "localhost:2191/kafka",
+      "stream.kafka.zk.broker.url": "localhost:2181/kafka",
       "stream.kafka.broker.list": "localhost:19092",
       "realtime.segment.flush.threshold.time": "12h",
       "realtime.segment.flush.threshold.rows": "100000",

--- a/developers/advanced/advanced-pinot-setup.md
+++ b/developers/advanced/advanced-pinot-setup.md
@@ -392,13 +392,13 @@ Sending request: http://pinot-controller:9000/schemas to controller: 8fbe601012f
 **Start Kafka-Zookeeper**
 
 ```
-bin/pinot-admin.sh StartZookeeper -zkPort 2191
+bin/pinot-admin.sh StartZookeeper -zkPort 2181
 ```
 
 **Start Kafka**
 
 ```
-bin/pinot-admin.sh  StartKafka -zkAddress=localhost:2191/kafka -port 19092
+bin/pinot-admin.sh  StartKafka -zkAddress=localhost:2181/kafka -port 19092
 ```
 
 **Create stream table**
@@ -518,7 +518,7 @@ Run below command to stream JSON data into Kafka topic: **flights-realtime**
 ```
 bin/pinot-admin.sh StreamAvroIntoKafka \
   -avroFile examples/stream/airlineStats/sample_data/airlineStats_data.avro \
-  -kafkaTopic flights-realtime -kafkaBrokerList localhost:19092 -zkAddress localhost:2191/kafka
+  -kafkaTopic flights-realtime -kafkaBrokerList localhost:19092 -zkAddress localhost:2181/kafka
 ```
 {% endtab %}
 {% endtabs %}

--- a/manage-data/data-import/pinot-stream-ingestion/import-from-apache-kafka.md
+++ b/manage-data/data-import/pinot-stream-ingestion/import-from-apache-kafka.md
@@ -293,7 +293,7 @@ Here is an example config which uses SSL based authentication to talk with kafka
         "stream.kafka.topic.name": "transcript-topic",
         "stream.kafka.decoder.class.name": "org.apache.pinot.plugin.inputformat.avro.confluent.KafkaConfluentSchemaRegistryAvroMessageDecoder",
         "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory",
-        "stream.kafka.zk.broker.url": "pinot-zookeeper:2191/kafka",
+        "stream.kafka.zk.broker.url": "pinot-zookeeper:2181/kafka",
         "stream.kafka.broker.list": "localhost:9092",
         "schema.registry.url": "",
         "security.protocol": "SSL",
@@ -343,7 +343,7 @@ For example,
         "stream.kafka.topic.name": "transcript-topic",
         "stream.kafka.decoder.class.name": "org.apache.pinot.plugin.inputformat.avro.confluent.KafkaConfluentSchemaRegistryAvroMessageDecoder",
         "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory",
-        "stream.kafka.zk.broker.url": "pinot-zookeeper:2191/kafka",
+        "stream.kafka.zk.broker.url": "pinot-zookeeper:2181/kafka",
         "stream.kafka.broker.list": "kafka:9092",
         "stream.kafka.isolation.level": "read_committed"
       }

--- a/manage-data/data-import/upsert-and-dedup/upsert.md
+++ b/manage-data/data-import/upsert-and-dedup/upsert.md
@@ -675,7 +675,7 @@ Putting these together, you can find the table configurations of the quick start
           "stream.kafka.topic.name": "upsertMeetupRSVPEvents",
           "stream.kafka.decoder.class.name": "org.apache.pinot.plugin.inputformat.json.JSONMessageDecoder",
           "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory",
-          "stream.kafka.zk.broker.url": "localhost:2191/kafka",
+          "stream.kafka.zk.broker.url": "localhost:2181/kafka",
           "stream.kafka.broker.list": "localhost:19092"
         }
       ]
@@ -752,7 +752,7 @@ Putting these together, you can find the table configurations of the quick start
           "stream.kafka.topic.name": "upsertPartialMeetupRSVPEvents",
           "stream.kafka.decoder.class.name": "org.apache.pinot.plugin.inputformat.json.JSONMessageDecoder",
           "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory",
-          "stream.kafka.zk.broker.url": "localhost:2191/kafka",
+          "stream.kafka.zk.broker.url": "localhost:2181/kafka",
           "stream.kafka.broker.list": "localhost:19092"
         }
       ]

--- a/users/clients/java.md
+++ b/users/clients/java.md
@@ -87,7 +87,7 @@ Here's an example demonstrating all methods of Connection factory -
 
 ```java
 Connection connection = ConnectionFactory.fromZookeeper
-  ("some-zookeeper-server:2191/zookeeperPath");
+  ("some-zookeeper-server:2181/zookeeperPath");
 
 Connection connection = ConnectionFactory.fromProperties("demo.properties");
 


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                         
  Fix ZooKeeper port mismatch between documentation and configuration files.                                                                                                                                                                         
                                                                                                                                                                                                                                                     
  ## Problem                                                                                                                                                                                                                                         
  The documentation instructed users to start ZooKeeper on port 2191, but the default configuration files in the main Pinot repository use port 2181 (the standard ZooKeeper port). This caused connection failures when users followed the          
  quickstart documentation.                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                     
  ## Solution                                                                                                                                                                                                                                        
  Updated all references to ZooKeeper port from 2191 to 2181 across the documentation to align with:                                                                                                                                                 
  - Standard ZooKeeper default port (2181)                                                                                                                                                                                                           
  - Default configuration files in apache/pinot repository                                                                                                                                                                                           
  - Common practice across the ecosystem      
  
  Why Port 2181 is the Correct Default                                                                                                                                                                                                               
                                                                                                                                                                                                                                                     
  Port 2181 is the standard ZooKeeper client port and has been since ZooKeeper's inception. This is:                                                                                                                                                 
                                                                                                                                                                                                                                                  
  1. Hardcoded as the default in Apache Pinot's codebase - The StartZookeeperCommand.java class (pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartZookeeperCommand.java:42) explicitly defines:                                   
  private int _zkPort = 2181;                                                                                                                                                                                                                        
  2. The universal standard across the ecosystem - All ZooKeeper implementations and integrations use 2181 as the default:                                                                                                                           
    - https://zookeeper.apache.org/doc/r3.1.2/zookeeperStarted.html                                                                                                                                                                                  
    - https://hub.docker.com/_/zookeeper                                                                                                                                                                                                             
    - https://docs.aws.amazon.com/msk/latest/developerguide/port-info.html                                                                                                                                                                           
    - All Hadoop ecosystem tools (Kafka, HBase, Solr, etc.)                                                                                                                                                                                          
  3. Already used throughout the Pinot codebase - There are 7+ references to localhost:2181 in Java files and all default configuration files use 2181                                                                                               
  4. Defined in all existing config files in this repository:                                                                                                                                                                                        
    - pinot-broker.conf: pinot.zk.server=localhost:2181                                                                                                                                                                                              
    - pinot-controller.conf: pinot.zk.server=localhost:2181                                                                                                                                                                                          
    - pinot-minion.conf: pinot.zk.server=localhost:2181                                                                                                                                                                                              
    - pinot-server.conf: pinot.zk.server=localhost:2181                                                                                                                                                                                                        
                                                                                                                                                                                                                                                     
  ## Files Changed                                                                                                                                                                                                                                   
  - basics/getting-started/running-pinot-locally.md                                                                                                                                                                                                  
  - developers/advanced/advanced-pinot-setup.md                                                                                                                                                                                                      
  - basics/components/table/README.md                                                                                                                                                                                                                
  - basics/components/table/segment/README.md                                                                                                                                                                                                        
  - basics/recipes/github-events-stream.md                                                                                                                                                                                                           
  - users/clients/java.md                                                                                                                                                                                                                            
  - manage-data/data-import/upsert-and-dedup/upsert.md                                                                                                                                                                                               
  - manage-data/data-import/pinot-stream-ingestion/import-from-apache-kafka.md                                                                                                                                                                       
                                                                                                                                                                                                                                                     
  Fixes apache/pinot#16674                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                     
  Sources:                                                                                                                                                                                                                                           
  - https://github.com/pinot-contrib/pinot-docs                                                                                                                                                                                                      
  - https://docs.pinot.apache.org/    