### PR TITLE
Add Continuous Java Flight Recorder (JFR) documentation and reference in monitoring section

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -205,6 +205,7 @@
   * [Consistent Push and Rollback](operators/operating-pinot/consistent-push-and-rollback.md)
   * [Access Control](operators/operating-pinot/access-control.md)
   * [Monitoring](operators/operating-pinot/monitoring.md)
+  * [Continuous Java Flight Recorder (JFR)](operators/operating-pinot/continuous-jfr.md)
   * [Tuning](operators/operating-pinot/tuning/README.md)
     * [Tuning Default MMAP Advice](operators/operating-pinot/tuning/tuning-default-mmap-advice.md)
     * [Real-time](operators/operating-pinot/tuning/realtime.md)

--- a/operators/operating-pinot/continuous-jfr.md
+++ b/operators/operating-pinot/continuous-jfr.md
@@ -1,0 +1,159 @@
+---
+description: Continuous JFR runbook for Pinot with dynamic cluster-level on/off control
+---
+
+# Continuous Java Flight Recorder (JFR)
+
+This page is the runbook for running **continuous Java Flight Recorder (JFR)** in Pinot.
+
+Pinot supports cluster-level runtime control through `ContinuousJfrStarter`, so operators can turn recording on/off or adjust settings without restarting Pinot processes.
+
+## What is Java Flight Recorder (JFR)?
+
+**Java Flight Recorder (JFR)** is a profiling and diagnostics framework built into the JDK. It records events from the JVM and application (for example CPU, memory, allocation, GC, thread, and lock events) into `.jfr` files with low production overhead.
+
+{% hint style="info" %}
+In Java 8, JFR was a commercial feature and older documentation may mention `-XX:+UnlockCommercialFeatures -XX:+FlightRecorder`. Since **Java 11**, JFR is part of OpenJDK and does not require commercial flags.
+{% endhint %}
+
+## Official deployment model
+
+Run one long-lived recording in each Pinot JVM process (Controller, Broker, Server, Minion) and control it with `pinot.jfr.*` cluster config.
+
+### Configure with cluster config
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `pinot.jfr.enabled` | `false` | Enables/disables continuous recording. |
+| `pinot.jfr.configuration` | `default` | JFR settings profile (`default`, `profile`, or custom JFR config). |
+| `pinot.jfr.name` | `pinot-continuous` | Recording name. |
+| `pinot.jfr.dumpOnExit` | `true` | Dumps recording on JVM exit. |
+| `pinot.jfr.toDisk` | `true` | Stores recording repository on disk. |
+| `pinot.jfr.maxSize` | `209715200` | Max recording size in bytes when `toDisk=true`. |
+| `pinot.jfr.maxAge` | `P1D` | Max event age (ISO-8601 duration) when `toDisk=true`. |
+| `pinot.jfr.directory` | system temp directory | JFR repository path, applied through `JFR.configure repositorypath=...`. |
+| `pinot.jfr.dumpPath` | unset | Default JFR dump path, applied through `JFR.configure dumppath=...`. |
+
+Example:
+
+```properties
+pinot.jfr.enabled=true
+pinot.jfr.configuration=default
+pinot.jfr.name=pinot-continuous
+pinot.jfr.dumpOnExit=true
+pinot.jfr.toDisk=true
+pinot.jfr.maxSize=2147483648
+pinot.jfr.maxAge=PT24H
+pinot.jfr.directory=/var/log/pinot/jfr-repository
+pinot.jfr.dumpPath=/var/log/pinot/jfr-dumps
+```
+
+Notes:
+
+- `configuration=default` is low-overhead and production-safe.
+- Use `configuration=profile` only during active investigations.
+- `maxAge` and `maxSize` cap footprint and history.
+- Configuration changes are applied dynamically; Pinot restarts the active recording in-process.
+
+### Behavior of ContinuousJfrStarter
+
+- Starts/stops one recording per Pinot JVM based on `pinot.jfr.enabled`.
+- Reacts to `pinot.jfr.*` config updates at runtime.
+- Applies runtime JFR options via the DiagnosticCommand MBean (`JFR.configure`) for repository and dump paths.
+- Starts/stops recordings via the DiagnosticCommand MBean (`JFR.start` and `JFR.stop`).
+- If the DiagnosticCommand MBean is unavailable, Pinot logs a warning and skips JFR operations instead of failing startup.
+- Does not rotate dump files, does not run a cleaner thread, and does not schedule periodic dumps.
+- Uses standard JFR lifecycle controls (same model as JVM-native JFR), with Pinot cluster config as the control plane.
+
+## Operational checks
+
+List JVMs:
+
+```bash
+jcmd -l
+```
+
+Inspect recordings:
+
+```bash
+jcmd <pid> JFR.check
+```
+
+## Incident workflow
+
+Capture a point-in-time dump without restarting the process:
+
+```bash
+jcmd <pid> JFR.dump name=pinot-continuous filename=/var/log/pinot/jfr/pinot-incident-$(date +%Y%m%d-%H%M%S).jfr
+```
+
+Take additional dumps as needed during the incident timeline.
+
+### Alternative startup via JVM options
+
+If you prefer static startup-only configuration, you can configure JFR in `JAVA_OPTS`:
+
+```bash
+-XX:StartFlightRecording=name=pinot-continuous,settings=default,disk=true,maxage=24h,maxsize=2g,dumponexit=true
+```
+
+Use this only when dynamic cluster-level toggling is not required.
+
+## Handling large recordings
+
+When a recording is too large to transfer or inspect as one file, split it:
+
+```bash
+jfr disassemble --output /tmp/jfr-chunks <file.jfr>
+```
+
+Share only relevant chunks for triage.
+
+## Retention and tuning
+
+- Start with `configuration=default`.
+- Increase `maxAge` for longer timeline retention.
+- Increase `maxSize` for high event-volume workloads.
+- Keep host-level cleanup policies for operator-created dump files.
+- Use explicit timestamped names for ad hoc dump files.
+
+## Common pitfalls
+
+- Assuming Pinot automatically rotates JFR dump files.
+- Running without disk budget guardrails (`maxAge` and `maxSize`).
+- Leaving `configuration=profile` enabled permanently.
+
+## Minimal operator checklist
+
+- [ ] `pinot.jfr.enabled=true` applied in cluster config.
+- [ ] `pinot.jfr.*` values validated for footprint (`toDisk`, `maxSize`, `maxAge`).
+- [ ] `jcmd <pid> JFR.check` validated post-deploy.
+- [ ] Incident dump command tested in non-prod.
+- [ ] Retention and cleanup policy applied to operator-created dump files.
+
+## Related
+
+- [Monitoring](monitoring.md) — Metrics, Prometheus, and Grafana.
+- [Configuration Reference / Monitoring Metrics](../../configuration-reference/monitoring-metrics.md) — Pinot metrics reference.
+
+## Opening and analyzing JFR files
+
+- `jfr summary <file.jfr>` for high-level stats.
+- `jfr view <file.jfr>` for aggregated views.
+- `jfr print <file.jfr>` for detailed events (`--json` and `--xml` supported).
+- Java Mission Control (JMC) for interactive analysis.
+- `jdk.jfr.consumer.RecordingFile` for programmatic analysis.
+
+Quick sanity check:
+
+```bash
+jfr summary /var/log/pinot/jfr/pinot-incident-20260310-120000.jfr
+```
+
+## External references
+
+- [Package jdk.jfr (Java SE 21)](https://docs.oracle.com/en/java/javase/21/docs/api/jdk.jfr/jdk/jfr/package-summary.html) — Overview of the JFR API: defining events, controlling Flight Recorder, and the `jdk.jfr` package.
+- [The `jfr` command](https://docs.oracle.com/en/java/javase/21/docs/specs/man/jfr.html) — Command-line tool to view, print, and summarize `.jfr` files (JDK 21+).
+- [Using JDK Flight Recorder with Java Mission Control](https://docs.oracle.com/en/java/java-components/jdk-mission-control/9/user-guide/using-jdk-flight-recorder.html) — Recording and inspecting flights with the JMC GUI; includes an overview of JFR and how to analyze recordings.
+- [JDK Mission Control (JMC) — Download](https://jdk.java.net/jmc/) — Standalone JMC build for opening and analyzing `.jfr` recordings.
+- [RecordingFile (jdk.jfr.consumer)](https://docs.oracle.com/en/java/javase/21/docs/api/jdk.jfr/jdk/jfr/consumer/RecordingFile.html) — API for reading and parsing `.jfr` files programmatically.

--- a/operators/operating-pinot/continuous-jfr.md
+++ b/operators/operating-pinot/continuous-jfr.md
@@ -29,8 +29,8 @@ Run one long-lived recording in each Pinot JVM process (Controller, Broker, Serv
 | `pinot.jfr.name` | `pinot-continuous` | Recording name. |
 | `pinot.jfr.dumpOnExit` | `true` | Dumps recording on JVM exit. |
 | `pinot.jfr.toDisk` | `true` | Stores recording repository on disk. |
-| `pinot.jfr.maxSize` | `209715200` | Max recording size in bytes when `toDisk=true`. |
-| `pinot.jfr.maxAge` | `P1D` | Max event age (ISO-8601 duration) when `toDisk=true`. |
+| `pinot.jfr.maxSize` | `2GB` | Max recording size when `toDisk=true`; supports human-readable values (for example `512MB`, `2GB`) or raw bytes. |
+| `pinot.jfr.maxAge` | `P7D` | Max event age (ISO-8601 duration) when `toDisk=true`. |
 | `pinot.jfr.directory` | system temp directory | JFR repository path, applied through `JFR.configure repositorypath=...`. |
 | `pinot.jfr.dumpPath` | unset | Default JFR dump path, applied through `JFR.configure dumppath=...`. |
 
@@ -42,7 +42,7 @@ pinot.jfr.configuration=default
 pinot.jfr.name=pinot-continuous
 pinot.jfr.dumpOnExit=true
 pinot.jfr.toDisk=true
-pinot.jfr.maxSize=2147483648
+pinot.jfr.maxSize=2GB
 pinot.jfr.maxAge=PT24H
 pinot.jfr.directory=/var/log/pinot/jfr-repository
 pinot.jfr.dumpPath=/var/log/pinot/jfr-dumps

--- a/operators/operating-pinot/monitoring.md
+++ b/operators/operating-pinot/monitoring.md
@@ -326,12 +326,6 @@ For low-overhead, always-on JVM profiling (CPU, memory, threads, locks), you can
 
 ---
 
-## JVM diagnostics (Continuous JFR)
-
-For low-overhead, always-on JVM profiling (CPU, memory, threads, locks), you can enable [Continuous Java Flight Recorder (JFR)](continuous-jfr.md). JFR recordings can be dumped on exit or inspected with JDK tools; configuration is dynamic via cluster config.
-
----
-
 ## Further Reading
 
 - [Full Metrics Reference](../../configuration-reference/monitoring-metrics.md) -- Complete list of all Pinot metrics

--- a/operators/operating-pinot/monitoring.md
+++ b/operators/operating-pinot/monitoring.md
@@ -319,6 +319,17 @@ When building dashboards, organize panels by component and focus on these key vi
 - Periodic task execution and errors
 - Table storage quota utilization
 
+
+## JVM diagnostics (Continuous JFR)
+
+For low-overhead, always-on JVM profiling (CPU, memory, threads, locks), you can enable [Continuous Java Flight Recorder (JFR)](continuous-jfr.md). JFR recordings can be dumped on exit or inspected with JDK tools; configuration is dynamic via cluster config.
+
+---
+
+## JVM diagnostics (Continuous JFR)
+
+For low-overhead, always-on JVM profiling (CPU, memory, threads, locks), you can enable [Continuous Java Flight Recorder (JFR)](continuous-jfr.md). JFR recordings can be dumped on exit or inspected with JDK tools; configuration is dynamic via cluster config.
+
 ---
 
 ## Further Reading


### PR DESCRIPTION
This pull request adds documentation for enabling and operating continuous Java Flight Recorder (JFR) in Pinot, providing a comprehensive runbook and integration points for JVM diagnostics. The main changes introduce a new guide on continuous JFR, update the documentation structure to include this topic, and reference JFR as a recommended profiling tool in the monitoring documentation.

**New documentation for JVM profiling and diagnostics:**

* Added a new runbook, `continuous-jfr.md`, covering how to enable, configure, and operate continuous Java Flight Recorder (JFR) in Pinot, including cluster-level dynamic control, operational workflows, incident handling, retention, and common pitfalls.
* Updated the documentation sidebar (`SUMMARY.md`) to include the new "Continuous Java Flight Recorder (JFR)" guide under the operators section.

**Monitoring and observability documentation:**

* Added a section to the monitoring documentation (`monitoring.md`) introducing continuous JFR as a low-overhead, always-on JVM profiling option, with a link to the new runbook and notes on dynamic configuration and tooling.This pull request introduces documentation for enabling continuous Java Flight Recorder (JFR) in Apache Pinot, providing operators with a low-overhead, always-on JVM diagnostics option. The changes add a new guide explaining how to configure and use JFR, update the summary table of contents, and reference JFR in the monitoring documentation.

New feature documentation:

* Added a comprehensive guide `continuous-jfr.md` describing how to enable, configure, and analyze continuous Java Flight Recorder (JFR) recordings in Pinot, including configuration options, use cases, and external references.

Documentation navigation:

* Updated `SUMMARY.md` to include the new "Continuous Java Flight Recorder (JFR)" section for easier discoverability in the operator documentation.

Monitoring documentation:

* Added a section to `monitoring.md` referencing continuous JFR as a method for JVM diagnostics, linking to the new guide and explaining its use for profiling CPU, memory, threads, and locks with dynamic configuration.