### PR TITLE
docs: create Integrations hub and elevate Flink connector

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -509,11 +509,13 @@
 
 ## Integrations
 
+* [Overview](integrations/README.md)
 * [Tableau](integrations/tableau.md)
 * [Trino](integrations/trino.md)
 * [ThirdEye](integrations/thirdeye.md)
 * [Superset](integrations/superset.md)
 * [Presto](integrations/presto.md)
+* [Flink Connector](integrations/flink-connector.md)
 * [Spark-Pinot Connector](integrations/spark-pinot-connector/README.md)
   * [Spark Pinot Connector Read Model](integrations/spark-pinot-connector/spark-pinot-connector-read-model.md)
   * [Spark Pinot Connector Write Model](integrations/spark-pinot-connector/spark-pinot-connector-write-model.md)

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -1,0 +1,45 @@
+---
+description: >-
+  Overview of tools and connectors that integrate with Apache Pinot for querying,
+  visualization, data processing, and observability.
+---
+
+# Integrations
+
+Apache Pinot integrates with a broad ecosystem of tools for querying, visualization, data ingestion, and observability. This page organizes integrations by category to help you find the right tool for your use case.
+
+## Query Engines
+
+Run federated SQL queries against Pinot alongside other data sources.
+
+| Integration | Description |
+| --- | --- |
+| [Trino](trino.md) | Distributed SQL query engine with a built-in Pinot connector for interactive analytics across multiple data sources. |
+| [Presto](presto.md) | Distributed SQL query engine originally developed at Facebook, with native Pinot connector support. |
+
+## BI & Visualization
+
+Connect dashboarding and exploration tools to Pinot for interactive analytics.
+
+| Integration | Description |
+| --- | --- |
+| [Superset](superset.md) | Open-source BI platform with a native Pinot connector for building dashboards and running ad hoc queries. |
+| [Tableau](tableau.md) | Enterprise BI platform that can connect to Pinot via JDBC for drag-and-drop visual analytics. |
+| [Metabase](metabase.md) | Open-source BI tool with a community Pinot driver for self-service analytics and dashboards. |
+
+## Data Processing Connectors
+
+Write data into Pinot programmatically from batch or streaming processing frameworks.
+
+| Integration | Description |
+| --- | --- |
+| [Flink Connector](flink-connector.md) | Apache Flink sink for writing data directly into Pinot tables. Ideal for backfilling offline tables and bootstrapping upsert tables. |
+| [Spark-Pinot Connector](spark-pinot-connector/README.md) | Read data from Pinot into Spark DataFrames and write data back. Supports distributed parallel scans, column/filter pushdown, and gRPC streaming reads. |
+
+## Observability
+
+Monitor and detect anomalies in Pinot data.
+
+| Integration | Description |
+| --- | --- |
+| [ThirdEye](thirdeye.md) | Anomaly detection and root cause analysis platform designed to work with Pinot time-series data. |

--- a/integrations/flink-connector.md
+++ b/integrations/flink-connector.md
@@ -1,0 +1,72 @@
+---
+description: >-
+  Apache Flink connector for writing data directly into Apache Pinot tables,
+  supporting offline, realtime, and upsert table types.
+---
+
+# Flink Connector
+
+The Pinot Flink Connector provides a `PinotSinkFunction` that plugs into any Flink streaming or batch job to generate Pinot segments in-process and upload them directly to the cluster. It supports offline tables, realtime tables, and full-upsert tables.
+
+## Use Cases
+
+* **Offline table backfill** -- Populate or refresh an offline table from a data lake, database export, or any Flink-readable source.
+* **Upsert table bootstrapping** -- Seed a realtime upsert table with historical data while preserving correct partition assignment and comparison-column ordering.
+* **ETL and enrichment pipelines** -- Embed Pinot writes inside a larger Flink DAG that joins, filters, or enriches data before loading.
+
+## When to Use Flink vs. Other Ingestion Methods
+
+| Capability | Flink Connector | Spark Batch Ingestion | Standalone `LaunchDataIngestionJob` |
+| --- | --- | --- | --- |
+| Processing framework | Apache Flink (streaming or batch) | Apache Spark | None (standalone Java process) |
+| Upsert table backfill | Yes -- generates correctly partitioned uploaded-realtime segments | Not natively supported | Not natively supported |
+| Custom transformation logic | Full Flink API (joins, windows, aggregations) | Full Spark API | Limited to ingestion config transforms |
+| Cluster dependency | Requires a Flink cluster or local Flink environment | Requires a Spark cluster | Runs as a single JVM process |
+| Typical data sources | Kafka, data lake files, JDBC, any Flink source | HDFS, S3, GCS, any Spark source | Local/remote files (CSV, JSON, Avro, Parquet, ORC, Thrift) |
+| Best for | Teams already running Flink; upsert backfill scenarios | Teams already running Spark; large-scale batch loads | Simple one-off or scheduled loads without a processing framework |
+
+## Maven Dependency
+
+```xml
+<dependency>
+  <groupId>org.apache.pinot</groupId>
+  <artifactId>pinot-flink-connector</artifactId>
+  <version>${pinot.version}</version>
+</dependency>
+```
+
+Replace `${pinot.version}` with your Pinot release version. Check [Apache Pinot releases](https://pinot.apache.org/download/) for the latest stable version.
+
+The artifact is published to the Apache Maven repository and transitively includes the Pinot controller client, segment writer, and Flink core dependencies.
+
+## Quick Example
+
+```java
+StreamExecutionEnvironment execEnv = StreamExecutionEnvironment.getExecutionEnvironment();
+execEnv.setParallelism(2);
+
+DataStream<Row> srcRows = execEnv.addSource(new FlinkKafkaConsumer<Row>(...));
+
+HttpClient httpClient = HttpClient.getInstance();
+ControllerRequestClient client = new ControllerRequestClient(
+    ControllerRequestURLBuilder.baseUrl("http://localhost:9000"), httpClient);
+
+Schema schema = PinotConnectionUtils.getSchema(client, "myTable");
+TableConfig tableConfig = PinotConnectionUtils.getTableConfig(client, "myTable", "OFFLINE");
+
+srcRows.addSink(new PinotSinkFunction<>(
+    new FlinkRowGenericRowConverter(typeInfo),
+    tableConfig,
+    schema));
+execEnv.execute();
+```
+
+## Full Configuration Reference
+
+For complete configuration details, including upsert partitioning requirements, segment flush control, segment naming, and realtime table support, see the [Flink batch ingestion reference](../manage-data/data-import/batch-ingestion/flink.md).
+
+## Additional Resources
+
+* [Design proposal](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=177045634) -- Original motivation and architecture
+* [Source code](https://github.com/apache/pinot/tree/master/pinot-connectors/pinot-flink-connector) -- Connector implementation on GitHub
+* [FlinkQuickStart.java](https://github.com/apache/pinot/blob/master/pinot-connectors/pinot-flink-connector/src/main/java/org/apache/pinot/connector/flink/FlinkQuickStart.java) -- Runnable example


### PR DESCRIPTION
## Summary
- Add a categorized Integrations landing page (`integrations/README.md`) that organizes existing integrations into four categories: Query Engines, BI & Visualization, Data Processing Connectors, and Observability
- Create a dedicated Flink Connector page (`integrations/flink-connector.md`) with use cases, a comparison table (Flink vs Spark vs standalone ingestion), Maven coordinates, and links to the full batch ingestion reference
- Update SUMMARY.md to include the new landing page and Flink connector entry

## Test plan
- [ ] Verify all links in the new pages resolve correctly in GitBook
- [ ] Confirm SUMMARY.md renders the Integrations section with the new Overview and Flink Connector entries
- [ ] Check that the Flink connector comparison table renders properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)