### PR TITLE
Fix broken link in Kafka streaming ingestion page

### DIFF
--- a/manage-data/data-import/pinot-stream-ingestion/import-from-apache-kafka.md
+++ b/manage-data/data-import/pinot-stream-ingestion/import-from-apache-kafka.md
@@ -487,7 +487,7 @@ Remember to follow the [schema evolution guidelines](../../../users/tutorials/sc
 
 #### Tell Pinot where to find an Avro schema
 
-There is a standalone utility to generate the schema from an Avro file. See \[infer the pinot schema from the avro schema and JSON data]\([https://docs.pinot.apache.org/basics/data-import/complex-type#infer-the-pinot-schema-from-the-avro-schema-and-json-data](https://docs.pinot.apache.org/basics/data-import/complex-type#infer-the-pinot-schema-from-the-avro-schema-and-json-data)) for details.
+There is a standalone utility to generate the schema from an Avro file. See [infer the pinot schema from the avro schema and JSON data](https://docs.pinot.apache.org/basics/data-import/complex-type#infer-the-pinot-schema-from-the-avro-schema-and-json-data) for details.
 
 To avoid errors like `The Avro schema must be provided`, designate the location of the schema in your `streamConfigs` section. For example, if your current section contains the following:
 


### PR DESCRIPTION
## Summary
- Fixes the broken markdown link in the "Tell Pinot where to find an Avro schema" section of the Kafka streaming ingestion page
- The link to "infer the pinot schema from the avro schema and JSON data" had escaped brackets (`\[...\]`) and a double-nested URL pattern (`([url](url))`) causing it to render as raw text instead of a clickable hyperlink

Fixes #338

## Test plan
- [ ] Verify the link renders correctly on the GitBook-hosted docs page

🤖 Generated with [Claude Code](https://claude.com/claude-code)