### PR TITLE
Fix Kubernetes quickstart Kafka setup for Bitnami KRaft default

### DIFF
--- a/basics/getting-started/kubernetes-quickstart.md
+++ b/basics/getting-started/kubernetes-quickstart.md
@@ -90,9 +90,18 @@ kubectl get all -n pinot-quickstart
 
 ### **Bring up a Kafka cluster for real-time data ingestion**
 
+{% hint style="warning" %}
+Bitnami's Kafka Helm chart now defaults to **KRaft mode**, which does not deploy ZooKeeper. Because the Pinot Helm chart already runs its own ZooKeeper quorum, you must configure Kafka to use **ZooKeeper mode** so that it registers with the existing ZooKeeper ensemble. Add the flags below to disable KRaft and enable ZooKeeper.
+{% endhint %}
+
 ```bash
 helm repo add kafka https://charts.bitnami.com/bitnami
-helm install -n pinot-quickstart kafka kafka/kafka --set replicas=1,zookeeper.image.tag=latest,listeners.client.protocol=PLAINTEXT
+helm install -n pinot-quickstart kafka kafka/kafka \
+    --set replicas=1 \
+    --set kraft.enabled=false \
+    --set zookeeper.enabled=true \
+    --set zookeeper.replicaCount=3 \
+    --set listeners.client.protocol=PLAINTEXT
 ```
 
 ### Check Kafka deployment status


### PR DESCRIPTION
## Summary
- Updated the Kafka Helm install command in the Kubernetes quickstart to explicitly disable KRaft mode and enable ZooKeeper mode, since Bitnami's Kafka chart now defaults to KRaft
- Added `--set kraft.enabled=false`, `--set zookeeper.enabled=true`, and `--set zookeeper.replicaCount=3` flags
- Added a warning hint explaining why ZooKeeper mode is required (Pinot's Helm chart runs its own ZooKeeper quorum)

Fixes #359

## Test plan
- [ ] Follow the updated Kubernetes quickstart instructions on a fresh cluster
- [ ] Verify Kafka pods start correctly in ZooKeeper mode
- [ ] Verify Kafka topic creation and data ingestion work as documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)