### PR TITLE
docs: expand plugin architecture docs for all plugin families

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -178,6 +178,9 @@
     * [Batch Segment Fetcher Plugin](developers/plugin-architecture/write-custom-plugins/write-your-batch.md)
     * [Stream Ingestion Plugin](developers/plugin-architecture/write-custom-plugins/write-your-stream.md)
     * [Time Series Language Plugin](developers/plugin-architecture/write-custom-plugins/time-series-language-plugin.md)
+    * [Segment Uploader Plugin](developers/plugin-architecture/write-custom-plugins/segment-uploader-plugin.md)
+    * [Segment Writer Plugin](developers/plugin-architecture/write-custom-plugins/segment-writer-plugin.md)
+    * [Metrics Plugin](developers/plugin-architecture/write-custom-plugins/metrics-plugin.md)
 * [Design Documents](developers/design-documents/README.md)
   * [Segment Writer API](developers/design-documents/segment-writer-api.md)
 

--- a/developers/plugin-architecture/README.md
+++ b/developers/plugin-architecture/README.md
@@ -1,43 +1,110 @@
 # Plugins
 
-Starting from the 0.3.X release, Pinot supports a plug-and-play architecture. This means that starting from version 0.3.0, Pinot can be easily extended to support new tools, like streaming services and storage systems.
+Starting from the 0.3.X release, Pinot supports a plug-and-play architecture. This means that starting from version 0.3.0, Pinot can be easily extended to support new tools, like streaming services, storage systems, input formats, and metrics providers.
 
 ![](<../../.gitbook/assets/Pinot Dependency Graph.svg>)
 
-Plugins are collected in folders, based on their purpose. The following types of plugins are supported.
+Plugins are collected in folders, based on their purpose. Pinot organizes its plugins into **ten plugin families**, each targeting a specific extensibility need. The table below summarizes every family, its SPI module, and the implementations that ship with Pinot.
 
-#### Input Format
+## Plugin Families at a Glance
 
-Input format is a set of plugins with the goal of reading data from files during data ingestion. It can be split into two additional types: record encoders (for batch jobs) and decoders (for ingestion). Currently supported record encoder formats are: avro, orc and parquet encoders, while for streaming: csv, json and thrift decoders.
+| Plugin Family | SPI Interface / Module | Built-in Implementations |
+| --- | --- | --- |
+| **Input Format** | `RecordReader` / `StreamMessageDecoder` | Avro, CSV, JSON, ORC, Parquet, Thrift, Protobuf, Arrow, CLP-Log, Confluent Avro, Confluent JSON, Confluent Protobuf |
+| **Filesystem** | `PinotFS` | S3, GCS, HDFS, ADLS |
+| **Stream Ingestion** | `StreamConsumerFactory` | Kafka 3.0, Kafka 4.0, Kinesis, Pulsar |
+| **Batch Ingestion** | `IngestionJobRunner` | Standalone, Hadoop, Spark 2.4, Spark 3 |
+| **Metrics** | `PinotMetricsFactory` | Dropwizard, Yammer, Compound |
+| **Segment Writer** | `SegmentWriter` | File-based |
+| **Segment Uploader** | `SegmentUploader` | Default |
+| **Minion Tasks** | `PinotTaskGenerator` / `PinotTaskExecutor` | MergeRollup, Purge, RealtimeToOfflineSegments, SegmentGenerationAndPush, UpsertCompaction, UpsertCompactMerge, RefreshSegment |
+| **Environment** | `PinotEnv` | Azure |
+| **Time Series Language** | `TimeSeriesLogicalPlanner` | M3QL |
+
+---
+
+### Input Format
+
+Input format plugins read data from files or streams during data ingestion. Batch ingestion uses `RecordReader` implementations, while real-time ingestion uses `StreamMessageDecoder` implementations.
 
 {% content-ref url="../../manage-data/data-import/pinot-input-formats.md" %}
 [pinot-input-formats.md](../../manage-data/data-import/pinot-input-formats.md)
 {% endcontent-ref %}
 
-#### File System
+### Filesystem
 
-File System is a set of plugins devoted to storage purpose. Currently supported file systems are: adsl, gcs and hdfs.
+Filesystem plugins provide a storage abstraction layer so that Pinot segments can be stored on and fetched from different storage backends.
 
 {% content-ref url="../../manage-data/data-import/pinot-file-system/" %}
 [pinot-file-system](../../manage-data/data-import/pinot-file-system/)
 {% endcontent-ref %}
 
-#### Stream Ingestion&#x20;
+### Stream Ingestion
 
-Stream Ingestion is a set of plugins targeted to ingest data from streams. Currently supported streaming services: kafka 0.9 and kafka 2.0.
+Stream ingestion plugins allow Pinot to consume data from real-time streaming platforms.
 
 {% content-ref url="../../manage-data/data-import/pinot-stream-ingestion/" %}
 [pinot-stream-ingestion](../../manage-data/data-import/pinot-stream-ingestion/)
 {% endcontent-ref %}
 
-#### Batch Ingestion
+### Batch Ingestion
 
-Batch Ingestion is a set of plugins targeted to ingest data from batches. Currently supported ingestion systems are: spark, hadoop and standalone jobs.
+Batch ingestion plugins run data ingestion jobs on different execution frameworks.
 
 {% content-ref url="../../manage-data/data-import/batch-ingestion/" %}
 [batch-ingestion](../../manage-data/data-import/batch-ingestion/)
 {% endcontent-ref %}
 
-### Developing Plugins
+### Metrics
 
-Plugins can be developed with no restriction. There are some standards that have to be followed, though. The plugin have to implement the interfaces from the link [https://github.com/apache/pinot/tree/master/pinot-spi/src/main/java/org/apache/pinot/spi](https://github.com/apache/pinot/tree/master/pinot-spi/src/main/java/org/apache/pinot/spi)
+Metrics plugins control which metrics library Pinot uses to collect and expose internal metrics via JMX. Pinot ships with Dropwizard (default), Yammer, and a Compound implementation that can fan out to multiple registries simultaneously.
+
+{% content-ref url="write-custom-plugins/metrics-plugin.md" %}
+[metrics-plugin.md](write-custom-plugins/metrics-plugin.md)
+{% endcontent-ref %}
+
+### Segment Writer
+
+The Segment Writer plugin provides an API for programmatically collecting `GenericRow` records and building Pinot segments without going through a full batch ingestion job. The built-in file-based implementation buffers rows as Avro records on local disk.
+
+{% content-ref url="write-custom-plugins/segment-writer-plugin.md" %}
+[segment-writer-plugin.md](write-custom-plugins/segment-writer-plugin.md)
+{% endcontent-ref %}
+
+### Segment Uploader
+
+The Segment Uploader plugin handles uploading completed segment tar files to the Pinot cluster. The default implementation supports all push modes configured via `batchConfigMaps` in the table config.
+
+{% content-ref url="write-custom-plugins/segment-uploader-plugin.md" %}
+[segment-uploader-plugin.md](write-custom-plugins/segment-uploader-plugin.md)
+{% endcontent-ref %}
+
+### Minion Tasks
+
+Minion task plugins define background processing tasks that run on Pinot Minion nodes. Built-in tasks include segment merge/rollup, purge, real-time to offline conversion, upsert compaction, and more.
+
+{% content-ref url="../../basics/components/cluster/minion.md" %}
+[minion.md](../../basics/components/cluster/minion.md)
+{% endcontent-ref %}
+
+### Environment
+
+Environment plugins allow Pinot to integrate with cloud-specific features and configurations. The Azure environment plugin provides Azure-specific functionality.
+
+### Time Series Language
+
+Time series language plugins allow Pinot to support custom time series query languages like PromQL or M3QL.
+
+{% content-ref url="write-custom-plugins/time-series-language-plugin.md" %}
+[time-series-language-plugin.md](write-custom-plugins/time-series-language-plugin.md)
+{% endcontent-ref %}
+
+---
+
+## Developing Plugins
+
+Plugins can be developed with no restriction. There are some standards that have to be followed, though. The plugin has to implement the interfaces from [pinot-spi](https://github.com/apache/pinot/tree/master/pinot-spi/src/main/java/org/apache/pinot/spi).
+
+{% content-ref url="write-custom-plugins/" %}
+[write-custom-plugins](write-custom-plugins/)
+{% endcontent-ref %}

--- a/developers/plugin-architecture/write-custom-plugins/metrics-plugin.md
+++ b/developers/plugin-architecture/write-custom-plugins/metrics-plugin.md
@@ -1,0 +1,91 @@
+# Metrics Plugin
+
+## Overview
+
+The Metrics plugin controls which metrics library Pinot uses to collect and expose internal metrics. All Pinot components (broker, server, controller, minion) use the `PinotMetricsFactory` SPI to create metric registries, counters, gauges, meters, timers, and JMX reporters.
+
+Pinot ships with three metrics implementations:
+
+| Implementation | Class | Description |
+| --- | --- | --- |
+| **Dropwizard** | `DropwizardMetricsFactory` | Based on Dropwizard Metrics (formerly Codahale). This is the default. |
+| **Yammer** | `YammerMetricsFactory` | Based on Yammer Metrics, used in older Pinot versions. |
+| **Compound** | `CompoundPinotMetricsFactory` | A meta-implementation that fans metrics out to multiple registries simultaneously. Useful for comparing or migrating between metrics libraries. |
+
+## Configuration
+
+To configure which metrics factory Pinot uses, set the following property in the component configuration (broker, server, controller, or minion):
+
+```properties
+pinot.<component>.metrics.factory.className=org.apache.pinot.plugin.metrics.dropwizard.DropwizardMetricsFactory
+```
+
+Replace `<component>` with `broker`, `server`, `controller`, or `minion`.
+
+### Dropwizard Configuration
+
+The Dropwizard metrics plugin supports an optional JMX domain property:
+
+```properties
+pinot.metrics.dropwizard.domain=org.apache.pinot.common.metrics
+```
+
+If not set, the default domain `org.apache.pinot.common.metrics` is used.
+
+### Yammer Configuration
+
+The Yammer metrics plugin does not require any additional configuration beyond setting the factory class name.
+
+### Compound Metrics Configuration
+
+The Compound metrics factory reports to multiple metrics registries at once. This is useful for comparing behavior between different implementations during a migration.
+
+```properties
+pinot.<component>.metrics.factory.className=org.apache.pinot.plugin.metrics.compound.CompoundPinotMetricsFactory
+```
+
+The following additional properties control how the Compound factory discovers sub-factories:
+
+| Property Suffix | Values | Description |
+| --- | --- | --- |
+| `compound.algorithm` | `CLASSPATH` (default), `SERVICE_LOADER`, `LIST` | How to discover sub-factories. |
+| `compound.ignored` | Comma-separated class names | Metrics factory classes to exclude. |
+| `compound.list` | Comma-separated class names | Explicit list of factory classes (used with `LIST` algorithm). |
+
+## SPI Interface
+
+To write a custom metrics plugin, implement the [PinotMetricsFactory](https://github.com/apache/pinot/blob/master/pinot-spi/src/main/java/org/apache/pinot/spi/annotations/metrics/PinotMetricsFactory.java) interface:
+
+```java
+public interface PinotMetricsFactory {
+  void init(PinotConfiguration metricsConfiguration);
+  PinotMetricsRegistry getPinotMetricsRegistry();
+  PinotMetricName makePinotMetricName(Class<?> klass, String name);
+  <T> PinotGauge<T> makePinotGauge(Function<Void, T> condition);
+  PinotJmxReporter makePinotJmxReporter(PinotMetricsRegistry metricsRegistry);
+  String getMetricsFactoryName();
+}
+```
+
+### Key Methods
+
+| Method | Description |
+| --- | --- |
+| `init(PinotConfiguration)` | Initializes the factory with Pinot configuration. |
+| `getPinotMetricsRegistry()` | Returns the singleton metrics registry instance. |
+| `makePinotMetricName(Class, String)` | Creates a metric name scoped to a class. |
+| `makePinotGauge(Function)` | Creates a gauge metric backed by the provided function. |
+| `makePinotJmxReporter(PinotMetricsRegistry)` | Creates a JMX reporter for the given registry. |
+| `getMetricsFactoryName()` | Returns a human-readable name for the factory. |
+
+## Writing a Custom Metrics Plugin
+
+To implement a custom metrics plugin:
+
+1. Create a class that implements `PinotMetricsFactory`.
+2. Annotate it with `@AutoService(PinotMetricsFactory.class)` and `@MetricsFactory`.
+3. Implement wrapper classes for the Pinot metric types (`PinotCounter`, `PinotGauge`, `PinotMeter`, `PinotTimer`, `PinotMetricsRegistry`, `PinotJmxReporter`).
+4. Package it as a Pinot plugin (see [Write Custom Plugins](./)).
+5. Place the plugin JAR in the Pinot `/plugins` directory.
+
+A custom metrics plugin could be useful for integrating with monitoring systems such as Prometheus, Micrometer, or OpenTelemetry.

--- a/developers/plugin-architecture/write-custom-plugins/segment-uploader-plugin.md
+++ b/developers/plugin-architecture/write-custom-plugins/segment-uploader-plugin.md
@@ -1,0 +1,80 @@
+# Segment Uploader Plugin
+
+## Overview
+
+The Segment Uploader plugin is responsible for uploading completed segment tar files to the Pinot cluster. It abstracts the details of segment push so that different upload strategies (HTTP push, URI push, metadata push) can be supported through configuration.
+
+The default implementation, `SegmentUploaderDefault`, reads push configuration from the table config's `batchConfigMaps` and delegates to `IngestionUtils` for the actual upload.
+
+## SPI Interface
+
+To write a custom segment uploader, implement the [SegmentUploader](https://github.com/apache/pinot/blob/master/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/segment/uploader/SegmentUploader.java) interface:
+
+```java
+public interface SegmentUploader {
+
+  void init(TableConfig tableConfig) throws Exception;
+
+  void init(TableConfig tableConfig, Map<String, String> batchConfigOverride) throws Exception;
+
+  void uploadSegment(URI segmentTarFile, AuthProvider authProvider) throws Exception;
+
+  void uploadSegmentsFromDir(URI segmentDir, AuthProvider authProvider) throws Exception;
+}
+```
+
+### Key Methods
+
+| Method | Description |
+| --- | --- |
+| `init(TableConfig)` | Initializes the uploader using batch config from the table config. |
+| `init(TableConfig, Map)` | Initializes with additional config overrides on top of the table config. |
+| `uploadSegment(URI, AuthProvider)` | Uploads a single segment tar file to the cluster. |
+| `uploadSegmentsFromDir(URI, AuthProvider)` | Recursively finds and uploads all `.tar.gz` segment files from a directory. |
+
+## Default Implementation
+
+The built-in `SegmentUploaderDefault` works as follows:
+
+1. Reads the `batchConfigMaps` from `tableConfig.ingestionConfig.batchIngestionConfig`.
+2. Requires exactly one `BatchConfig` entry in the list.
+3. Uses the `push.controllerUri` property to determine the target controller.
+4. Supports all push modes: `tar`, `uri`, and `metadata`.
+
+## Configuration
+
+The segment uploader is configured through `batchConfigMaps` in the table config. The following properties are relevant:
+
+```json
+{
+  "ingestionConfig": {
+    "batchIngestionConfig": {
+      "batchConfigMaps": [
+        {
+          "push.controllerUri": "https://pinot-controller:9000",
+          "push.mode": "tar"
+        }
+      ]
+    }
+  }
+}
+```
+
+| Property | Required | Description |
+| --- | --- | --- |
+| `push.controllerUri` | Yes | URI of the Pinot controller for segment upload. |
+| `push.mode` | No | Push mode: `tar` (default), `uri`, or `metadata`. |
+
+## Writing a Custom Segment Uploader
+
+To implement a custom segment uploader:
+
+1. Create a class that implements `SegmentUploader`.
+2. Package it as a Pinot plugin (see [Write Custom Plugins](./)).
+3. Place the plugin JAR in the Pinot `/plugins` directory.
+
+A custom uploader could be useful for scenarios such as:
+
+* Uploading segments to a custom deep store before notifying the controller.
+* Adding custom authentication or encryption during upload.
+* Integrating with an external orchestration system that manages segment lifecycle.

--- a/developers/plugin-architecture/write-custom-plugins/segment-writer-plugin.md
+++ b/developers/plugin-architecture/write-custom-plugins/segment-writer-plugin.md
@@ -1,0 +1,98 @@
+# Segment Writer Plugin
+
+## Overview
+
+The Segment Writer plugin provides an API for programmatically collecting `GenericRow` records and building Pinot segments without running a full batch ingestion job. This is particularly useful when you need to generate segments from application code, such as in a Minion task or a custom ingestion pipeline.
+
+The built-in file-based implementation (`FileBasedSegmentWriter`) buffers incoming rows as Avro records on local disk and creates a Pinot segment when `flush()` is called.
+
+## SPI Interface
+
+To write a custom segment writer, implement the [SegmentWriter](https://github.com/apache/pinot/blob/master/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/segment/writer/SegmentWriter.java) interface:
+
+```java
+public interface SegmentWriter extends Closeable {
+
+  void init(TableConfig tableConfig, Schema schema) throws Exception;
+
+  void init(TableConfig tableConfig, Schema schema, Map<String, String> batchConfigOverride)
+      throws Exception;
+
+  void collect(GenericRow row) throws Exception;
+
+  default void collect(GenericRow[] rowBatch) throws Exception;
+
+  URI flush() throws Exception;
+}
+```
+
+### Key Methods
+
+| Method | Description |
+| --- | --- |
+| `init(TableConfig, Schema)` | Initializes the writer with table config and Pinot schema. |
+| `init(TableConfig, Schema, Map)` | Initializes with additional batch config overrides. |
+| `collect(GenericRow)` | Buffers a single row. The row is not written to a segment until `flush()` is called. |
+| `collect(GenericRow[])` | Buffers a batch of rows. |
+| `flush()` | Builds a Pinot segment from buffered rows and returns the URI of the generated segment tar file. Resets the buffer on success. |
+| `close()` | Releases resources. |
+
+## File-Based Implementation
+
+The `FileBasedSegmentWriter` works as follows:
+
+1. **Initialization** -- Reads `batchConfigMaps` from the table config. Requires exactly one `BatchConfig` entry with an `outputDirURI`.
+2. **Buffering** -- Each `collect()` call applies the table's transform pipeline and appends the result as an Avro record to a local buffer file.
+3. **Flushing** -- The `flush()` method builds a Pinot segment from the buffer file, compresses it as a `.tar.gz`, writes it to the configured `outputDirURI`, and resets the buffer. If flush fails, the buffer is preserved so `flush()` can be retried.
+4. **Closing** -- The `close()` method releases resources and cleans up staging directories.
+
+## Configuration
+
+The segment writer is configured through `batchConfigMaps` in the table config:
+
+```json
+{
+  "ingestionConfig": {
+    "batchIngestionConfig": {
+      "segmentIngestionType": "APPEND",
+      "batchConfigMaps": [
+        {
+          "outputDirURI": "/path/to/segment/output",
+          "overwrite": "false"
+        }
+      ]
+    }
+  }
+}
+```
+
+| Property | Required | Description |
+| --- | --- | --- |
+| `outputDirURI` | Yes | Directory where generated segment tar files are written. |
+| `overwrite` | No | Whether to overwrite segments with duplicate names. Defaults to `false`. |
+
+## Usage Example
+
+```java
+SegmentWriter writer = new FileBasedSegmentWriter();
+writer.init(tableConfig, schema);
+
+for (GenericRow row : rows) {
+  writer.collect(row);
+}
+
+URI segmentURI = writer.flush();
+// segmentURI points to the generated .tar.gz file
+
+writer.close();
+```
+
+## Writing a Custom Segment Writer
+
+To implement a custom segment writer:
+
+1. Create a class that implements `SegmentWriter`.
+2. Package it as a Pinot plugin (see [Write Custom Plugins](./)).
+3. Place the plugin JAR in the Pinot `/plugins` directory.
+
+Custom implementations could use different buffering strategies (for example, in-memory buffering for smaller datasets) or write to remote storage directly.


### PR DESCRIPTION
## Summary
- Rewrote the plugin architecture overview page to catalog all 10 plugin families (Input Format, Filesystem, Stream Ingestion, Batch Ingestion, Metrics, Segment Writer, Segment Uploader, Minion Tasks, Environment, Time Series Language) with a summary table listing SPI interfaces and built-in implementations
- Added new Segment Uploader Plugin guide documenting the `SegmentUploader` SPI, default implementation, and configuration
- Added new Segment Writer Plugin guide documenting the `SegmentWriter` SPI, file-based implementation, configuration, and usage example
- Added new Metrics Plugin guide documenting the `PinotMetricsFactory` SPI, Dropwizard/Yammer/Compound implementations, and configuration options
- Updated SUMMARY.md navigation to include the three new plugin pages

## Test plan
- [ ] Verify all new pages render correctly in GitBook
- [ ] Confirm all internal cross-references and GitHub links resolve
- [ ] Check that the SUMMARY.md nav entries appear under the correct parent

🤖 Generated with [Claude Code](https://claude.com/claude-code)