### PR TITLE
Add SUPERSET_SECRET_KEY to Superset Docker instructions

### DIFF
--- a/integrations/superset.md
+++ b/integrations/superset.md
@@ -14,6 +14,7 @@ Start running [Superset Image](https://hub.docker.com/repository/docker/apachepi
 
 ```
 docker run \
+  -e SUPERSET_SECRET_KEY=<your_secret_key> \
   --network pinot-demo \
   --name=superset \
   -p 8088:8088 \


### PR DESCRIPTION
Fixes #326.

Newer versions of Superset require a `SECRET_KEY` environment variable to start. Without it, the container fails on startup.

This adds `-e SUPERSET_SECRET_KEY=<your_secret_key>` to the Docker run command in the Superset integration docs.