### PR TITLE
Improve and remove duplication in user query guide

### DIFF
--- a/users/user-guide-query/README.md
+++ b/users/user-guide-query/README.md
@@ -54,10 +54,6 @@ description: >-
 [joins.md](query-syntax/joins.md)
 {% endcontent-ref %}
 
-{% content-ref url="query-syntax/joins.md" %}
-[joins.md](query-syntax/joins.md)
-{% endcontent-ref %}
-
 {% content-ref url="query-syntax/lookup-udf-join.md" %}
 [lookup-udf-join.md](query-syntax/lookup-udf-join.md)
 {% endcontent-ref %}
@@ -68,10 +64,6 @@ description: >-
 
 {% content-ref url="scalar-functions.md" %}
 [scalar-functions.md](scalar-functions.md)
-{% endcontent-ref %}
-
-{% content-ref url="query-syntax/windows-functions.md" %}
-[windows-functions.md](query-syntax/windows-functions.md)
 {% endcontent-ref %}
 
 {% content-ref url="query-syntax/windows-functions.md" %}


### PR DESCRIPTION
I've successfully removed the duplicate content-ref entries from the README.md file. The file originally had two duplicate references to `joins.md` and two duplicate references to `windows-functions.md`. Both duplicates have been removed, leaving only one reference to each file. The file now has a clean, non-redundant list of content references.


@Jackie-Jiang @xiangfu0 please review.