### PR TITLE
docs: add Kafka 4.0 connector docs, segment pruning guide, fix deprecated kafka20 refs

### DIFF
--- a/manage-data/data-import/pinot-stream-ingestion/import-from-apache-kafka.md
+++ b/manage-data/data-import/pinot-stream-ingestion/import-from-apache-kafka.md
@@ -8,6 +8,10 @@ description: >-
 
 Learn how to ingest data from Kafka, a stream processing platform. You should have a local cluster up and running, following the instructions in [Set up a cluster](../../../operators/operating-pinot/setup-cluster.md).
 
+{% hint style="info" %}
+This guide uses the Kafka 3.0 connector (`kafka30`). Pinot also supports a **Kafka 4.0 connector** for KRaft-mode Kafka clusters. See [Kafka Connector Versions](kafka-connector-versions.md) for details on choosing the right connector.
+{% endhint %}
+
 ## Install and Launch Kafka
 
 Let's start by downloading Kafka to our local machine.
@@ -209,7 +213,7 @@ Create a file called `/tmp/pinot/table-config-stream.json` and add the following
       "streamType": "kafka",
       "stream.kafka.topic.name": "events",
       "stream.kafka.decoder.class.name": "org.apache.pinot.plugin.inputformat.json.JSONMessageDecoder",
-      "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory",
+      "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka30.KafkaConsumerFactory",
       "stream.kafka.broker.list": "kafka:9092",
       "realtime.segment.flush.threshold.rows": "0",
       "realtime.segment.flush.threshold.time": "24h",
@@ -292,7 +296,7 @@ Here is an example config which uses SSL based authentication to talk with kafka
         "streamType": "kafka",
         "stream.kafka.topic.name": "transcript-topic",
         "stream.kafka.decoder.class.name": "org.apache.pinot.plugin.inputformat.avro.confluent.KafkaConfluentSchemaRegistryAvroMessageDecoder",
-        "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory",
+        "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka30.KafkaConsumerFactory",
         "stream.kafka.zk.broker.url": "pinot-zookeeper:2181/kafka",
         "stream.kafka.broker.list": "localhost:9092",
         "schema.registry.url": "",
@@ -350,7 +354,7 @@ If your messages are Avro-encoded and registered with Schema Registry, use `Kafk
       "streamType": "kafka",
       "stream.kafka.topic.name": "events",
       "stream.kafka.decoder.class.name": "org.apache.pinot.plugin.inputformat.json.confluent.KafkaConfluentSchemaRegistryJsonMessageDecoder",
-      "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory",
+      "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka30.KafkaConsumerFactory",
       "stream.kafka.broker.list": "localhost:9092",
       "stream.kafka.schema.registry.url": "http://localhost:8081",
       "stream.kafka.decoder.prop.schema.registry.rest.url": "http://localhost:8081",
@@ -409,7 +413,7 @@ For example,
         "streamType": "kafka",
         "stream.kafka.topic.name": "transcript-topic",
         "stream.kafka.decoder.class.name": "org.apache.pinot.plugin.inputformat.avro.confluent.KafkaConfluentSchemaRegistryAvroMessageDecoder",
-        "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory",
+        "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka30.KafkaConsumerFactory",
         "stream.kafka.zk.broker.url": "pinot-zookeeper:2181/kafka",
         "stream.kafka.broker.list": "kafka:9092",
         "stream.kafka.isolation.level": "read_committed"
@@ -432,7 +436,7 @@ Here is an example config which uses SASL\_SSL based authentication to talk with
         "streamType": "kafka",
         "stream.kafka.topic.name": "mytopic",
         "stream.kafka.consumer.prop.auto.offset.reset": "largest",
-        "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory",
+        "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka30.KafkaConsumerFactory",
         "stream.kafka.broker.list": "kafka:9092",
         "stream.kafka.schema.registry.url": "https://xxx",
         "stream.kafka.decoder.class.name": "org.apache.pinot.plugin.inputformat.avro.confluent.KafkaConfluentSchemaRegistryAvroMessageDecoder",
@@ -497,7 +501,7 @@ To avoid errors like `The Avro schema must be provided`, designate the location 
   "streamType": "kafka",
   "stream.kafka.topic.name": "",
   "stream.kafka.decoder.class.name": "org.apache.pinot.plugin.inputformat.avro.SimpleAvroMessageDecoder",
-  "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory",
+  "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka30.KafkaConsumerFactory",
   "stream.kafka.broker.list": "",
   "stream.kafka.consumer.prop.auto.offset.reset": "largest"
   ...
@@ -553,7 +557,7 @@ Table `events_part_0`:
           "stream.kafka.topic.name": "events",
           "stream.kafka.partition.ids": "0",
           "stream.kafka.decoder.class.name": "org.apache.pinot.plugin.inputformat.json.JSONMessageDecoder",
-          "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory",
+          "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka30.KafkaConsumerFactory",
           "stream.kafka.broker.list": "kafka:9092",
           "stream.kafka.consumer.prop.auto.offset.reset": "smallest",
           "realtime.segment.flush.threshold.rows": "0",
@@ -592,7 +596,7 @@ Table `events_part_1`:
           "stream.kafka.topic.name": "events",
           "stream.kafka.partition.ids": "1",
           "stream.kafka.decoder.class.name": "org.apache.pinot.plugin.inputformat.json.JSONMessageDecoder",
-          "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory",
+          "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka30.KafkaConsumerFactory",
           "stream.kafka.broker.list": "kafka:9092",
           "stream.kafka.consumer.prop.auto.offset.reset": "smallest",
           "realtime.segment.flush.threshold.rows": "0",
@@ -640,7 +644,7 @@ Example `streamConfigs`:
   "streamType": "kafka",
   "stream.kafka.topic.name": "my-protobuf-topic",
   "stream.kafka.decoder.class.name": "org.apache.pinot.plugin.inputformat.protobuf.ProtoBufMessageDecoder",
-  "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory",
+  "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka30.KafkaConsumerFactory",
   "stream.kafka.broker.list": "kafka:9092",
   "stream.kafka.decoder.prop.descriptorFile": "/path/to/my_message.desc",
   "stream.kafka.decoder.prop.protoClassName": "mypackage.MyMessage"
@@ -665,7 +669,7 @@ Example `streamConfigs`:
   "streamType": "kafka",
   "stream.kafka.topic.name": "my-protobuf-topic",
   "stream.kafka.decoder.class.name": "org.apache.pinot.plugin.inputformat.protobuf.ProtoBufCodeGenMessageDecoder",
-  "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory",
+  "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka30.KafkaConsumerFactory",
   "stream.kafka.broker.list": "kafka:9092",
   "stream.kafka.decoder.prop.jarFile": "/path/to/my-protobuf-classes.jar",
   "stream.kafka.decoder.prop.protoClassName": "com.example.proto.MyMessage"
@@ -696,7 +700,7 @@ Example `streamConfigs`:
   "streamType": "kafka",
   "stream.kafka.topic.name": "my-protobuf-topic",
   "stream.kafka.decoder.class.name": "org.apache.pinot.plugin.inputformat.protobuf.KafkaConfluentSchemaRegistryProtoBufMessageDecoder",
-  "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory",
+  "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka30.KafkaConsumerFactory",
   "stream.kafka.broker.list": "kafka:9092",
   "stream.kafka.decoder.prop.schema.registry.rest.url": "http://schema-registry:8081"
 }
@@ -719,7 +723,7 @@ Example `streamConfigs`:
   "streamType": "kafka",
   "stream.kafka.topic.name": "my-arrow-topic",
   "stream.kafka.decoder.class.name": "org.apache.pinot.plugin.inputformat.arrow.ArrowMessageDecoder",
-  "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory",
+  "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka30.KafkaConsumerFactory",
   "stream.kafka.broker.list": "kafka:9092",
   "stream.kafka.decoder.prop.arrow.allocator.limit": "536870912"
 }

--- a/manage-data/data-import/pinot-stream-ingestion/kafka-connector-versions.md
+++ b/manage-data/data-import/pinot-stream-ingestion/kafka-connector-versions.md
@@ -1,0 +1,112 @@
+---
+description: >-
+  Choose the right Apache Kafka connector version for your Pinot deployment.
+---
+
+# Kafka Connector Versions
+
+Apache Pinot provides multiple Kafka connector versions to match different Kafka broker deployments. Choose the connector that matches your Kafka cluster version.
+
+## Available Connectors
+
+| Connector Plugin | Kafka Client Version | Notes |
+|---|---|---|
+| `pinot-kafka-3.0` | 3.9.x | Recommended for Kafka 3.x clusters. Requires Scala dependency. |
+| `pinot-kafka-4.0` | 4.1.x | Recommended for Kafka 4.x clusters (KRaft mode). Pure Java — no Scala dependency. |
+
+{% hint style="warning" %}
+The `pinot-kafka-2.0` (kafka20) plugin is deprecated. If your table config references `org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory`, you should migrate to either `kafka30` or `kafka40`.
+{% endhint %}
+
+## Kafka 4.0 Connector
+
+The Kafka 4.0 connector (`pinot-kafka-4.0`) supports Apache Kafka 4.x brokers running in **KRaft mode** (ZooKeeper-free). It uses pure Java Kafka clients with no Scala dependency, resulting in a smaller deployment footprint.
+
+### When to use Kafka 4.0
+
+- Your Kafka cluster runs Kafka 4.0+ with KRaft mode
+- You want to eliminate the Scala transitive dependency
+- You are deploying new Pinot clusters against modern Kafka infrastructure
+
+### Configuration
+
+The Kafka 4.0 connector uses the same configuration properties as the Kafka 3.0 connector. The only difference is the `stream.kafka.consumer.factory.class.name`:
+
+```json
+{
+  "streamConfigs": {
+    "streamType": "kafka",
+    "stream.kafka.topic.name": "your-topic",
+    "stream.kafka.broker.list": "kafka:9092",
+    "stream.kafka.consumer.type": "lowlevel",
+    "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka40.KafkaConsumerFactory",
+    "stream.kafka.decoder.class.name": "org.apache.pinot.plugin.stream.kafka.KafkaJSONMessageDecoder",
+    "realtime.segment.flush.threshold.rows": "0",
+    "realtime.segment.flush.threshold.time": "24h",
+    "realtime.segment.flush.threshold.segment.size": "100M"
+  }
+}
+```
+
+### Migration from Kafka 2.0/3.0
+
+To migrate from an older Kafka connector to Kafka 4.0:
+
+1. Update the consumer factory class name in your table configuration:
+
+| From | To |
+|---|---|
+| `org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory` | `org.apache.pinot.plugin.stream.kafka40.KafkaConsumerFactory` |
+| `org.apache.pinot.plugin.stream.kafka30.KafkaConsumerFactory` | `org.apache.pinot.plugin.stream.kafka40.KafkaConsumerFactory` |
+
+2. Ensure the `pinot-kafka-4.0` plugin JAR is available in your Pinot plugin directory.
+
+3. All other `stream.kafka.*` configuration properties remain the same.
+
+{% hint style="info" %}
+The Kafka 4.0 connector is fully compatible with all existing Kafka consumer configuration properties including SSL/TLS, SASL authentication, isolation levels, and Schema Registry integration. See the [main Kafka ingestion guide](import-from-apache-kafka.md) for detailed configuration examples.
+{% endhint %}
+
+## Kafka 3.0 Connector
+
+The Kafka 3.0 connector (`pinot-kafka-3.0`) supports Apache Kafka 3.x brokers. This is the most widely deployed connector version.
+
+### Configuration
+
+```json
+{
+  "streamConfigs": {
+    "streamType": "kafka",
+    "stream.kafka.topic.name": "your-topic",
+    "stream.kafka.broker.list": "kafka:9092",
+    "stream.kafka.consumer.type": "lowlevel",
+    "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka30.KafkaConsumerFactory",
+    "stream.kafka.decoder.class.name": "org.apache.pinot.plugin.stream.kafka.KafkaJSONMessageDecoder"
+  }
+}
+```
+
+## Common Configuration Properties
+
+All Kafka connector versions share the same configuration properties. See [Ingest streaming data from Apache Kafka](import-from-apache-kafka.md) for the complete configuration reference, including:
+
+- SSL/TLS setup
+- SASL authentication
+- Schema Registry integration (Avro, JSON Schema, Protobuf)
+- Consumer tuning properties
+- Isolation levels (`read_committed` / `read_uncommitted`)
+
+## Passing Native Kafka Consumer Properties
+
+You can pass any native Kafka consumer configuration property using the `stream.kafka.consumer.prop.` prefix:
+
+```json
+{
+  "streamConfigs": {
+    "stream.kafka.consumer.prop.auto.offset.reset": "smallest",
+    "stream.kafka.consumer.prop.max.poll.records": "500",
+    "stream.kafka.consumer.prop.fetch.min.bytes": "100000",
+    "stream.kafka.consumer.prop.session.timeout.ms": "30000"
+  }
+}
+```

--- a/operators/operating-pinot/tuning/segment-pruning.md
+++ b/operators/operating-pinot/tuning/segment-pruning.md
@@ -1,0 +1,172 @@
+---
+description: >-
+  Understand how Pinot prunes irrelevant segments to reduce query latency and resource usage.
+---
+
+# Segment Pruning
+
+Segment pruning is a query optimization technique that eliminates irrelevant segments before scanning data. By skipping segments that cannot contain matching records, Pinot significantly reduces query latency, I/O, and CPU usage.
+
+Pruning happens at two levels: **broker-side** (during query routing) and **server-side** (during query execution).
+
+## Broker-Side Pruning
+
+The broker prunes segments before dispatching queries to servers. This reduces the number of segments that servers need to process. Configure broker-side pruning in the table's `routing` configuration.
+
+### Time Pruning
+
+Time pruning skips segments whose time range does not overlap with the query's time filter. This is the most commonly used pruning strategy for time-series workloads.
+
+**Configuration:**
+
+```json
+{
+  "routing": {
+    "segmentPrunerTypes": ["time"]
+  }
+}
+```
+
+**Requirements:**
+- The schema must define a primary time column (`dateTimeFieldSpecs` with `"granularity": "1:MILLISECONDS:EPOCH"` or similar)
+- Data should be ingested in approximate chronological order for best results
+
+**Supported filter operators:** `=`, `<`, `<=`, `>`, `>=`, `RANGE`, `BETWEEN`, `AND`, `OR`
+
+**Example query that benefits from time pruning:**
+
+```sql
+SELECT count(*) FROM events
+WHERE ts > 1700000000000 AND ts < 1700100000000
+```
+
+{% hint style="info" %}
+Time pruning is more selective when data is strictly time-ordered. With out-of-order data, segments may have overlapping time ranges, reducing pruning effectiveness.
+{% endhint %}
+
+### Partition Pruning
+
+Partition pruning skips segments that do not contain records matching the query's partition column filter. This is effective for queries that filter on a partitioned column.
+
+**Configuration:**
+
+First, define the partition scheme in the table's index config:
+
+```json
+{
+  "tableIndexConfig": {
+    "segmentPartitionConfig": {
+      "columnPartitionMap": {
+        "memberId": {
+          "functionName": "Modulo",
+          "numPartitions": 8
+        }
+      }
+    }
+  },
+  "routing": {
+    "segmentPrunerTypes": ["partition"]
+  }
+}
+```
+
+**Supported partition functions:** `Modulo`, `Murmur`, `ByteArray`, `HashCode`
+
+**Supported filter operators:** `=` (equality), `IN`
+
+**Example query that benefits from partition pruning:**
+
+```sql
+SELECT * FROM userEvents
+WHERE memberId = 12345
+```
+
+{% hint style="tip" %}
+For maximum partition pruning effectiveness, ensure each segment contains data from only one partition. When using Kafka, configure the Kafka topic partitioning to match the Pinot partition configuration.
+{% endhint %}
+
+### Combining Pruners
+
+You can enable both time and partition pruning simultaneously:
+
+```json
+{
+  "routing": {
+    "segmentPrunerTypes": ["partition", "time"]
+  }
+}
+```
+
+## Server-Side Pruning
+
+Server-side pruning happens after the broker routes the query but before the server scans segment data. These pruners use segment-level metadata and indexes.
+
+### Column Value Pruning
+
+Prunes segments based on min/max column statistics stored in segment metadata. If a query filters on a column value outside a segment's min/max range, that segment is skipped.
+
+This pruner works automatically and requires no special configuration. Column statistics are maintained as part of the segment metadata.
+
+### Bloom Filter Pruning
+
+When a [Bloom filter index](../../../basics/indexing/bloom-filter.md) is configured on a column, the server uses it to prune segments that definitely do not contain a queried value. This is especially effective for high-cardinality equality lookups.
+
+**Configuration** (in `fieldConfigList`):
+
+```json
+{
+  "fieldConfigList": [
+    {
+      "name": "userId",
+      "indexes": {
+        "bloom": {
+          "fpp": 0.05,
+          "maxSizeInBytes": 1048576
+        }
+      }
+    }
+  ]
+}
+```
+
+{% hint style="info" %}
+Bloom filter pruning for `IN` clauses is limited to 10 values or fewer to minimize overhead.
+{% endhint %}
+
+## Multi-Stage Query Engine (MSE)
+
+The multi-stage query engine supports broker-side pruning via the `useBrokerPruning` query option (enabled by default):
+
+```sql
+SET "useBrokerPruning" = true;
+SELECT count(*) FROM events WHERE ts > 1700000000000
+```
+
+When the [physical optimizer](../../../users/user-guide-query/multi-stage-query/physical-optimizer.md) is enabled, time and partition pruning are automatically applied to the Leaf Stage of multi-stage queries.
+
+## Monitoring Pruning Effectiveness
+
+Use the following metrics to assess pruning effectiveness:
+
+| Metric | Description |
+|---|---|
+| `SEGMENT_PRUNING` | Time spent pruning segments (part of server query latency) |
+| `NUM_SEGMENTS_PRUNED_BY_VALUE` | Number of segments pruned by value-based pruning |
+| `numSegmentsQueried` | Segments sent to servers by the broker |
+| `numSegmentsProcessed` | Segments actually scanned by servers |
+
+A large gap between `numSegmentsQueried` and `numSegmentsProcessed` indicates that server-side pruning is doing significant work. If `numSegmentsQueried` is close to the total segment count, consider enabling broker-side pruning.
+
+**Diagnosis:** If `NUM_DOCS_SCANNED` or `NUM_ENTRIES_SCANNED_POST_FILTER` is high relative to the result set, review:
+1. Whether time pruning is enabled and effective
+2. Whether the table would benefit from partitioning
+3. Whether bloom filters would help for high-cardinality equality lookups
+
+## Best Practices
+
+1. **Always enable time pruning** for tables with a time column — it has minimal overhead and significant benefit
+2. **Partition tables** on frequently filtered columns (e.g., tenant ID, user ID) for equality-based queries
+3. **Match Kafka partitioning** with Pinot partitioning for real-time tables to ensure segments contain single partitions
+4. **Use bloom filters** on high-cardinality columns used in equality lookups (e.g., UUIDs, session IDs)
+5. **Ingest data in time order** when possible, to maximize time pruning selectivity
+6. **Monitor pruning metrics** to identify tables where pruning could be improved


### PR DESCRIPTION
## Summary

- **New: Kafka Connector Versions guide** — Documents the Kafka 4.0 connector (`pinot-kafka-4.0`) which supports KRaft-mode Kafka 4.x clusters with pure Java clients (no Scala dependency). Includes migration guide from deprecated kafka20/kafka30 plugins.
- **New: Segment Pruning guide** — Comprehensive documentation of broker-side pruning (time, partition) and server-side pruning (column value, bloom filter), including MSE support, monitoring metrics, and best practices.
- **Fix: Update deprecated kafka20 references** — Replaces all 12 occurrences of `kafka20.KafkaConsumerFactory` with `kafka30.KafkaConsumerFactory` in the main Kafka ingestion doc, and adds an info hint linking to the new connector versions page.

### Cross-checked against source code

All new documentation was verified against the `apache/pinot` source:

| Feature | Source Location | Verified |
|---------|----------------|----------|
| Kafka 4.0 connector | `pinot-plugins/pinot-stream-ingestion/pinot-kafka-4.0/` | Uses Kafka client 4.1.1, pure Java (no Scala) |
| Kafka 4.0 factory class | `KafkaConsumerFactory.java` | `org.apache.pinot.plugin.stream.kafka40.KafkaConsumerFactory` |
| kafka20 deprecation | No `pinot-kafka-2.0` module exists in current source | Confirmed removed |
| Time segment pruner | `pinot-broker/.../segmentpruner/TimeSegmentPruner.java` | Supports RANGE, =, <, <=, >, >= |
| Partition segment pruner | `pinot-broker/.../segmentpruner/SinglePartitionColumnSegmentPruner.java` | Supports =, IN with Modulo/Murmur/ByteArray/HashCode |
| Bloom filter pruning | `pinot-segment-local/.../BloomFilterSegmentPruner.java` | IN limited to 10 values |
| Column value pruning | `pinot-core/.../ColumnValueSegmentPruner.java` | Uses min/max metadata |
| MSE broker pruning | `useBrokerPruning` query option | Default true |

## Test plan

- [ ] Verify all internal links resolve correctly
- [ ] Confirm Kafka 4.0 factory class name matches source code
- [ ] Review segment pruning metrics against monitoring docs
- [ ] Check that updated kafka30 references work with current Pinot versions
