### PR TITLE
docs: add missing plugin documentation for metrics, environment, decoders, Arrow, and Minion tasks

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -72,6 +72,7 @@
   * [Ingest from Apache Pulsar](manage-data/data-import/pinot-stream-ingestion/apache-pulsar.md)
   * [Configure Indexes](manage-data/data-import/pinot-stream-ingestion/configure-indexes.md)
   * [Stream Ingestion with CLP](manage-data/data-import/pinot-stream-ingestion/clp.md)
+  * [Confluent Schema Registry Decoders](manage-data/data-import/pinot-stream-ingestion/confluent-schema-registry-decoders.md)
 * [Upsert and Dedup](manage-data/data-import/upsert-and-dedup/README.md)
   * [Offline Table Upsert](manage-data/data-import/upsert-and-dedup/offline-table-upsert.md)
   * [Stream Ingestion with Upsert](manage-data/data-import/upsert-and-dedup/upsert.md)
@@ -247,6 +248,8 @@
 * [Plugin Reference](configuration-reference/plugin-reference/README.md)
   * [Stream Ingestion Connectors](configuration-reference/plugin-reference/stream-ingestion-connectors.md)
   * [Stream Connector Version Matrix](configuration-reference/plugin-reference/stream-connector-matrix.md)
+  * [Metrics Plugins](configuration-reference/plugin-reference/metrics-plugins.md)
+  * [Environment Provider](configuration-reference/plugin-reference/environment-provider.md)
 
 ## Functions
 
@@ -493,6 +496,7 @@
     * [Segment Uploader Plugin](developers/plugin-architecture/write-custom-plugins/segment-uploader-plugin.md)
     * [Segment Writer Plugin](developers/plugin-architecture/write-custom-plugins/segment-writer-plugin.md)
     * [Metrics Plugin](developers/plugin-architecture/write-custom-plugins/metrics-plugin.md)
+    * [Minion Task Plugin](developers/plugin-architecture/write-custom-plugins/minion-task-plugin.md)
 * [Design Documents](developers/design-documents/README.md)
   * [Segment Writer API](developers/design-documents/segment-writer-api.md)
 

--- a/configuration-reference/plugin-reference/environment-provider.md
+++ b/configuration-reference/plugin-reference/environment-provider.md
@@ -1,0 +1,61 @@
+---
+description: >-
+  Configure cloud environment providers for automatic Pinot instance configuration.
+---
+
+# Environment Provider Plugins
+
+Environment Provider plugins allow Pinot to discover cloud-specific instance metadata at startup. This metadata is used to configure failure domains, availability zones, and other cloud-specific settings that improve data placement and fault tolerance.
+
+## Available Implementations
+
+| Plugin | Class Name | Cloud Provider |
+|--------|-----------|---------------|
+| **Azure** | `org.apache.pinot.plugin.provider.AzureEnvironmentProvider` | Microsoft Azure |
+
+## Azure Environment Provider
+
+The Azure Environment Provider queries the [Azure Instance Metadata Service (IMDS)](https://learn.microsoft.com/en-us/azure/virtual-machines/instance-metadata-service) to retrieve the platform fault domain for the current VM. This information is used by Pinot's Helix-based cluster management to distribute instances across Azure failure domains for improved fault tolerance.
+
+### Configuration
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `maxRetry` | Integer | Yes | Maximum number of HTTP retries (must be > 0) |
+| `imdsEndpoint` | String | Yes | Azure IMDS endpoint URL |
+| `connectionTimeoutMillis` | Integer | Yes | HTTP connection timeout in milliseconds |
+| `requestTimeoutMillis` | Integer | Yes | HTTP request/response timeout in milliseconds |
+
+### Example Configuration
+
+```properties
+pinot.server.environment.provider.className=org.apache.pinot.plugin.provider.AzureEnvironmentProvider
+pinot.server.environment.provider.maxRetry=3
+pinot.server.environment.provider.imdsEndpoint=http://169.254.169.254/metadata/instance?api-version=2020-09-01
+pinot.server.environment.provider.connectionTimeoutMillis=5000
+pinot.server.environment.provider.requestTimeoutMillis=5000
+```
+
+### How It Works
+
+1. At startup, the provider sends an HTTP GET request to the Azure IMDS endpoint
+2. The IMDS response contains VM metadata including the `compute.platformFaultDomain` field
+3. The failure domain value is returned and used by Helix to configure the instance
+4. This enables Pinot to distribute replicas across fault domains, improving availability during Azure infrastructure failures
+
+{% hint style="info" %}
+The Azure IMDS endpoint (`169.254.169.254`) is only accessible from within an Azure VM. This plugin should only be enabled when running Pinot on Azure infrastructure.
+{% endhint %}
+
+## Writing a Custom Environment Provider
+
+To create a custom environment provider, implement the `PinotEnvironmentProvider` interface:
+
+```java
+public interface PinotEnvironmentProvider {
+    void init(PinotConfiguration pinotConfiguration);
+    String getFailureDomain();
+}
+```
+
+See the [Plugin Architecture](../../developers/plugin-architecture/README.md) docs for general guidance on building Pinot plugins.

--- a/configuration-reference/plugin-reference/metrics-plugins.md
+++ b/configuration-reference/plugin-reference/metrics-plugins.md
@@ -1,0 +1,109 @@
+---
+description: >-
+  Configure Pinot's metrics system using pluggable metrics backends.
+---
+
+# Metrics Plugins
+
+Apache Pinot uses a pluggable metrics factory to support multiple metrics backends. Each Pinot component (Server, Broker, Controller, Minion) can be independently configured with a metrics implementation.
+
+## Available Implementations
+
+| Plugin | Class Name | Description |
+|--------|-----------|-------------|
+| **Yammer** (default) | `org.apache.pinot.plugin.metrics.yammer.YammerMetricsFactory` | Lightweight, default metrics implementation |
+| **Dropwizard** | `org.apache.pinot.plugin.metrics.dropwizard.DropwizardMetricsFactory` | Full Dropwizard Metrics integration with sliding time window reservoirs |
+| **Compound** | `org.apache.pinot.plugin.metrics.compound.CompoundPinotMetricsFactory` | Registers metrics in multiple backends simultaneously |
+
+## Configuration
+
+Configure the metrics factory for any component using:
+
+```properties
+pinot.<component>.metrics.factory.className=<factory-class-name>
+```
+
+Where `<component>` is one of: `server`, `broker`, `controller`, `minion`.
+
+### Yammer Metrics (Default)
+
+The default metrics backend. No additional configuration required.
+
+```properties
+pinot.server.metrics.factory.className=org.apache.pinot.plugin.metrics.yammer.YammerMetricsFactory
+```
+
+### Dropwizard Metrics
+
+Provides full Dropwizard Metrics library integration with sliding 15-minute time window reservoirs, detailed histograms and timers, and JMX reporting.
+
+```properties
+pinot.server.metrics.factory.className=org.apache.pinot.plugin.metrics.dropwizard.DropwizardMetricsFactory
+```
+
+**Additional properties:**
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| `pinot.<component>.metrics.dropwizard.domain` | `org.apache.pinot.common.metrics` | JMX domain name for metrics |
+
+**Example:**
+
+```properties
+pinot.server.metrics.factory.className=org.apache.pinot.plugin.metrics.dropwizard.DropwizardMetricsFactory
+pinot.server.metrics.dropwizard.domain=my.company.pinot.metrics
+```
+
+### Compound Metrics (Multi-Backend)
+
+The Compound metrics plugin registers metrics in multiple backends simultaneously. This is useful for comparing metric implementations or reporting to multiple monitoring systems.
+
+```properties
+pinot.server.metrics.factory.className=org.apache.pinot.plugin.metrics.compound.CompoundPinotMetricsFactory
+```
+
+**Additional properties:**
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| `pinot.<component>.metrics.compound.algorithm` | `CLASSPATH` | Discovery algorithm: `CLASSPATH`, `SERVICE_LOADER`, or `LIST` |
+| `pinot.<component>.metrics.compound.ignored` | (empty) | Comma-separated list of factory class names to exclude |
+| `pinot.<component>.metrics.compound.list` | (empty) | Comma-separated list of factory class names to include (only with `algorithm=LIST`) |
+
+**Example: Use both Yammer and Dropwizard:**
+
+```properties
+pinot.server.metrics.factory.className=org.apache.pinot.plugin.metrics.compound.CompoundPinotMetricsFactory
+pinot.server.metrics.compound.algorithm=LIST
+pinot.server.metrics.compound.list=org.apache.pinot.plugin.metrics.yammer.YammerMetricsFactory,org.apache.pinot.plugin.metrics.dropwizard.DropwizardMetricsFactory
+```
+
+**Example: Classpath discovery excluding Yammer:**
+
+```properties
+pinot.server.metrics.factory.className=org.apache.pinot.plugin.metrics.compound.CompoundPinotMetricsFactory
+pinot.server.metrics.compound.algorithm=CLASSPATH
+pinot.server.metrics.compound.ignored=org.apache.pinot.plugin.metrics.yammer.YammerMetricsFactory
+```
+
+{% hint style="warning" %}
+When using Compound metrics, ensure JMX MBean names don't conflict between registries. Conflicting MBean names may cause unpredictable metric values.
+{% endhint %}
+
+## Metric Types
+
+Pinot exposes the following metric primitives through all backends:
+
+| Type | Description | Example |
+|------|-------------|---------|
+| **Counter** | Discrete event counts | Total queries processed |
+| **Meter** | Event rates | Queries per second |
+| **Timer** | Latency and throughput | Query execution time |
+| **Histogram** | Value distributions | Query result sizes |
+| **Gauge** | Point-in-time values | Segment count, heap usage |
+
+## JMX Reporting
+
+All metrics implementations include a JMX reporter enabled by default. The `JmxReporterMetricsRegistryRegistrationListener` is automatically registered when the metrics system initializes.
+
+To configure additional metrics reporting (e.g., Prometheus, Grafana), see [Monitor Pinot Using Prometheus and Grafana](../../operators/tutorials/monitor-pinot-using-prometheus-and-grafana.md).

--- a/developers/plugin-architecture/write-custom-plugins/minion-task-plugin.md
+++ b/developers/plugin-architecture/write-custom-plugins/minion-task-plugin.md
@@ -1,0 +1,200 @@
+---
+description: >-
+  Write a custom Minion task plugin with a task generator and task executor.
+---
+
+# Minion Task Plugin
+
+Minion tasks execute background maintenance and data processing jobs in Pinot. Each task type has two components: a **Task Generator** (runs on the Controller) that creates task configurations, and a **Task Executor** (runs on the Minion) that performs the work.
+
+## Architecture
+
+```
+Controller                          Minion
+┌────────────────────┐             ┌────────────────────┐
+│  PinotTaskGenerator│  ─ Helix ─> │ PinotTaskExecutor  │
+│  - generateTasks() │  schedules  │ - executeTask()    │
+│  - getTaskType()   │             │ - cancel()         │
+└────────────────────┘             └────────────────────┘
+```
+
+1. The Controller runs the Task Generator on a schedule or via ad-hoc API call
+2. The Generator creates `PinotTaskConfig` objects describing the work
+3. The Controller schedules tasks via Helix
+4. Minion instances pick up tasks based on tag/routing
+5. The Minion executes the task using the Task Executor
+6. Results are returned to the Controller
+
+## Step 1: Implement the Task Executor
+
+The executor runs on the Minion and performs the actual work.
+
+### Task Executor Factory
+
+```java
+import org.apache.pinot.minion.executor.PinotTaskExecutorFactory;
+import org.apache.pinot.minion.executor.PinotTaskExecutor;
+import org.apache.pinot.spi.annotations.minion.TaskExecutorFactory;
+
+@TaskExecutorFactory(enabled = true)
+public class MyTaskExecutorFactory implements PinotTaskExecutorFactory {
+
+  @Override
+  public void init(MinionTaskZkMetadataManager zkMetadataManager, MinionConf minionConf) {
+    // Initialize resources needed by the executor
+  }
+
+  @Override
+  public String getTaskType() {
+    return "MyCustomTask";  // Must match the generator's task type
+  }
+
+  @Override
+  public PinotTaskExecutor create() {
+    return new MyTaskExecutor();
+  }
+}
+```
+
+### Task Executor
+
+```java
+import org.apache.pinot.minion.executor.PinotTaskExecutor;
+import org.apache.pinot.core.minion.PinotTaskConfig;
+
+public class MyTaskExecutor implements PinotTaskExecutor {
+
+  private volatile boolean _cancelled = false;
+
+  @Override
+  public Object executeTask(PinotTaskConfig pinotTaskConfig) throws Exception {
+    String tableName = pinotTaskConfig.getTableName();
+    Map<String, String> config = pinotTaskConfig.getConfig();
+
+    // Perform the task work here
+    // Check _cancelled periodically for long-running tasks
+
+    return "Task completed successfully";
+  }
+
+  @Override
+  public void cancel() {
+    _cancelled = true;
+  }
+}
+```
+
+{% hint style="info" %}
+The executor factory class must be annotated with `@TaskExecutorFactory(enabled = true)` for auto-registration. The class must be in a package matching `org.apache.pinot.*.plugin.minion.tasks.*`.
+{% endhint %}
+
+## Step 2: Implement the Task Generator
+
+The generator runs on the Controller and decides when and how to create tasks.
+
+```java
+import org.apache.pinot.controller.helix.core.minion.generator.PinotTaskGenerator;
+import org.apache.pinot.spi.annotations.minion.TaskGenerator;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.core.minion.PinotTaskConfig;
+
+@TaskGenerator(enabled = true)
+public class MyTaskGenerator implements PinotTaskGenerator {
+
+  private ClusterInfoAccessor _clusterInfoAccessor;
+
+  @Override
+  public void init(ClusterInfoAccessor clusterInfoAccessor) {
+    _clusterInfoAccessor = clusterInfoAccessor;
+  }
+
+  @Override
+  public String getTaskType() {
+    return "MyCustomTask";  // Must match the executor's task type
+  }
+
+  // Called on schedule for all tables with this task type enabled
+  @Override
+  public List<PinotTaskConfig> generateTasks(List<TableConfig> tableConfigs) {
+    List<PinotTaskConfig> tasks = new ArrayList<>();
+    for (TableConfig tableConfig : tableConfigs) {
+      Map<String, String> taskConfig = new HashMap<>();
+      taskConfig.put("myParam", "myValue");
+
+      tasks.add(new PinotTaskConfig(
+          getTaskType(),
+          tableConfig.getTableName(),
+          taskConfig));
+    }
+    return tasks;
+  }
+
+  // Called for ad-hoc task execution via API
+  @Override
+  public List<PinotTaskConfig> generateTasks(
+      TableConfig tableConfig, Map<String, String> taskConfigs) throws Exception {
+    return List.of(new PinotTaskConfig(
+        getTaskType(),
+        tableConfig.getTableName(),
+        taskConfigs));
+  }
+}
+```
+
+### Optional Generator Overrides
+
+| Method | Default | Description |
+|--------|---------|-------------|
+| `getTaskTimeoutMs(String minionTag)` | 3,600,000 (1 hour) | Task timeout in milliseconds |
+| `getNumConcurrentTasksPerInstance(String minionTag)` | 1 | Max concurrent tasks per Minion |
+| `getMaxAttemptsPerTask(String minionTag)` | 1 (no retry) | Max retry attempts |
+| `getMinionInstanceTag(TableConfig tableConfig)` | `UNTAGGED_MINION_INSTANCE` | Tag for routing tasks to specific Minion instances |
+| `validateTaskConfigs(TableConfig, Schema, Map)` | no-op | Validate task-specific configs at table creation time |
+
+## Step 3: Enable the Task in Table Config
+
+Add the task configuration to the table config:
+
+```json
+{
+  "tableName": "myTable_OFFLINE",
+  "task": {
+    "taskTypeConfigsMap": {
+      "MyCustomTask": {
+        "schedule": "0 0 * * * ?",
+        "myParam": "myValue"
+      }
+    }
+  }
+}
+```
+
+The `schedule` property uses a CRON expression to define when the task generator runs. Without it, the task can only be triggered via the Controller API.
+
+## Step 4: Trigger Tasks via API
+
+To manually trigger task generation:
+
+```bash
+# Generate tasks for all tables with this task type
+POST /tasks/schedule?taskType=MyCustomTask
+
+# Generate tasks for a specific table
+POST /tasks/execute?taskType=MyCustomTask&tableName=myTable_OFFLINE
+```
+
+## Built-in Task Types
+
+Pinot includes several built-in Minion tasks:
+
+| Task Type | Description |
+|-----------|-------------|
+| `RealtimeToOfflineSegmentsTask` | Converts realtime segments to offline segments |
+| `UpsertCompactionTask` | Compacts segments in upsert-enabled tables |
+| `UpsertCompactMergeTask` | Merges and compacts upsert segments |
+| `PurgeTask` | Purges records matching a purge function |
+| `MergeRollupTask` | Merges and rolls up small segments |
+| `SegmentGenerationAndPushTask` | Generates and pushes segments from external data |
+| `RefreshSegmentTask` | Refreshes segments from deep store |
+
+For more details on built-in tasks, see [Minion Merge Rollup Task](../../../operators/operating-pinot/minion-merge-rollup-task.md) and [Upsert Compaction Task](../../../operators/operating-pinot/upsert-compaction-task.md).

--- a/manage-data/data-import/pinot-input-formats.md
+++ b/manage-data/data-import/pinot-input-formats.md
@@ -201,3 +201,25 @@ The reader requires a descriptor file to deserialize the data present in the fil
 ```
 protoc --include_imports --descriptor_set_out=/absolute/path/to/output.desc /absolute/path/to/input.proto
 ```
+
+### Apache Arrow
+
+```
+dataFormat: 'arrow'
+```
+
+The Arrow input format plugin supports reading data in [Apache Arrow IPC streaming format](https://arrow.apache.org/docs/format/Columnar.html#ipc-streaming-format). This is useful for ingesting data from systems that produce Arrow-formatted output.
+
+For stream ingestion, the Arrow decoder converts Arrow columnar batches to Pinot rows:
+
+```
+stream.kafka.decoder.class.name=org.apache.pinot.plugin.inputformat.arrow.ArrowMessageDecoder
+```
+
+**Configuration properties:**
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| `arrow.allocator.limit` | 268435456 (256 MB) | Memory limit for Arrow's off-heap allocator in bytes |
+
+The decoder handles Arrow type conversions automatically: `Text` → `String`, `LocalDateTime` → `Timestamp`, Arrow Maps → flattened `Map<String, Object>`, and Arrow Lists → `List<Object>`. Dictionary-encoded columns are also supported.

--- a/manage-data/data-import/pinot-stream-ingestion/confluent-schema-registry-decoders.md
+++ b/manage-data/data-import/pinot-stream-ingestion/confluent-schema-registry-decoders.md
@@ -1,0 +1,128 @@
+---
+description: >-
+  Decode Avro, JSON, and Protobuf messages from Kafka using Confluent Schema Registry.
+---
+
+# Confluent Schema Registry Decoders
+
+Pinot supports decoding Kafka messages serialized with [Confluent Schema Registry](https://docs.confluent.io/platform/current/schema-registry/index.html) for Avro, JSON Schema, and Protocol Buffers formats. These decoders automatically fetch and cache schemas from the registry, ensuring data is deserialized according to the registered schema.
+
+## Available Decoders
+
+| Format | Decoder Class | Plugin |
+|--------|--------------|--------|
+| **Avro** | `org.apache.pinot.plugin.inputformat.avro.confluent.KafkaConfluentSchemaRegistryAvroMessageDecoder` | `pinot-confluent-avro` |
+| **JSON Schema** | `org.apache.pinot.plugin.inputformat.json.confluent.KafkaConfluentSchemaRegistryJsonMessageDecoder` | `pinot-confluent-json` |
+| **Protocol Buffers** | `org.apache.pinot.plugin.inputformat.protobuf.KafkaConfluentSchemaRegistryProtoBufMessageDecoder` | `pinot-confluent-protobuf` |
+
+## Common Configuration
+
+All Confluent Schema Registry decoders share the same configuration properties:
+
+| Property | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `schema.registry.rest.url` | Yes | — | Confluent Schema Registry REST endpoint URL |
+| `cached.schema.map.capacity` | No | 1000 | Maximum number of schemas to cache locally |
+
+### SSL/TLS Configuration
+
+To connect to a Schema Registry endpoint over SSL/TLS, add properties with the `schema.registry.` prefix:
+
+| Property | Description |
+|----------|-------------|
+| `schema.registry.ssl.truststore.location` | Path to truststore file |
+| `schema.registry.ssl.truststore.password` | Truststore password |
+| `schema.registry.ssl.keystore.location` | Path to keystore file |
+| `schema.registry.ssl.keystore.password` | Keystore password |
+| `schema.registry.ssl.key.password` | Private key password |
+
+## Confluent Avro Decoder
+
+Decodes Avro-serialized Kafka messages with schema managed by Confluent Schema Registry.
+
+```json
+{
+  "streamConfigs": {
+    "streamType": "kafka",
+    "stream.kafka.topic.name": "my-avro-topic",
+    "stream.kafka.broker.list": "kafka:9092",
+    "stream.kafka.consumer.type": "lowlevel",
+    "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka30.KafkaConsumerFactory",
+    "stream.kafka.decoder.class.name": "org.apache.pinot.plugin.inputformat.avro.confluent.KafkaConfluentSchemaRegistryAvroMessageDecoder",
+    "stream.kafka.decoder.prop.schema.registry.rest.url": "http://schema-registry:8081"
+  }
+}
+```
+
+## Confluent JSON Schema Decoder
+
+Decodes JSON messages serialized with Confluent's JSON Schema serializer. Messages include a schema ID header that the decoder uses to fetch the JSON Schema from the registry for validation.
+
+```json
+{
+  "streamConfigs": {
+    "streamType": "kafka",
+    "stream.kafka.topic.name": "my-json-topic",
+    "stream.kafka.broker.list": "kafka:9092",
+    "stream.kafka.consumer.type": "lowlevel",
+    "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka30.KafkaConsumerFactory",
+    "stream.kafka.decoder.class.name": "org.apache.pinot.plugin.inputformat.json.confluent.KafkaConfluentSchemaRegistryJsonMessageDecoder",
+    "stream.kafka.decoder.prop.schema.registry.rest.url": "http://schema-registry:8081"
+  }
+}
+```
+
+{% hint style="info" %}
+The JSON Schema decoder validates incoming messages against the schema registered in Schema Registry. Messages that don't match the magic byte format (non-Confluent messages) are silently dropped.
+{% endhint %}
+
+## Confluent Protobuf Decoder
+
+Decodes Protocol Buffer messages serialized with Confluent's Protobuf serializer. The decoder fetches the `.proto` schema definition from the registry and deserializes the binary payload.
+
+```json
+{
+  "streamConfigs": {
+    "streamType": "kafka",
+    "stream.kafka.topic.name": "my-protobuf-topic",
+    "stream.kafka.broker.list": "kafka:9092",
+    "stream.kafka.consumer.type": "lowlevel",
+    "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka30.KafkaConsumerFactory",
+    "stream.kafka.decoder.class.name": "org.apache.pinot.plugin.inputformat.protobuf.KafkaConfluentSchemaRegistryProtoBufMessageDecoder",
+    "stream.kafka.decoder.prop.schema.registry.rest.url": "http://schema-registry:8081"
+  }
+}
+```
+
+## SSL/TLS Example
+
+To connect to a secured Schema Registry:
+
+```json
+{
+  "streamConfigs": {
+    "stream.kafka.decoder.class.name": "org.apache.pinot.plugin.inputformat.avro.confluent.KafkaConfluentSchemaRegistryAvroMessageDecoder",
+    "stream.kafka.decoder.prop.schema.registry.rest.url": "https://schema-registry:8082",
+    "stream.kafka.decoder.prop.schema.registry.ssl.truststore.location": "/path/to/truststore.jks",
+    "stream.kafka.decoder.prop.schema.registry.ssl.truststore.password": "changeit",
+    "stream.kafka.decoder.prop.schema.registry.ssl.keystore.location": "/path/to/keystore.jks",
+    "stream.kafka.decoder.prop.schema.registry.ssl.keystore.password": "changeit"
+  }
+}
+```
+
+## How Schema Resolution Works
+
+1. Each Confluent-serialized message starts with a magic byte (`0x00`) followed by a 4-byte schema ID
+2. The decoder extracts the schema ID from the message header
+3. The schema is fetched from Schema Registry and cached locally (up to `cached.schema.map.capacity`)
+4. The message payload is deserialized using the resolved schema
+5. Fields are extracted into Pinot's `GenericRow` format for ingestion
+
+Messages without the Confluent magic byte prefix are silently dropped and logged as errors.
+
+## See Also
+
+- [Ingest from Apache Kafka](import-from-apache-kafka.md) — General Kafka ingestion guide
+- [Stream Ingestion Connectors](../../../configuration-reference/plugin-reference/stream-ingestion-connectors.md) — Full connector configuration reference
+- [Supported Data Formats](../pinot-input-formats.md) — All supported input formats


### PR DESCRIPTION
## Summary

Adds documentation for 5 plugin categories that exist in the `apache/pinot` source code but had no user-facing documentation.

### New Documentation

| Document | Plugin(s) Covered | Source Cross-Check |
|----------|------------------|-------------------|
| **Metrics Plugins** (`configuration-reference/plugin-reference/metrics-plugins.md`) | Yammer, Dropwizard, Compound metrics backends | `pinot-plugins/pinot-metrics/` — verified factory classes, config properties, JMX domain setting |
| **Environment Provider** (`configuration-reference/plugin-reference/environment-provider.md`) | Azure IMDS-based failure domain discovery | `pinot-plugins/pinot-environment/pinot-azure/AzureEnvironmentProvider.java` — verified config properties, IMDS endpoint, fault domain extraction |
| **Confluent Schema Registry Decoders** (`manage-data/.../confluent-schema-registry-decoders.md`) | Confluent JSON Schema decoder, Confluent Protobuf decoder (Avro was already documented) | `pinot-plugins/pinot-input-format/pinot-confluent-json/` and `pinot-confluent-protobuf/` — verified decoder class names, SSL properties, schema resolution |
| **Minion Task Plugin** (`developers/.../minion-task-plugin.md`) | Custom task generator + executor development guide | `pinot-minion/.../executor/PinotTaskExecutor.java`, `pinot-controller/.../generator/PinotTaskGenerator.java` — verified interfaces, annotations, method signatures |
| **Apache Arrow format** (appended to `manage-data/.../pinot-input-formats.md`) | Arrow IPC streaming format decoder | `pinot-plugins/pinot-input-format/pinot-arrow/ArrowMessageDecoder.java` — verified allocator config, type mappings |

### Gap Analysis

These plugins were identified as undocumented by doing a systematic diff between all plugin directories in `apache/pinot` source vs. existing documentation pages:

- **Metrics plugins**: 3 implementations (Yammer, Dropwizard, Compound) with zero user docs — only mentioned in release notes
- **Environment provider**: Azure plugin completely undocumented — no search results in docs
- **Confluent JSON/Protobuf decoders**: Only Avro decoder was documented; JSON Schema and Protobuf decoders were missing
- **Arrow input format**: Not listed in the Supported Data Formats page despite having a full plugin implementation
- **Custom Minion task development**: Built-in tasks were documented but no guide existed for writing new task types

## Test plan

- [ ] Verify all internal links resolve correctly
- [ ] Confirm class names match current source code
- [ ] Check SUMMARY.md renders new entries in correct sections
- [ ] Review metrics configuration properties against actual factory init() methods
