### PR TITLE
update flink connector pinot-docs as per latest implementation

### DIFF
--- a/manage-data/data-import/batch-ingestion/flink.md
+++ b/manage-data/data-import/batch-ingestion/flink.md
@@ -4,105 +4,245 @@ description: Batch ingestion of data into Apache Pinot using Apache Flink.
 
 # Flink
 
-Pinot supports Apache Flink as a processing framework to push segment files to the database.
+Apache Pinot supports using Apache Flink as a processing framework to generate and upload segments. The Pinot distribution includes a [PinotSinkFunction](https://github.com/apache/pinot/blob/master/pinot-connectors/pinot-flink-connector/src/main/java/org/apache/pinot/connector/flink/sink/PinotSinkFunction.java) that can be integrated into Flink applications (streaming or batch) to directly write data as segments into Pinot tables.
 
-Pinot distribution contains an Apache Flink [SinkFunction](https://nightlies.apache.org/flink/flink-docs-release-1.12/api/java/org/apache/flink/streaming/api/functions/sink/SinkFunction.html) that can be used as part of the Apache Flink application (Streaming or Batch) to directly write into a designated Pinot database.
+The `PinotSinkFunction` supports offline tables, realtime tables, and upsert tables (full upsert only). Data is buffered in memory and flushed as segments when the configured threshold is reached, then uploaded to the Pinot cluster.
 
-## Example
+## Maven Dependency
 
-### Flink application
+To use the Pinot Flink Connector in your Flink job, add the following dependency to your `pom.xml`:
 
-Here is an example code snippet to show how to utilize the [PinotSinkFunction](https://github.com/apache/pinot/blob/master/pinot-connectors/pinot-flink-connector/src/main/java/org/apache/pinot/connector/flink/sink/PinotSinkFunction.java) in a Flink streaming application:
-
+```xml
+<dependency>
+  <groupId>org.apache.pinot</groupId>
+  <artifactId>pinot-flink-connector</artifactId>
+  <version>1.5.0-SNAPSHOT</version>
+</dependency>
 ```
-// some environmental setup
+
+Replace `1.5.0-SNAPSHOT` with the Pinot version you're using. For the latest stable version, check the [Apache Pinot releases](https://pinot.apache.org/download/).
+
+**Note**: The connector transitively includes dependencies for:
+- `pinot-controller` - For controller client APIs
+- `pinot-segment-writer-file-based` - For segment generation
+- `flink-streaming-java` and `flink-java` - Flink core dependencies
+
+## Offline Table Ingestion
+
+### Quick Start Example
+
+```java
+// Set up Flink environment and data source
 StreamExecutionEnvironment execEnv = StreamExecutionEnvironment.getExecutionEnvironment();
-DataStream<Row> srcRows = execEnv.addSource(new FlinkKafkaConsumer<Row>(...));
+execEnv.setParallelism(2);
+
+// Configure row type
 RowTypeInfo typeInfo = new RowTypeInfo(
-  new TypeInformation[]{Types.FLOAT, Types.FLOAT, Types.STRING, Types.STRING},
-  new String[]{"lon", "lat", "address", "name"});
+    new TypeInformation[]{Types.FLOAT, Types.FLOAT, Types.STRING, Types.STRING},
+    new String[]{"lon", "lat", "address", "name"});
 
+DataStream<Row> srcRows = execEnv.addSource(new FlinkKafkaConsumer<Row>(...));
 
-// add processing logic for the data stream for example:
-DataStream<Row> processedRows = srcRow.keyBy(r -> r.getField(0));
-...
+// Create a ControllerRequestClient to fetch Pinot schema and table config
+HttpClient httpClient = HttpClient.getInstance();
+ControllerRequestClient client = new ControllerRequestClient(
+    ControllerRequestURLBuilder.baseUrl(DEFAULT_CONTROLLER_URL), httpClient);
 
-// configurations for PinotSinkFunction
-Schema pinotSchema = ...
-TableConfig pinotTableConfig = ...
-processedRows.addSink(new PinotSinkFunction<>(
-  new FlinkRowGenericRowConverter(typeInfo), 
-  pinotTableConfig,
-  pinotSchema);
+// Fetch Pinot schema
+Schema schema = PinotConnectionUtils.getSchema(client, "starbucksStores");
+// Fetch Pinot table config
+TableConfig tableConfig = PinotConnectionUtils.getTableConfig(client, "starbucksStores", "OFFLINE");
 
-// execute the program
+// Create Flink Pinot Sink
+srcRows.addSink(new PinotSinkFunction<>(
+    new FlinkRowGenericRowConverter(typeInfo),
+    tableConfig,
+    schema));
 execEnv.execute();
 ```
 
-As in the example shown above, the only required information from the Pinot side is the table [schema](../../../configuration-reference/schema.md) and the table [config](../../../configuration-reference/table.md).
+### Table Configuration
 
-For a more detailed executable, refer to the [quick start example](https://github.com/apache/pinot/blob/master/pinot-connectors/pinot-flink-connector/src/main/java/org/apache/pinot/connector/flink/FlinkQuickStart.java).
+The `PinotSinkFunction` uses the TableConfig to determine batch ingestion settings for segment generation and upload. Here's an example table configuration:
 
-### Table Config
-
-PinotSinkFunction uses mostly the TableConfig object to infer the batch ingestion configuration to start a SegmentWriter and SegmentUploader to communicate with the Pinot cluster.&#x20;
-
-Note that even though in the above example Flink application is running in streaming mode, the data is still batch together and flush/upload to Pinot once the flush threshold is reached. It is not a direct streaming write into Pinot.
-
-Here is an example table config
-
-```
+```json
 {
-  "tableName" : "tbl_OFFLINE",
-  "tableType" : "OFFLINE",
-  "segmentsConfig" : {
+  "tableName": "starbucksStores_OFFLINE",
+  "tableType": "OFFLINE",
+  "segmentsConfig": {
     // ...
   },
-  "tenants" : {
+  "tenants": {
     // ...
   },
-  "tableIndexConfig" : {
-    // ....
+  "tableIndexConfig": {
+    // ...
   },
   "ingestionConfig": {
     "batchIngestionConfig": {
       "segmentIngestionType": "APPEND",
-      "segmentIngestionFrequency": "HOURLY", 
+      "segmentIngestionFrequency": "HOURLY",
       "batchConfigMaps": [
         {
-          "outputDirURI": "file://path/to/flink/segmentwriter/output/dir",
+          "outputDirURI": "file:///tmp/pinotoutput",
           "overwriteOutput": "false",
-          "push.controllerUri": "https://target.pinot.cluster.controller.url"
+          "push.controllerUri": "http://localhost:9000"
         }
       ]
     }
   }
 }
-
 ```
 
-the only required configurations are:
+Required configurations:
+* `outputDirURI` - Directory where segments are written before upload
+* `push.controllerUri` - Pinot controller URL for segment upload
 
-* `"outputDirURI"`: where PinotSinkFunction should write the constructed segment file to
-* `"push.controllerUri"`: which Pinot cluster (controller) URL PinotSinkFunction should communicate with.
+For a complete executable example, refer to [FlinkQuickStart.java](https://github.com/apache/pinot/blob/master/pinot-connectors/pinot-flink-connector/src/main/java/org/apache/pinot/connector/flink/FlinkQuickStart.java).
 
-The rest of the configurations are standard for any Pinot table.
+## Realtime Table Ingestion
 
+### Non-Upsert Realtime Tables
 
+For standard realtime tables without upsert, use the same approach as offline tables, but specify `REALTIME` as the table type:
 
+```java
+// Same setup as offline table example above...
 
+// Fetch table config for realtime table
+TableConfig tableConfig = PinotConnectionUtils.getTableConfig(client, "myTable", "REALTIME");
 
+// Same sink configuration
+srcRows.addSink(new PinotSinkFunction<>(
+    new FlinkRowGenericRowConverter(typeInfo),
+    tableConfig,
+    schema));
+execEnv.execute();
+```
 
+### Upsert Tables
 
+#### Full Upsert Tables
 
+Flink connector supports backfilling full upsert tables where each record contains all columns. The uploaded segments will correctly participate in upsert semantics based on the comparison column value.
 
+**Requirements:**
+1. **Partitioning**: Data must be partitioned using the same strategy as the upstream stream (e.g., Kafka)
+2. **Parallelism**: Flink job parallelism must match the number of upstream stream/table partitions
+3. **Comparison Column**: The values of the comparison column  must have ordering consistent with the upstream stream. This ensures that Pinot can correctly resolve which record is the latest for a given key. See [Pinot upsert comparison column docs](https://docs.pinot.apache.org/manage-data/data-import/upsert-and-dedup/upsert#comparison-column) for important considerations.
 
+**Example:**
 
+```java
+// Set up Flink environment
+StreamExecutionEnvironment execEnv = StreamExecutionEnvironment.getExecutionEnvironment();
+execEnv.setParallelism(2); // MUST match number of partitions in stream/table
 
+// Configure row type matching your upsert table schema
+RowTypeInfo typeInfo = new RowTypeInfo(
+    new TypeInformation[]{Types.INT, Types.STRING, Types.STRING, Types.FLOAT, Types.LONG, Types.BOOLEAN},
+    new String[]{"playerId", "name", "game", "score", "timestampInEpoch", "deleted"});
 
+DataStream<Row> srcRows = execEnv.addSource(new FlinkKafkaConsumer<Row>(...));
 
+// Fetch schema and table config (same as offline table example)
+// HttpClient httpClient = HttpClient.getInstance();
+// ControllerRequestClient client = ...
+Schema schema = PinotConnectionUtils.getSchema(client, "myUpsertTable");
+TableConfig tableConfig = PinotConnectionUtils.getTableConfig(client, "myUpsertTable", "REALTIME");
 
+// IMPORTANT: Partition data by primary key using the SAME logic as the stream
+srcRows.partitionCustom(
+    (Partitioner<Integer>) (key, partitions) -> key % partitions,
+    r -> (Integer) r.getField("playerId"))  // Primary key field
+  .addSink(new PinotSinkFunction<>(
+      new FlinkRowGenericRowConverter(typeInfo),
+      tableConfig,
+      schema));
+execEnv.execute();
+```
 
+**How Partitioning Works:**
 
+When uploading segments for upsert tables, Pinot uses a special segment naming convention [UploadedRealtimeSegmentName](https://github.com/apache/pinot/blob/7f701245ca71c482ce71456e4e5082bfa82d5e14/pinot-common/src/main/java/org/apache/pinot/common/utils/UploadedRealtimeSegmentName.java) that encodes the partition ID. The format is:
+```
+{prefix}__{tableName}__{partitionId}__{uploadTimeMs}__{sequenceId}
+```
 
+Example: `flink__myTable__0__1724045187__1`
 
+Each Flink subtask generates segments for a specific partition based on its subtask index. The segments are then assigned to the same server instances that handle that partition for stream-consumed segments, ensuring correct upsert behavior across all segments.
+
+**Configuration Options:**
+
+You can customize segment generation using additional constructor parameters:
+
+```java
+new PinotSinkFunction<>(
+    recordConverter,
+    tableConfig,
+    schema,
+    segmentFlushMaxNumRecords,  // Default: 500,000, number of rows per segment
+    executorPoolSize,            // Default: 5, number of threads to use to upload segment
+    segmentNamePrefix,           // Default: "flink"
+    segmentUploadTimeMs          // Default: current time, upload time value to encode in segment name
+)
+```
+
+#### Partial Upsert Tables
+
+**WARNING**: Flink-based upload is **not recommended** for partial upsert tables.
+
+In partial upsert tables, uploaded segments contain only a subset of columns or an intermdiate row for a primary key. If the uploaded row is not in its final state and subsequent updates arrive via the stream, the partial upsert merger may produce inconsistent results between replicas. This can lead to data inconsistency that is difficult to detect and resolve.
+
+For partial upsert tables, prefer stream-based ingestion only or ensure uploaded data represents the final state for each primary key.
+
+## Advanced Configuration
+
+### Segment Flush Control
+
+Control when segments are flushed and uploaded:
+
+```java
+// Same setup as previous examples...
+
+long segmentFlushMaxNumRecords = 1000000; // Flush after 1M records
+int executorPoolSize = 10; // Thread pool size for async uploads
+
+srcRows.addSink(new PinotSinkFunction<>(
+    new FlinkRowGenericRowConverter(typeInfo),
+    tableConfig,
+    schema,
+    segmentFlushMaxNumRecords,
+    executorPoolSize
+));
+```
+
+### Segment Naming
+
+Customize segment naming and upload time for better organization:
+
+```java
+// Same setup as previous examples...
+
+String segmentNamePrefix = "flink_job_daily";
+Long segmentUploadTimeMs = 1724045185000L; // Group segments by upload run time
+
+srcRows.addSink(new PinotSinkFunction<>(
+    new FlinkRowGenericRowConverter(typeInfo),
+    tableConfig,
+    schema,
+    DEFAULT_SEGMENT_FLUSH_MAX_NUM_RECORDS,
+    DEFAULT_EXECUTOR_POOL_SIZE,
+    segmentNamePrefix,
+    segmentUploadTimeMs
+));
+```
+
+## Additional Resources
+
+* [Design Proposal](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=177045634) - Original design motivation
+* [PR #13107](https://github.com/apache/pinot/pull/13107) - Externally partitioned segments for upsert tables
+* [PR #13837](https://github.com/apache/pinot/pull/13837) - Flink connector enhancements for upsert backfill
+* [Table Configuration Reference](../../../configuration-reference/table.md)
+* [Schema Configuration Reference](../../../configuration-reference/schema.md)


### PR DESCRIPTION
## Summary

Updated Flink connector documentation to reflect latest implementation supporting externally partitioned segments for upsert table backfill (PRs #13107, #13837).

## Key Changes

### Added
- Maven dependency setup section
- Comprehensive upsert table flink based ingestion documentation:
  - Full upsert support with partitioning requirements and examples
  - Warning against using partial upsert tables
  - Explanation of `UploadedRealtimeSegmentName` convention
- Advanced configuration examples (flush control, segment naming)
- Links to design docs and implementation PRs

### Technical Details
- Documented automatic segment naming for upsert tables
- Explained partition assignment across Flink subtasks and Pinot servers
- Added all configuration parameters with defaults