### PR TITLE
docs: add comprehensive SQL syntax and operators reference

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -510,11 +510,13 @@
 
 ## Integrations
 
+* [Overview](integrations/README.md)
 * [Tableau](integrations/tableau.md)
 * [Trino](integrations/trino.md)
 * [ThirdEye](integrations/thirdeye.md)
 * [Superset](integrations/superset.md)
 * [Presto](integrations/presto.md)
+* [Flink Connector](integrations/flink-connector.md)
 * [Spark-Pinot Connector](integrations/spark-pinot-connector/README.md)
   * [Spark Pinot Connector Read Model](integrations/spark-pinot-connector/spark-pinot-connector-read-model.md)
   * [Spark Pinot Connector Write Model](integrations/spark-pinot-connector/spark-pinot-connector-write-model.md)

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -89,6 +89,7 @@
 
 * [Query](users/user-guide-query/README.md)
   * [Querying Pinot](users/user-guide-query/querying-pinot.md)
+  * [SQL Syntax and Operators Reference](users/user-guide-query/sql-reference.md)
   * [Query Syntax](users/user-guide-query/query-syntax/README.md)
     * [Explain Plan (Single-Stage)](users/user-guide-query/explain-plan.md)
     * [Explain Plan (Multi-Stage)](users/user-guide-query/query-syntax/explain-plan-multi-stage.md)

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -1,0 +1,45 @@
+---
+description: >-
+  Overview of tools and connectors that integrate with Apache Pinot for querying,
+  visualization, data processing, and observability.
+---
+
+# Integrations
+
+Apache Pinot integrates with a broad ecosystem of tools for querying, visualization, data ingestion, and observability. This page organizes integrations by category to help you find the right tool for your use case.
+
+## Query Engines
+
+Run federated SQL queries against Pinot alongside other data sources.
+
+| Integration | Description |
+| --- | --- |
+| [Trino](trino.md) | Distributed SQL query engine with a built-in Pinot connector for interactive analytics across multiple data sources. |
+| [Presto](presto.md) | Distributed SQL query engine originally developed at Facebook, with native Pinot connector support. |
+
+## BI & Visualization
+
+Connect dashboarding and exploration tools to Pinot for interactive analytics.
+
+| Integration | Description |
+| --- | --- |
+| [Superset](superset.md) | Open-source BI platform with a native Pinot connector for building dashboards and running ad hoc queries. |
+| [Tableau](tableau.md) | Enterprise BI platform that can connect to Pinot via JDBC for drag-and-drop visual analytics. |
+| [Metabase](metabase.md) | Open-source BI tool with a community Pinot driver for self-service analytics and dashboards. |
+
+## Data Processing Connectors
+
+Write data into Pinot programmatically from batch or streaming processing frameworks.
+
+| Integration | Description |
+| --- | --- |
+| [Flink Connector](flink-connector.md) | Apache Flink sink for writing data directly into Pinot tables. Ideal for backfilling offline tables and bootstrapping upsert tables. |
+| [Spark-Pinot Connector](spark-pinot-connector/README.md) | Read data from Pinot into Spark DataFrames and write data back. Supports distributed parallel scans, column/filter pushdown, and gRPC streaming reads. |
+
+## Observability
+
+Monitor and detect anomalies in Pinot data.
+
+| Integration | Description |
+| --- | --- |
+| [ThirdEye](thirdeye.md) | Anomaly detection and root cause analysis platform designed to work with Pinot time-series data. |

--- a/integrations/flink-connector.md
+++ b/integrations/flink-connector.md
@@ -1,0 +1,72 @@
+---
+description: >-
+  Apache Flink connector for writing data directly into Apache Pinot tables,
+  supporting offline, realtime, and upsert table types.
+---
+
+# Flink Connector
+
+The Pinot Flink Connector provides a `PinotSinkFunction` that plugs into any Flink streaming or batch job to generate Pinot segments in-process and upload them directly to the cluster. It supports offline tables, realtime tables, and full-upsert tables.
+
+## Use Cases
+
+* **Offline table backfill** -- Populate or refresh an offline table from a data lake, database export, or any Flink-readable source.
+* **Upsert table bootstrapping** -- Seed a realtime upsert table with historical data while preserving correct partition assignment and comparison-column ordering.
+* **ETL and enrichment pipelines** -- Embed Pinot writes inside a larger Flink DAG that joins, filters, or enriches data before loading.
+
+## When to Use Flink vs. Other Ingestion Methods
+
+| Capability | Flink Connector | Spark Batch Ingestion | Standalone `LaunchDataIngestionJob` |
+| --- | --- | --- | --- |
+| Processing framework | Apache Flink (streaming or batch) | Apache Spark | None (standalone Java process) |
+| Upsert table backfill | Yes -- generates correctly partitioned uploaded-realtime segments | Not natively supported | Not natively supported |
+| Custom transformation logic | Full Flink API (joins, windows, aggregations) | Full Spark API | Limited to ingestion config transforms |
+| Cluster dependency | Requires a Flink cluster or local Flink environment | Requires a Spark cluster | Runs as a single JVM process |
+| Typical data sources | Kafka, data lake files, JDBC, any Flink source | HDFS, S3, GCS, any Spark source | Local/remote files (CSV, JSON, Avro, Parquet, ORC, Thrift) |
+| Best for | Teams already running Flink; upsert backfill scenarios | Teams already running Spark; large-scale batch loads | Simple one-off or scheduled loads without a processing framework |
+
+## Maven Dependency
+
+```xml
+<dependency>
+  <groupId>org.apache.pinot</groupId>
+  <artifactId>pinot-flink-connector</artifactId>
+  <version>${pinot.version}</version>
+</dependency>
+```
+
+Replace `${pinot.version}` with your Pinot release version. Check [Apache Pinot releases](https://pinot.apache.org/download/) for the latest stable version.
+
+The artifact is published to the Apache Maven repository and transitively includes the Pinot controller client, segment writer, and Flink core dependencies.
+
+## Quick Example
+
+```java
+StreamExecutionEnvironment execEnv = StreamExecutionEnvironment.getExecutionEnvironment();
+execEnv.setParallelism(2);
+
+DataStream<Row> srcRows = execEnv.addSource(new FlinkKafkaConsumer<Row>(...));
+
+HttpClient httpClient = HttpClient.getInstance();
+ControllerRequestClient client = new ControllerRequestClient(
+    ControllerRequestURLBuilder.baseUrl("http://localhost:9000"), httpClient);
+
+Schema schema = PinotConnectionUtils.getSchema(client, "myTable");
+TableConfig tableConfig = PinotConnectionUtils.getTableConfig(client, "myTable", "OFFLINE");
+
+srcRows.addSink(new PinotSinkFunction<>(
+    new FlinkRowGenericRowConverter(typeInfo),
+    tableConfig,
+    schema));
+execEnv.execute();
+```
+
+## Full Configuration Reference
+
+For complete configuration details, including upsert partitioning requirements, segment flush control, segment naming, and realtime table support, see the [Flink batch ingestion reference](../manage-data/data-import/batch-ingestion/flink.md).
+
+## Additional Resources
+
+* [Design proposal](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=177045634) -- Original motivation and architecture
+* [Source code](https://github.com/apache/pinot/tree/master/pinot-connectors/pinot-flink-connector) -- Connector implementation on GitHub
+* [FlinkQuickStart.java](https://github.com/apache/pinot/blob/master/pinot-connectors/pinot-flink-connector/src/main/java/org/apache/pinot/connector/flink/FlinkQuickStart.java) -- Runnable example

--- a/users/user-guide-query/querying-pinot.md
+++ b/users/user-guide-query/querying-pinot.md
@@ -6,7 +6,11 @@ description: Learn how to query Pinot using SQL
 
 ## SQL Interface
 
-Pinot provides a SQL interface for querying, which uses the **Calcite SQL** parser to parse queries and the **MYSQL\_ANSI** dialect. For details on the syntax, see the the [Calcite documentation](https://calcite.apache.org/docs/reference.html). To find supported SQL operators, see [Class SqlLibraryOperators](https://calcite.apache.org/javadocAggregate/org/apache/calcite/sql/fun/SqlLibraryOperators.html).
+Pinot provides a SQL interface for querying, which uses the **Calcite SQL** parser to parse queries and the **MYSQL\_ANSI** dialect.
+
+{% hint style="success" %}
+For a complete reference of all supported SQL statements, clauses, operators, and engine compatibility, see the [SQL Syntax and Operators Reference](sql-reference.md).
+{% endhint %}
 
 ## Pinot 1.0
 

--- a/users/user-guide-query/sql-reference.md
+++ b/users/user-guide-query/sql-reference.md
@@ -1,0 +1,643 @@
+---
+description: >-
+  Complete reference for SQL syntax, operators, and clauses supported by Apache
+  Pinot's single-stage engine (SSE) and multi-stage engine (MSE).
+---
+
+# SQL Syntax and Operators Reference
+
+Pinot uses the **Apache Calcite** SQL parser with the **MYSQL\_ANSI** dialect. This page documents every SQL statement, clause, and operator that Pinot supports, and notes where behavior differs between the single-stage engine (SSE) and the multi-stage engine (MSE).
+
+{% hint style="info" %}
+To use MSE-only features such as JOINs, subqueries, window functions, and set operations, enable the multi-stage engine with `SET useMultistageEngine = true;` before your query. See [Use the multi-stage query engine](../../developers/advanced/v2-multi-stage-query-engine.md) for details.
+{% endhint %}
+
+---
+
+## Supported Statements
+
+Pinot supports the following top-level statement types:
+
+| Statement | Description |
+|---|---|
+| `SELECT` | Query data from one or more tables |
+| `SET` | Set query options for the session (e.g., `SET useMultistageEngine = true`) |
+| `EXPLAIN PLAN FOR` | Display the query execution plan without running the query |
+
+```sql
+-- Set a query option, then run a query
+SET useMultistageEngine = true;
+SELECT COUNT(*) FROM myTable WHERE city = 'San Francisco';
+```
+
+```sql
+-- View the execution plan
+EXPLAIN PLAN FOR
+SELECT COUNT(*) FROM myTable GROUP BY city;
+```
+
+---
+
+## SELECT Syntax
+
+The full syntax for a `SELECT` statement in Pinot is:
+
+```
+SELECT [ DISTINCT ] select_expression [, select_expression ]*
+FROM table_reference
+[ WHERE filter_condition ]
+[ GROUP BY group_expression [, group_expression ]* ]
+[ HAVING having_condition ]
+[ ORDER BY order_expression [ ASC | DESC ] [ NULLS FIRST | NULLS LAST ] [, ...] ]
+[ LIMIT count ]
+[ OFFSET offset ]
+[ OPTION ( key = value [, key = value ]* ) ]
+```
+
+### Column Expressions
+
+A `select_expression` can be any of the following:
+
+- `*` -- all columns
+- A column name: `city`
+- A qualified column name: `myTable.city`
+- An expression: `price * quantity`
+- A function call: `UPPER(city)`
+- An aggregation function: `COUNT(*)`, `SUM(revenue)`
+- A `CASE WHEN` expression
+
+### Aliases
+
+Use `AS` to assign an alias to any select expression:
+
+```sql
+SELECT city AS metro_area, COUNT(*) AS total_orders
+FROM orders
+GROUP BY city
+```
+
+### DISTINCT
+
+Use `SELECT DISTINCT` to return unique combinations of column values:
+
+```sql
+SELECT DISTINCT city, state
+FROM stores
+LIMIT 100
+```
+
+{% hint style="warning" %}
+In the SSE, `DISTINCT` is implemented as an aggregation function. `DISTINCT *` is not supported; you must list specific columns. `DISTINCT` with `GROUP BY` is also not supported.
+{% endhint %}
+
+---
+
+## FROM Clause
+
+### Table References
+
+The simplest `FROM` clause references a single table:
+
+```sql
+SELECT * FROM myTable
+```
+
+### Subqueries (MSE Only)
+
+With the multi-stage engine, you can use a subquery as a data source:
+
+```sql
+SET useMultistageEngine = true;
+SELECT city, avg_revenue
+FROM (
+  SELECT city, AVG(revenue) AS avg_revenue
+  FROM orders
+  GROUP BY city
+) AS sub
+WHERE avg_revenue > 1000
+```
+
+### JOINs (MSE Only)
+
+The multi-stage engine supports the following join types:
+
+| Join Type | Description |
+|---|---|
+| `[INNER] JOIN` | Rows that match in both tables |
+| `LEFT [OUTER] JOIN` | All rows from the left table, matching rows from the right |
+| `RIGHT [OUTER] JOIN` | All rows from the right table, matching rows from the left |
+| `FULL [OUTER] JOIN` | All rows from both tables |
+| `CROSS JOIN` | Cartesian product of both tables |
+| `SEMI JOIN` | Rows from the left table that have a match in the right table |
+| `ANTI JOIN` | Rows from the left table that have no match in the right table |
+| `ASOF JOIN` | Rows matched by closest value (e.g., closest timestamp) |
+| `LEFT ASOF JOIN` | Like `ASOF JOIN` but keeps all left rows |
+
+```sql
+SET useMultistageEngine = true;
+SELECT o.order_id, c.name
+FROM orders AS o
+JOIN customers AS c ON o.customer_id = c.id
+WHERE o.amount > 100
+```
+
+For detailed join syntax and examples, see [JOINs](query-syntax/joins.md).
+
+---
+
+## WHERE Clause
+
+The `WHERE` clause filters rows using predicates. Multiple predicates can be combined with [logical operators](#logical-operators).
+
+### Comparison Operators
+
+| Operator | Description | Example |
+|---|---|---|
+| `=` | Equal to | `WHERE city = 'NYC'` |
+| `<>` or `!=` | Not equal to | `WHERE status <> 'canceled'` |
+| `<` | Less than | `WHERE price < 100` |
+| `>` | Greater than | `WHERE price > 50` |
+| `<=` | Less than or equal to | `WHERE quantity <= 10` |
+| `>=` | Greater than or equal to | `WHERE rating >= 4.0` |
+
+### BETWEEN
+
+Tests whether a value falls within an inclusive range:
+
+```sql
+SELECT * FROM orders
+WHERE amount BETWEEN 100 AND 500
+```
+
+`NOT BETWEEN` is also supported:
+
+```sql
+SELECT * FROM orders
+WHERE amount NOT BETWEEN 100 AND 500
+```
+
+### IN
+
+Tests whether a value matches any value in a list:
+
+```sql
+SELECT * FROM orders
+WHERE city IN ('NYC', 'LA', 'Chicago')
+```
+
+`NOT IN` is also supported:
+
+```sql
+SELECT * FROM orders
+WHERE status NOT IN ('canceled', 'refunded')
+```
+
+{% hint style="info" %}
+For large value lists, consider using [Filtering with IdSet](query-syntax/filtering-with-idset.md) for better performance.
+{% endhint %}
+
+### LIKE
+
+Pattern matching with wildcards. `%` matches any sequence of characters; `_` matches any single character:
+
+```sql
+SELECT * FROM customers
+WHERE name LIKE 'John%'
+```
+
+`NOT LIKE` is also supported.
+
+### IS NULL / IS NOT NULL
+
+Tests whether a value is null:
+
+```sql
+SELECT * FROM orders
+WHERE discount IS NOT NULL
+```
+
+See [NULL Semantics](#null-semantics) for details on how nulls work in Pinot.
+
+### REGEXP\_LIKE
+
+Filters rows using regular expression matching:
+
+```sql
+SELECT * FROM airlines
+WHERE REGEXP_LIKE(airlineName, '^U.*')
+```
+
+{% hint style="info" %}
+`REGEXP_LIKE` supports case-insensitive matching via a third parameter: `REGEXP_LIKE(col, pattern, 'i')`.
+{% endhint %}
+
+### TEXT\_MATCH
+
+Full-text search on columns with a text index:
+
+```sql
+SELECT * FROM logs
+WHERE TEXT_MATCH(message, 'error AND timeout')
+```
+
+### JSON\_MATCH
+
+Predicate matching on columns with a JSON index:
+
+```sql
+SELECT * FROM events
+WHERE JSON_MATCH(payload, '"$.type" = ''click''')
+```
+
+### VECTOR\_SIMILARITY
+
+Approximate nearest-neighbor search on vector-indexed columns:
+
+```sql
+SELECT * FROM embeddings
+WHERE VECTOR_SIMILARITY(vector_col, ARRAY[0.1, 0.2, 0.3], 10)
+```
+
+---
+
+## GROUP BY
+
+Groups rows that share values in the specified columns, typically used with aggregation functions:
+
+```sql
+SELECT city, COUNT(*) AS order_count, SUM(amount) AS total
+FROM orders
+GROUP BY city
+```
+
+**Rules:**
+
+- Every non-aggregated column in the `SELECT` list must appear in the `GROUP BY` clause.
+- Aggregation functions and non-aggregation columns cannot be mixed in the `SELECT` list without a `GROUP BY`.
+- Aggregate expressions are not allowed inside the `GROUP BY` clause.
+
+---
+
+## HAVING
+
+Filters groups after aggregation. Use `HAVING` instead of `WHERE` when filtering on aggregated values:
+
+```sql
+SELECT city, COUNT(*) AS order_count
+FROM orders
+GROUP BY city
+HAVING COUNT(*) > 100
+```
+
+---
+
+## ORDER BY
+
+Sorts the result set by one or more expressions:
+
+```sql
+SELECT city, SUM(amount) AS total
+FROM orders
+GROUP BY city
+ORDER BY total DESC
+```
+
+### Ordering Direction
+
+- `ASC` -- ascending order (default)
+- `DESC` -- descending order
+
+### NULL Ordering
+
+- `NULLS FIRST` -- null values appear first
+- `NULLS LAST` -- null values appear last
+
+```sql
+SELECT city, revenue
+FROM stores
+ORDER BY revenue DESC NULLS LAST
+```
+
+---
+
+## LIMIT / OFFSET
+
+### LIMIT
+
+Restricts the number of rows returned:
+
+```sql
+SELECT * FROM orders LIMIT 50
+```
+
+If no `LIMIT` is specified, Pinot defaults to returning 10 rows for selection queries.
+
+### OFFSET
+
+Skips a number of rows before returning results. Requires `ORDER BY` for consistent pagination:
+
+```sql
+SELECT * FROM orders
+ORDER BY created_at DESC
+LIMIT 20 OFFSET 40
+```
+
+Pinot also supports the legacy `LIMIT offset, count` syntax:
+
+```sql
+SELECT * FROM orders
+ORDER BY created_at DESC
+LIMIT 40, 20
+```
+
+---
+
+## Logical Operators
+
+| Operator | Description |
+|---|---|
+| `AND` | True if both conditions are true |
+| `OR` | True if either condition is true |
+| `NOT` | Negates a condition |
+
+### Precedence
+
+From highest to lowest:
+
+1. `NOT`
+2. `AND`
+3. `OR`
+
+Use parentheses to override default precedence:
+
+```sql
+SELECT * FROM orders
+WHERE (status = 'completed' OR status = 'shipped')
+  AND amount > 100
+```
+
+---
+
+## Arithmetic Operators
+
+Arithmetic expressions can be used in `SELECT` expressions, `WHERE` clauses, and other contexts:
+
+| Operator | Description | Example |
+|---|---|---|
+| `+` | Addition | `price + tax` |
+| `-` | Subtraction | `total - discount` |
+| `*` | Multiplication | `price * quantity` |
+| `/` | Division | `total / count` |
+| `%` | Modulo (remainder) | `id % 10` |
+
+```sql
+SELECT order_id, price * quantity AS line_total
+FROM line_items
+WHERE (price * quantity) > 1000
+```
+
+---
+
+## Type Casting
+
+Use `CAST` to convert a value from one type to another:
+
+```sql
+SELECT CAST(revenue AS BIGINT) FROM orders
+```
+
+### Supported Target Types
+
+| Type | Description |
+|---|---|
+| `INT` / `INTEGER` | 32-bit signed integer |
+| `BIGINT` / `LONG` | 64-bit signed integer |
+| `FLOAT` | 32-bit floating point |
+| `DOUBLE` | 64-bit floating point |
+| `BOOLEAN` | Boolean value |
+| `TIMESTAMP` | Timestamp value |
+| `VARCHAR` / `STRING` | Variable-length string |
+| `BYTES` | Byte array |
+| `JSON` | JSON value |
+
+```sql
+SELECT CAST(event_time AS TIMESTAMP), CAST(user_id AS VARCHAR)
+FROM events
+```
+
+---
+
+## Set Operations (MSE Only)
+
+The multi-stage engine supports combining results from multiple queries:
+
+| Operation | Description |
+|---|---|
+| `UNION ALL` | Combine all rows from both queries (including duplicates) |
+| `UNION` | Combine rows from both queries, removing duplicates |
+| `INTERSECT` | Return rows that appear in both queries |
+| `EXCEPT` | Return rows from the first query that do not appear in the second |
+
+```sql
+SET useMultistageEngine = true;
+
+SELECT city FROM stores
+UNION ALL
+SELECT city FROM warehouses
+```
+
+```sql
+SET useMultistageEngine = true;
+
+SELECT customer_id FROM orders_2024
+INTERSECT
+SELECT customer_id FROM orders_2025
+```
+
+---
+
+## Window Functions (MSE Only)
+
+Window functions compute a value across a set of rows related to the current row, without collapsing them into a single output row.
+
+### Syntax
+
+```
+function_name ( expression ) OVER (
+  [ PARTITION BY partition_expression [, ...] ]
+  [ ORDER BY order_expression [ ASC | DESC ] [, ...] ]
+  [ frame_clause ]
+)
+```
+
+### Frame Clause
+
+```
+{ ROWS | RANGE } BETWEEN frame_start AND frame_end
+
+frame_start / frame_end:
+  UNBOUNDED PRECEDING
+  | offset PRECEDING
+  | CURRENT ROW
+  | offset FOLLOWING
+  | UNBOUNDED FOLLOWING
+```
+
+### Example
+
+```sql
+SET useMultistageEngine = true;
+
+SELECT
+  city,
+  order_date,
+  amount,
+  SUM(amount) OVER (PARTITION BY city ORDER BY order_date) AS running_total,
+  ROW_NUMBER() OVER (PARTITION BY city ORDER BY amount DESC) AS rank
+FROM orders
+```
+
+For the full list of supported window functions and detailed syntax, see [Window Functions](query-syntax/windows-functions.md).
+
+---
+
+## OPTION Clause
+
+The `OPTION` clause provides Pinot-specific query hints. These are not standard SQL but allow you to control engine behavior:
+
+```sql
+SELECT * FROM orders
+WHERE city = 'NYC'
+OPTION(timeoutMs=5000)
+```
+
+The preferred approach is to use `SET` statements before the query:
+
+```sql
+SET timeoutMs = 5000;
+SET useMultistageEngine = true;
+SELECT * FROM orders WHERE city = 'NYC'
+```
+
+Common query options include:
+
+| Option | Description |
+|---|---|
+| `timeoutMs` | Query timeout in milliseconds |
+| `useMultistageEngine` | Use the multi-stage engine (`true`/`false`) |
+| `enableNullHandling` | Enable three-valued null logic |
+| `maxExecutionThreads` | Limit CPU threads used by the query |
+| `useStarTree` | Enable or disable star-tree index usage |
+| `skipUpsert` | Query all records in an upsert table, ignoring deletes |
+
+For the complete list of query options, see [Query Options](query-options.md).
+
+---
+
+## NULL Semantics
+
+### Default Behavior
+
+By default, Pinot treats null values as the **default value for the column type** (0 for numeric types, empty string for strings, etc.). This avoids the overhead of null tracking and maintains backward compatibility.
+
+### Nullable Columns
+
+To enable full null handling:
+
+1. Mark columns as nullable in the schema (do not set `notNull: true`).
+2. Enable null handling at query time:
+
+```sql
+SET enableNullHandling = true;
+SELECT * FROM orders WHERE discount IS NULL
+```
+
+### Three-Valued Logic
+
+When null handling is enabled, Pinot follows standard SQL three-valued logic:
+
+| `A` | `B` | `A AND B` | `A OR B` | `NOT A` |
+|---|---|---|---|---|
+| TRUE | TRUE | TRUE | TRUE | FALSE |
+| TRUE | FALSE | FALSE | TRUE | FALSE |
+| TRUE | NULL | NULL | TRUE | NULL |
+| FALSE | FALSE | FALSE | FALSE | TRUE |
+| FALSE | NULL | FALSE | NULL | TRUE |
+| NULL | NULL | NULL | NULL | NULL |
+
+Key behaviors with null handling enabled:
+
+- Comparisons with NULL (e.g., `col = NULL`) return NULL (not TRUE or FALSE). Use `IS NULL` / `IS NOT NULL` instead.
+- `NULL IN (...)` returns NULL, not FALSE.
+- `NULL NOT IN (...)` returns NULL, not TRUE.
+- Aggregate functions like `SUM`, `AVG`, `MIN`, `MAX` ignore NULL values.
+- `COUNT(*)` counts all rows; `COUNT(col)` counts only non-null values.
+
+For more details, see [Null value support](../../developers/advanced/null-value-support.md).
+
+---
+
+## Identifier and Literal Rules
+
+- **Double quotes** (`"`) delimit identifiers (column names, table names). Use double quotes for reserved keywords or special characters: `SELECT "timestamp", "date" FROM myTable`.
+- **Single quotes** (`'`) delimit string literals: `WHERE city = 'NYC'`. Escape an embedded single quote by doubling it: `'it''s'`.
+- **Decimal literals** should be enclosed in single quotes to preserve precision.
+
+---
+
+## CASE WHEN
+
+Pinot supports `CASE WHEN` expressions for conditional logic:
+
+```sql
+SELECT
+  order_id,
+  CASE
+    WHEN amount > 1000 THEN 'high'
+    WHEN amount > 100 THEN 'medium'
+    ELSE 'low'
+  END AS tier
+FROM orders
+```
+
+`CASE WHEN` can be used inside aggregation functions:
+
+```sql
+SELECT
+  SUM(CASE WHEN status = 'completed' THEN amount ELSE 0 END) AS completed_revenue
+FROM orders
+```
+
+{% hint style="warning" %}
+Aggregation functions inside the `ELSE` clause are not supported.
+{% endhint %}
+
+---
+
+## Engine Compatibility Matrix
+
+The following table summarizes feature support across the single-stage engine (SSE) and multi-stage engine (MSE):
+
+| Feature | SSE | MSE |
+|---|---|---|
+| SELECT, WHERE, GROUP BY, HAVING, ORDER BY, LIMIT | Yes | Yes |
+| DISTINCT | Yes | Yes |
+| Aggregation functions | Yes | Yes |
+| CASE WHEN | Yes | Yes |
+| BETWEEN, IN, LIKE, IS NULL | Yes | Yes |
+| Arithmetic operators (+, -, *, /, %) | Yes | Yes |
+| CAST | Yes | Yes |
+| OPTION / SET query hints | Yes | Yes |
+| EXPLAIN PLAN | Yes | Yes |
+| OFFSET | Yes | Yes |
+| JOINs (INNER, LEFT, RIGHT, FULL, CROSS) | No | Yes |
+| Semi / Anti joins | No | Yes |
+| ASOF / LEFT ASOF joins | No | Yes |
+| Subqueries | No | Yes |
+| Set operations (UNION, INTERSECT, EXCEPT) | No | Yes |
+| Window functions (OVER, PARTITION BY) | No | Yes |
+| Correlated subqueries | No | No |
+| INSERT INTO (from file) | No | Yes |
+| CREATE TABLE / DROP TABLE DDL | No | No |
+| DISTINCT with * | No | No |
+| DISTINCT with GROUP BY | No | No |


### PR DESCRIPTION
## Summary
- Creates a first-class SQL syntax and operators reference for Pinot
- Covers all supported SQL statements, operators, and clauses
- Documents single-stage vs multi-stage engine compatibility
- Documents NULL semantics and Pinot-specific OPTION clause
- Replaces the pattern of sending users to external Calcite docs

## Test plan
- [ ] Verify syntax examples execute correctly against a Pinot cluster
- [ ] Cross-reference engine compatibility notes with actual behavior