### PR TITLE
Refresh Data Explorer UI documentation with 1.4+ features

### DIFF
--- a/basics/components/exploring-pinot.md
+++ b/basics/components/exploring-pinot.md
@@ -12,7 +12,7 @@ Navigate to [http://localhost:9000](http://localhost:9000) in your browser to op
 
 ## Cluster Manager
 
-The first screen that you'll see when you open the Pinot Data Explorer is the Cluster Manager. The Cluster Manager provides a UI to operate and manage your cluster.
+The first screen that you'll see when you open the Pinot Data Explorer is the Cluster Manager. The Cluster Manager provides a UI to operate and manage your cluster, giving you an overview of tenants, instances, tables, and their current status.
 
 ![Pinot Cluster Manager](../../.gitbook/assets/cluster-manager.png)
 
@@ -20,19 +20,52 @@ If you want to view the contents of a server, click on its instance name. You'll
 
 ![Pinot Server](../../.gitbook/assets/view-server-contents.png)
 
-To view the _baseballStats_ table, click on its name, which will show the following screen:
+### Table management
+
+To view a table, click on its name from the tables list. From the table detail screen, you can edit or delete the table, edit or adjust its schema, and perform several other operations.
 
 ![baseballStats Table](<../../.gitbook/assets/view-table-baseball-stats (1).png>)
-
-From this screen, we can edit or delete the table, edit or adjust its schema, as well as several other operations.
 
 For example, if we want to add _yearID_ to the list of inverted indexes, click on **Edit Table,** add the extra column, and click **Save:**
 
 ![Edit Table](../../.gitbook/assets/edit-baseball-stats-table-config.png)
 
+#### Pause and resume consumption
+
+For real-time tables, the table detail screen includes a **Pause/Resume Consumption** button ([#15657](https://github.com/apache/pinot/pull/15657)). This lets you pause ingestion on a real-time table directly from the UI without issuing REST API calls, and resume it when ready. This is useful during maintenance windows or when you need to temporarily halt data ingestion.
+
+#### Consuming segments info
+
+A **Consuming Segments Info** button ([#15623](https://github.com/apache/pinot/pull/15623)) is available on real-time tables, providing a quick view of all currently consuming segments. This shows details such as the partition, current offset, and consumption state, making it easier to monitor real-time ingestion health.
+
+#### Reset segment
+
+The UI now supports a **Reset Segment** operation ([#16078](https://github.com/apache/pinot/pull/16078)), allowing you to reset a segment directly from the table detail screen. This is helpful when a segment is stuck in an error state and needs to be re-processed.
+
+#### Segment state filter
+
+A segment state filter ([#16085](https://github.com/apache/pinot/pull/16085)) has been added to the table detail screen. You can filter segments by their state (e.g., ONLINE, CONSUMING, ERROR) to quickly locate segments that need attention, which is especially valuable for tables with a large number of segments.
+
+#### Table rebalance
+
+The table detail screen also provides access to table rebalance operations. Several UI fixes and improvements ([#15511](https://github.com/apache/pinot/pull/15511)) have been made to improve the reliability and usability of the rebalance workflow, including better parameter validation and progress display.
+
+### Logical table management
+
+Starting with Pinot 1.4 and later, the Data Explorer includes a logical table management UI ([#17878](https://github.com/apache/pinot/pull/17878)). Logical tables are collections of physical tables (REALTIME and OFFLINE) that can be queried as a single unified table.
+
+The logical tables listing is accessible from the main **Tables** page, alongside physical tables and schemas. From there you can:
+
+- **Browse** all logical tables in the cluster with search support.
+- **View details** of a logical table, including its configuration, the list of physical tables it maps to, and metadata.
+- **Edit** a logical table's configuration.
+- **Delete** a logical table with a confirmation dialog.
+
+For more information about logical tables, see the [Logical Table Support](../releases/1.4.0.md#logical-table-support-design) section in the 1.4.0 release notes.
+
 ## Query Console
 
-Let's run some queries on the data in the Pinot cluster. Navigate to [Query Console](http://localhost:9000/#/query) to see the querying interface.
+Navigate to [Query Console](http://localhost:9000/#/query) to see the querying interface. The Query Console lets you run SQL queries against your Pinot cluster and view the results interactively.
 
 We can see our `baseballStats` table listed on the left (you will see `meetupRSVP` or `airlineStats` if you used the streaming or the hybrid [quick start](https://docs.pinot.apache.org/basics/getting-started/running-pinot-in-docker)). Click on the table name to display all the names along with the data types of the columns of the table.
 
@@ -45,27 +78,31 @@ You can also execute a sample query `select * from baseballStats limit 10` by ty
 Here are some sample queries you can try:
 
 ```sql
-select playerName, max(hits) 
-from baseballStats 
-group by playerName 
+select playerName, max(hits)
+from baseballStats
+group by playerName
 order by max(hits) desc
 ```
 
 ```sql
-select sum(hits), sum(homeRuns), sum(numberOfGames) 
-from baseballStats 
+select sum(hits), sum(homeRuns), sum(numberOfGames)
+from baseballStats
 where yearID > 2010
 ```
 
 ```sql
-select * 
-from baseballStats 
+select *
+from baseballStats
 order by league
 ```
 
 Pinot supports a subset of standard SQL. For more information, see [Pinot Query Language](../../users/user-guide-query/querying-pinot.md).
 
-## Rest API
+### Time-series query execution
+
+The Query Console also supports time-series query execution ([#16305](https://github.com/apache/pinot/pull/16305)), introduced as part of the Time Series Engine beta. This feature provides a dedicated interface for running and visualizing time-series queries using languages such as PromQL. It connects to a Prometheus-compatible `/query_range` endpoint ([#16286](https://github.com/apache/pinot/pull/16286)) exposed by the Pinot controller, letting you explore time-series data and inspect query execution plans directly from the UI.
+
+## REST API
 
 The [Pinot Admin UI](http://localhost:9000/help) contains all the APIs that you will need to operate and manage your cluster. It provides a set of APIs for Pinot cluster management including health check, instances management, schema and table management, data segments management.
 


### PR DESCRIPTION
## Summary
- Modernize the Pinot Data Explorer page (`basics/components/exploring-pinot.md`) to reflect UI improvements from Pinot 1.4 and later
- Add documentation for logical table management UI (PR #17878) with browse, view, edit, and delete capabilities
- Add documentation for time-series query execution UI (#16305) and the Prometheus-compatible controller endpoint (#16286)
- Document new table management features: pause/resume consumption (#15657), consuming segments info viewer (#15623), reset segment operation (#16078), segment state filter (#16085), and table rebalance UI improvements (#15511)
- Restructure the Cluster Manager section with subsections for better organization

## Test plan
- [ ] Verify all PR links resolve correctly
- [ ] Verify internal doc cross-references (release notes link, query language link) work
- [ ] Review content accuracy against the referenced PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)