### PR TITLE
Document immediate table and schema delete option

### DIFF
--- a/basics/concepts/segment-retention.md
+++ b/basics/concepts/segment-retention.md
@@ -20,4 +20,6 @@ There are a couple of scenarios where segments in offline tables won't be purged
 
 If the retention period isn't specified, segments aren't purged from tables.
 
-The retention manager initially moves these segments into a _Deleted Segments_ area, from where they will eventually be permanently removed.
+The retention manager initially moves these segments into a _Deleted Segments_ area, from where they will eventually be permanently removed. The duration that deleted segments are kept is controlled by the `controller.deleted.segments.retentionInDays` configuration (default: 7 days).
+
+When deleting a table via the API, you can override this behavior by passing a `retention` query parameter. For example, `DELETE /tables/{tableName}?retention=0d` deletes all segments immediately without moving them to the deleted-segments area. See the [Controller API Reference](../../users/api/controller-api-reference.md#delete-tables-less-than-tablename-greater-than) for more details.

--- a/basics/getting-started/create-and-update-table-config.md
+++ b/basics/getting-started/create-and-update-table-config.md
@@ -35,7 +35,7 @@ To update existing data and segments, after you update and save the changes to t
 
 **When you change the transform function used to populate a derived field** or **increase the number of partitions in an upsert-enabled table**, perform a table re-bootstrap. One way to do this is to delete and recreate the table:
 
-* Using the Pinot API, first send `DELETE /tables/{tableName}` followed by `POST /tables` with the new table configuration.
+* Using the Pinot API, first send `DELETE /tables/{tableName}` followed by `POST /tables` with the new table configuration. To skip the default segment retention period and delete immediately, use `DELETE /tables/{tableName}?retention=0d`. See the [Controller API Reference](../../users/api/controller-api-reference.md#delete-tables-less-than-tablename-greater-than) for details.
 
 **When you change the stream topic** or **change the Kafka cluster** containing the Kafka topic you want to consume from, perform a real-time ingestion pause and resume. To pause and resume real-time ingestion:
 

--- a/users/api/controller-api-reference.md
+++ b/users/api/controller-api-reference.md
@@ -365,6 +365,71 @@ curl -X POST "http://localhost:9000/applicationQuotas/myApp" \
 ```
 
 
+### DELETE /tables/\<tableName>
+
+Deletes a table from the cluster. By default, deleted segments are moved to a _Deleted Segments_ area and retained for a configurable period (controlled by `controller.deleted.segments.retentionInDays`, default 7 days) before being permanently removed. This allows recovery if the deletion was accidental.
+
+You can override this behavior by passing the `retention` query parameter to specify a custom retention period for the deleted segments. Setting `retention=0d` deletes segments immediately, bypassing the default retention period entirely.
+
+**Query Parameters**
+
+| Parameter  | Type   | Required | Description                                                                                                              |
+| ---------- | ------ | -------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `type`     | string | No       | Table type (`OFFLINE` or `REALTIME`). If not specified, both types are deleted if they exist.                             |
+| `retention`| string | No       | Retention period for deleted segments (e.g., `0d` for immediate deletion, `1d` for one day). Overrides the cluster default. |
+
+**Request (default behavior)**
+
+```
+curl -X DELETE "http://localhost:9000/tables/baseballStats" -H "accept: application/json"
+```
+
+**Request (immediate deletion)**
+
+```
+curl -X DELETE "http://localhost:9000/tables/baseballStats?retention=0d" -H "accept: application/json"
+```
+
+**Response**
+
+```
+{
+  "status": "Tables: [baseballStats_OFFLINE] deleted"
+}
+```
+
+{% hint style="warning" %}
+Setting `retention=0d` permanently deletes all segments immediately with no possibility of recovery. Use this option only when you are certain the data is no longer needed, such as during development, testing, or cleaning up temporary tables.
+{% endhint %}
+
+{% hint style="info" %}
+For large tables, the default delete operation may time out because it copies segments to the deleted-segments area. Using `retention=0d` bypasses this copy step, which can help avoid timeouts.
+{% endhint %}
+
+### DELETE /schemas/\<schemaName>
+
+Deletes a schema from the cluster. A schema can only be deleted if no tables are currently using it. If a table still references the schema, the delete request will fail.
+
+To delete both a table and its schema in a single workflow, first delete the table using `DELETE /tables/<tableName>`, then delete the schema using this endpoint.
+
+**Request**
+
+```
+curl -X DELETE "http://localhost:9000/schemas/baseballStats" -H "accept: application/json"
+```
+
+**Response**
+
+```
+{
+  "status": "Schema baseballStats deleted"
+}
+```
+
+{% hint style="info" %}
+In the Pinot Data Explorer UI, you can delete both the table and its schema together by checking the **Delete Schema** option in the delete table dialog. The UI will delete the table first and then automatically delete the associated schema.
+{% endhint %}
+
 ## Table Config Validation
 
 {% hint style="info" %}

--- a/users/api/pinot-rest-admin-interface.md
+++ b/users/api/pinot-rest-admin-interface.md
@@ -130,4 +130,35 @@ Take a look at the schema by going to [Schema -> Get a schema](http://localhost:
 
 Finally, let's checkout the data segments in the cluster by going to [List all segments](http://localhost:9000/help#!/Segment/getSegments), type in `baseballStats` in the table name, and click `Try it out!`. There's 1 segment for this table, called `baseballStats_OFFLINE_0`.
 
+## Deleting tables and schemas
+
+You can delete tables and schemas using the REST API or the Pinot Data Explorer UI.
+
+### Using the API
+
+To delete a table, send a `DELETE` request to `/tables/{tableName}`. By default, segments are moved to a deleted-segments area and retained for a period (default 7 days) before permanent removal. To delete segments immediately with no retention, pass `retention=0d`:
+
+```
+curl -X DELETE "http://localhost:9000/tables/baseballStats?retention=0d" -H "accept: application/json"
+```
+
+To also delete the schema after deleting the table, send a separate `DELETE` request:
+
+```
+curl -X DELETE "http://localhost:9000/schemas/baseballStats" -H "accept: application/json"
+```
+
+{% hint style="warning" %}
+Using `retention=0d` permanently deletes all data immediately with no possibility of recovery. Only use this for development, testing, or cleanup scenarios where the data is no longer needed.
+{% endhint %}
+
+For more details on the delete table API and its parameters, see the [Controller API Reference](controller-api-reference.md#delete-tables-less-than-tablename-greater-than).
+
+### Using the Data Explorer UI
+
+In the Pinot Data Explorer, navigate to a table and click **Delete Table**. The delete dialog provides two options:
+
+* **Delete Immediately** -- Bypasses the default segment retention period and deletes all segments right away. This is equivalent to passing `retention=0d` in the API. This is useful for large tables where the default delete operation might time out.
+* **Delete Schema** -- After successfully deleting the table, also deletes the associated schema. This only works if no other tables are using the same schema.
+
 You might have figured out by now, in order to get data into the Pinot cluster, we need a table, a schema and segments. Let's head over to [Batch upload sample data](../../basics/getting-started/pushing-your-data-to-pinot.md), to find out more about these components and learn how to create them for your own data.


### PR DESCRIPTION
## Summary
- Documents the `retention` query parameter on `DELETE /tables/{tableName}` introduced in [apache/pinot#14736](https://github.com/apache/pinot/pull/14736)
- Adds `DELETE /tables/{tableName}` and `DELETE /schemas/{schemaName}` endpoints to the Controller API Reference with full parameter documentation
- Documents the "Delete Immediately" and "Delete Schema" checkboxes in the Pinot Data Explorer UI
- Adds cross-references from segment retention docs and table config guide

## Files changed
- `users/api/controller-api-reference.md` -- Added DELETE endpoints for tables and schemas with query parameters, examples, and warnings
- `users/api/pinot-rest-admin-interface.md` -- Added section on deleting tables/schemas via API and UI
- `basics/getting-started/create-and-update-table-config.md` -- Added note about `retention=0d` option
- `basics/concepts/segment-retention.md` -- Added cross-reference to immediate delete option

## Test plan
- [ ] Verify all internal doc links resolve correctly
- [ ] Confirm API examples match actual Pinot 1.4 behavior
- [ ] Review writing style consistency with existing docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)