### PR TITLE
Replace deprecated kafka20 refs and remove stream.kafka.zk.broker.url

### DIFF
--- a/configuration-reference/table.md
+++ b/configuration-reference/table.md
@@ -347,7 +347,6 @@ Here's an example table config for a real-time table. **All the fields from the 
         "stream.kafka.decoder.prop.schema.registry.rest.url": "XXXX",
         "stream.kafka.decoder.prop.schema.registry.schema.name": "XXXX",
         "stream.kafka.topic.name": "XXXX",
-        "stream.kafka.zk.broker.url": "XXXX",
         "streamType": "kafka"
       }]
     }

--- a/manage-data/data-import/pinot-file-system/amazon-s3.md
+++ b/manage-data/data-import/pinot-file-system/amazon-s3.md
@@ -12,7 +12,7 @@ Enable the [Amazon S3](https://aws.amazon.com/s3/) file system backend by includ
 ```
 
 {% hint style="info" %}
-By default Pinot loads all the plugins, so you can just drop this plugin there. Also, if you specify `-Dplugins.include`, you need to put all the plugins you want to use, e.g. `pinot-json`, `pinot-avro` , `pinot-kafka-2.0...`
+By default Pinot loads all the plugins, so you can just drop this plugin there. Also, if you specify `-Dplugins.include`, you need to put all the plugins you want to use, e.g. `pinot-json`, `pinot-avro` , `pinot-kafka-3.0...`
 {% endhint %}
 
 You can configure the S3 file system using the following options:

--- a/manage-data/data-import/pinot-file-system/import-from-adls-azure.md
+++ b/manage-data/data-import/pinot-file-system/import-from-adls-azure.md
@@ -13,7 +13,7 @@ Enable the Azure Data Lake Storage using the `pinot-adls` plugin. In the control
 ```
 
 {% hint style="info" %}
-By default Pinot loads all the plugins, so you can just drop this plugin there. Also, if you specify `-Dplugins.include`, you need to put all the plugins you want to use, e.g. `pinot-json`, `pinot-avro` , `pinot-kafka-2.0...`
+By default Pinot loads all the plugins, so you can just drop this plugin there. Also, if you specify `-Dplugins.include`, you need to put all the plugins you want to use, e.g. `pinot-json`, `pinot-avro` , `pinot-kafka-3.0...`
 {% endhint %}
 
 Azure Blob Storage provides the following options:

--- a/manage-data/data-import/pinot-file-system/import-from-gcp.md
+++ b/manage-data/data-import/pinot-file-system/import-from-gcp.md
@@ -11,7 +11,7 @@ Enable the [Google Cloud Storage](https://cloud.google.com/products/storage/) us
 ```
 
 {% hint style="info" %}
-By default Pinot loads all the plugins, so you can just drop this plugin there. Also, if you specify `-Dplugins.include`, you need to put all the plugins you want to use, e.g. `pinot-json`, `pinot-avro` , `pinot-kafka-2.0...`
+By default Pinot loads all the plugins, so you can just drop this plugin there. Also, if you specify `-Dplugins.include`, you need to put all the plugins you want to use, e.g. `pinot-json`, `pinot-avro` , `pinot-kafka-3.0...`
 {% endhint %}
 
 GCP file systems provides the following options:

--- a/manage-data/data-import/pinot-file-system/import-from-hdfs.md
+++ b/manage-data/data-import/pinot-file-system/import-from-hdfs.md
@@ -11,7 +11,7 @@ Enable the [Hadoop distributed file system (HDFS)](https://hadoop.apache.org/) u
 ```
 
 {% hint style="info" %}
-By default Pinot loads all the plugins, so you can just drop this plugin there. Also, if you specify `-Dplugins.include`, you need to put all the plugins you want to use, e.g. `pinot-json`, `pinot-avro` , `pinot-kafka-2.0...`
+By default Pinot loads all the plugins, so you can just drop this plugin there. Also, if you specify `-Dplugins.include`, you need to put all the plugins you want to use, e.g. `pinot-json`, `pinot-avro` , `pinot-kafka-3.0...`
 {% endhint %}
 
 HDFS implementation provides the following options:

--- a/manage-data/data-import/pinot-stream-ingestion/import-from-apache-kafka.md
+++ b/manage-data/data-import/pinot-stream-ingestion/import-from-apache-kafka.md
@@ -302,7 +302,6 @@ Here is an example config which uses SSL based authentication to talk with kafka
         "stream.kafka.topic.name": "transcript-topic",
         "stream.kafka.decoder.class.name": "org.apache.pinot.plugin.inputformat.avro.confluent.KafkaConfluentSchemaRegistryAvroMessageDecoder",
         "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka30.KafkaConsumerFactory",
-        "stream.kafka.zk.broker.url": "pinot-zookeeper:2181/kafka",
         "stream.kafka.broker.list": "localhost:9092",
         "schema.registry.url": "",
         "security.protocol": "SSL",
@@ -419,7 +418,6 @@ For example,
         "stream.kafka.topic.name": "transcript-topic",
         "stream.kafka.decoder.class.name": "org.apache.pinot.plugin.inputformat.avro.confluent.KafkaConfluentSchemaRegistryAvroMessageDecoder",
         "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka30.KafkaConsumerFactory",
-        "stream.kafka.zk.broker.url": "pinot-zookeeper:2181/kafka",
         "stream.kafka.broker.list": "kafka:9092",
         "stream.kafka.isolation.level": "read_committed"
       }

--- a/manage-data/data-import/upsert-and-dedup/upsert.md
+++ b/manage-data/data-import/upsert-and-dedup/upsert.md
@@ -721,7 +721,6 @@ Putting these together, you can find the table configurations of the quick start
           "stream.kafka.topic.name": "upsertMeetupRSVPEvents",
           "stream.kafka.decoder.class.name": "org.apache.pinot.plugin.inputformat.json.JSONMessageDecoder",
           "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka30.KafkaConsumerFactory",
-          "stream.kafka.zk.broker.url": "localhost:2181/kafka",
           "stream.kafka.broker.list": "localhost:19092"
         }
       ]
@@ -798,7 +797,6 @@ Putting these together, you can find the table configurations of the quick start
           "stream.kafka.topic.name": "upsertPartialMeetupRSVPEvents",
           "stream.kafka.decoder.class.name": "org.apache.pinot.plugin.inputformat.json.JSONMessageDecoder",
           "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka30.KafkaConsumerFactory",
-          "stream.kafka.zk.broker.url": "localhost:2181/kafka",
           "stream.kafka.broker.list": "localhost:19092"
         }
       ]


### PR DESCRIPTION
## Summary
- Replace all `org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory` references with `kafka30` in config examples across 12 files
- Remove deprecated `stream.kafka.zk.broker.url` config lines from JSON/YAML examples (6 files)
- Update `pinot-kafka-2.0` artifact references to `pinot-kafka-3.0` in file system plugin docs (4 files)
- Fix KafkaConsumerFactory GitHub link in write-your-stream.md to point to kafka-3.0 source

Migration/deprecation docs (kafka-connector-versions.md, import-from-apache-kafka.md, stream-connector-matrix.md) intentionally retain kafka20 references to guide users through migration.

## Test plan
- [ ] Verify `grep -rn "kafka20" --include="*.md" --include="*.yaml"` returns only migration/deprecation docs
- [ ] Verify `grep -rn "stream.kafka.zk.broker.url" --include="*.md" --include="*.yaml"` returns no results outside .unused/
- [ ] Spot-check JSON examples still parse correctly (no trailing commas introduced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)