### PR TITLE
docs: improve docs navigation and entrypoints

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,100 @@
+# CLAUDE.md
+
+This repository is the GitHub-backed content repo for the Apache Pinot docs site. Treat it as a documentation product, not as a generic Markdown repo.
+
+## What This Repo Is
+
+- The docs site is powered by GitBook.
+- The docs entrypoints are defined in `.gitbook.yaml`:
+  - `README.md` is the root landing page.
+  - `SUMMARY.md` is the navigation tree.
+- Many pages use GitBook-specific markup such as `content-ref`, `hint`, `figure`, and frontmatter blocks. Preserve that syntax unless there is a clear reason to change it.
+- The default PR base branch is `latest`.
+
+## Primary Source Of Truth
+
+- For product behavior, APIs, config keys, planner rules, minion tasks, query options, and function names, the source of truth is the Apache Pinot source repo, not memory and not old docs text.
+- Cross-check facts against a local clone of `apache/pinot` whenever the docs describe shipped behavior.
+- If a local clone is not available, use `gh repo clone apache/pinot ../apache-pinot` or another nearby path.
+- Prefer inspecting code, constants, tests, and integration tests over guessing.
+
+## Repo-Specific Editing Rules
+
+- Keep the docs task-oriented. Favor user journeys such as:
+  - overview
+  - get started
+  - ingest and model data
+  - query and build applications
+  - operate Pinot
+  - develop and extend Pinot
+  - reference
+- When changing information architecture, update all three together when needed:
+  - `README.md`
+  - `SUMMARY.md`
+  - the relevant landing pages for the affected section
+- Every page should be discoverable from either `SUMMARY.md` or a landing page. Hidden pages are usually a docs bug.
+- Do not move or rename files casually. Existing docs URLs may be linked from blog posts, issues, release notes, or the main Pinot repo.
+- If you must change a path, add or update redirects in `.gitbook.yaml` and update internal links in the same change.
+- Prefer adding navigation and landing-page links before doing large file moves.
+- Preserve frontmatter and page titles unless there is a strong reason to change them.
+- Use relative links or GitBook `content-ref` blocks for internal navigation. Avoid hardcoding GitHub blob URLs when an internal docs link will work.
+
+## Known Structural Risks
+
+- Function documentation is split across multiple surfaces:
+  - `functions/`
+  - `functions-1/`
+  - `configuration-reference/functions/`
+- Avoid creating a fourth surface. Prefer improving discoverability and pointing to a canonical page.
+- Top-level docs changes can easily drift into broken navigation if `SUMMARY.md` is not kept in sync.
+- Some pages may exist only because of legacy URLs. Before deleting anything, check whether a redirect would be safer.
+
+## Style
+
+- Follow `contributing/style-guide.md`.
+- Follow the Google developer documentation style guide for anything not covered locally.
+- Pinot-specific wording rule already documented here:
+  - use `star-tree` as an adjective
+  - use `star tree` as a noun
+- Prefer concrete, source-backed statements over marketing language.
+- Call out version caveats explicitly when behavior differs by Pinot release.
+
+## Validation Expectations
+
+There is no obvious local site build command in this repo, so validation is mostly structural and factual.
+
+Always run:
+
+```bash
+git diff --check
+```
+
+When editing links or navigation, also validate that changed links resolve. A lightweight approach is fine, for example checking edited files for `content-ref` targets and relative Markdown links.
+
+When editing facts about Pinot behavior, also validate against source:
+
+- planner rules: query planner constants and tests
+- minion tasks: task generator/executor classes and integration tests
+- query options: constants and request handling code
+- function names/signatures: function classes, enums, and tests
+
+## Git And GitHub Workflow
+
+- Use `gh` for GitHub operations.
+- Base PRs against `latest` unless the repo state clearly requires otherwise.
+- Keep commits clean and purposeful.
+- The repo owner prefers avoiding a pile of incremental commits. If you are asked to commit repeatedly during the same task, prefer amending the in-progress commit instead of stacking noise.
+- In PR descriptions, explain:
+  - what changed for readers
+  - what was structurally reorganized
+  - what was cross-checked against `apache/pinot`
+  - how you validated the change
+
+## Good Default Workflow
+
+1. Read `README.md`, `SUMMARY.md`, `.gitbook.yaml`, and the relevant landing pages.
+2. If the change describes Pinot behavior, inspect the corresponding code in `apache/pinot`.
+3. Make the smallest change that improves discoverability and correctness.
+4. Update navigation and landing pages together when the change affects how users find content.
+5. Run structural validation and source cross-checks.
+6. Open or update a PR against `latest` with a concise explanation of the user-facing impact.

--- a/README.md
+++ b/README.md
@@ -94,3 +94,53 @@ To understand the distributed systems architecture that explains Pinot's operati
 {% content-ref url="basics/architecture.md" %}
 [architecture.md](basics/architecture.md)
 {% endcontent-ref %}
+
+To understand how Pinot accelerates queries, explore the indexing documentation:
+
+{% content-ref url="basics/indexing/README.md" %}
+[README.md](basics/indexing/README.md)
+{% endcontent-ref %}
+
+## Build applications on Pinot
+
+To query Pinot from applications and BI tools, start with the user-facing guides:
+
+{% content-ref url="users/user-guide-query/" %}
+[user-guide-query](users/user-guide-query/)
+{% endcontent-ref %}
+
+{% content-ref url="users/api/" %}
+[README.md](users/api/)
+{% endcontent-ref %}
+
+{% content-ref url="users/clients/" %}
+[README.md](users/clients/)
+{% endcontent-ref %}
+
+## Operate Pinot in production
+
+To run Pinot reliably in production, use the operator guides and troubleshooting reference:
+
+{% content-ref url="operators/operating-pinot/" %}
+[README.md](operators/operating-pinot/)
+{% endcontent-ref %}
+
+{% content-ref url="reference/troubleshooting/" %}
+[README.md](reference/troubleshooting/)
+{% endcontent-ref %}
+
+## Extend and contribute
+
+If you are extending Pinot or contributing back to the project, start here:
+
+{% content-ref url="developers/developers-and-contributors/" %}
+[README.md](developers/developers-and-contributors/)
+{% endcontent-ref %}
+
+{% content-ref url="developers/plugin-architecture/" %}
+[README.md](developers/plugin-architecture/)
+{% endcontent-ref %}
+
+{% content-ref url="contributing/contributing.md" %}
+[contributing.md](contributing/contributing.md)
+{% endcontent-ref %}

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -2,7 +2,7 @@
 
 * [Introduction](README.md)
 
-## Basics
+## Overview
 
 * [Concepts](basics/concepts/README.md)
   * [Pinot storage model](basics/concepts/pinot-storage-model.md)
@@ -23,6 +23,28 @@
       * [Time boundary](basics/concepts/time-boundary.md)
       * [Logical Table](basics/components/table/logical-table.md)
     * [Pinot Data Explorer](basics/components/exploring-pinot.md)
+* [Indexing](basics/indexing/README.md)
+  * [Bloom filter](basics/indexing/bloom-filter.md)
+  * [Dictionary index](basics/indexing/dictionary-index.md)
+  * [Forward index](basics/indexing/forward-index.md)
+  * [FST index](basics/indexing/fst-index.md)
+  * [Geospatial](basics/indexing/geospatial-support.md)
+  * [Inverted index](basics/indexing/inverted-index.md)
+  * [JSON index](basics/indexing/json-index.md)
+  * [Native text index](basics/indexing/native-text-index.md)
+  * [Range index](basics/indexing/range-index.md)
+  * [Star-tree index](basics/indexing/star-tree-index.md)
+  * [Text search support](basics/indexing/text-search-support.md)
+  * [Timestamp index](basics/indexing/timestamp-index.md)
+  * [Vector index](basics/indexing/vector-index.md)
+* [Recipes](basics/recipes/README.md)
+  * [Connect to Streamlit](basics/recipes/streamlit.md)
+  * [Connect to Dash](basics/recipes/dash.md)
+  * [Visualize data with Redash](basics/recipes/redash.md)
+  * [GitHub Events Stream](basics/recipes/github-events-stream.md)
+
+## Get Started
+
 * [Getting Started](basics/getting-started/README.md)
   * [Running Pinot locally](basics/getting-started/running-pinot-locally.md)
   * [Running Pinot in Docker](basics/getting-started/running-pinot-in-docker.md)
@@ -43,49 +65,40 @@
     * [Ingestion FAQ](basics/getting-started/frequent-questions/ingestion-faq.md)
     * [Query FAQ](basics/getting-started/frequent-questions/query-faq.md)
     * [Operations FAQ](basics/getting-started/frequent-questions/operations-faq.md)
-* [Indexing](basics/indexing/README.md)
-  * [Bloom filter](basics/indexing/bloom-filter.md)
-  * [Dictionary index](basics/indexing/dictionary-index.md)
-  * [Forward index](basics/indexing/forward-index.md)
-  * [FST index](basics/indexing/fst-index.md)
-  * [Geospatial](basics/indexing/geospatial-support.md)
-  * [Inverted index](basics/indexing/inverted-index.md)
-  * [JSON index](basics/indexing/json-index.md)
-  * [Native text index](basics/indexing/native-text-index.md)
-  * [Range index](basics/indexing/range-index.md)
-  * [Star-tree index](basics/indexing/star-tree-index.md)
-  * [Text search support](basics/indexing/text-search-support.md)
-  * [Timestamp index](basics/indexing/timestamp-index.md)
-  * [Vector index](basics/indexing/vector-index.md)
-* [Release notes](basics/releases/README.md)
-  * [1.4.0](basics/releases/1.4.0.md)
-  * [1.3.0](basics/releases/1.3.0.md)
-  * [1.2.0](basics/releases/1.2.0.md)
-  * [1.1.0](basics/releases/1.1.0.md)
-  * [1.0.0](basics/releases/1.0.0.md)
-  * [0.12.1](basics/releases/0.12.1.md)
-  * [0.12.0](basics/releases/0.12.0.md)
-  * [0.11.0](basics/releases/0.11.0.md)
-  * [0.10.0](basics/releases/0.10.0.md)
-  * [0.9.3](basics/releases/0.9.3.md)
-  * [0.9.2](basics/releases/0.9.2.md)
-  * [0.9.1](basics/releases/0.9.1.md)
-  * [0.9.0](basics/releases/0.9.0.md)
-  * [0.8.0](basics/releases/0.8.0.md)
-  * [0.7.1](basics/releases/0.7.1.md)
-  * [0.6.0](basics/releases/0.6.0.md)
-  * [0.5.0](basics/releases/0.5.0.md)
-  * [0.4.0](basics/releases/0.4.0.md)
-  * [0.3.0](basics/releases/0.3.0.md)
-  * [0.2.0](basics/releases/0.2.0.md)
-  * [0.1.0](basics/releases/0.1.0.md)
-* [Recipes](basics/recipes/README.md)
-  * [Connect to Streamlit](basics/recipes/streamlit.md)
-  * [Connect to Dash](basics/recipes/dash.md)
-  * [Visualize data with Redash](basics/recipes/redash.md)
-  * [GitHub Events Stream](basics/recipes/github-events-stream.md)
 
-## For Users <a href="#users" id="users"></a>
+## Ingest and Model Data
+
+* [Import Data](manage-data/data-import/README.md)
+  * [SQL Insert Into From Files](manage-data/data-import/from-query-console.md)
+  * [Upload Pinot segment Using CommandLine](manage-data/data-import/segment-upload.md)
+  * [Batch Ingestion](manage-data/data-import/batch-ingestion/README.md)
+    * [Spark](manage-data/data-import/batch-ingestion/spark.md)
+    * [Flink](manage-data/data-import/batch-ingestion/flink.md)
+    * [Hadoop](manage-data/data-import/batch-ingestion/hadoop.md)
+    * [Backfill Data](manage-data/data-import/batch-ingestion/backfill-data.md)
+    * [Dimension table](manage-data/data-import/batch-ingestion/dim-table.md)
+  * [Stream Ingestion](manage-data/data-import/pinot-stream-ingestion/README.md)
+    * [Ingest streaming data from Apache Kafka](manage-data/data-import/pinot-stream-ingestion/import-from-apache-kafka.md)
+    * [Ingest streaming data from Amazon Kinesis](manage-data/data-import/pinot-stream-ingestion/amazon-kinesis.md)
+    * [Ingest streaming data from Apache Pulsar](manage-data/data-import/pinot-stream-ingestion/apache-pulsar.md)
+    * [Configure indexes](manage-data/data-import/pinot-stream-ingestion/configure-indexes.md)
+    * [Stream ingestion with CLP](manage-data/data-import/pinot-stream-ingestion/clp.md)
+  * [Upsert and Dedup](manage-data/data-import/upsert-and-dedup/README.md)
+    * [Offline Table Upsert](manage-data/data-import/upsert-and-dedup/offline-table-upsert.md)
+    * [Stream ingestion with Upsert](manage-data/data-import/upsert-and-dedup/upsert.md)
+    * [Segment compaction on upserts](manage-data/data-import/upsert-and-dedup/segment-compaction-on-upserts.md)
+    * [Stream ingestion with Dedup](manage-data/data-import/upsert-and-dedup/dedup.md)
+  * [Supported Data Formats](manage-data/data-import/pinot-input-formats.md)
+  * [File Systems](manage-data/data-import/pinot-file-system/README.md)
+    * [Amazon S3](manage-data/data-import/pinot-file-system/amazon-s3.md)
+    * [Azure Data Lake Storage](manage-data/data-import/pinot-file-system/import-from-adls-azure.md)
+    * [HDFS](manage-data/data-import/pinot-file-system/import-from-hdfs.md)
+    * [Google Cloud Storage](manage-data/data-import/pinot-file-system/import-from-gcp.md)
+  * [Complex Type (Array, Map) Handling](manage-data/data-import/complex-type/README.md)
+    * [Complex Type Examples (Unnest)](manage-data/data-import/complex-type/complex-type-examples.md)
+  * [Ingest records with dynamic schemas](manage-data/data-import/schema-conforming-transformer.md)
+
+## Query and Build Applications <a href="#users" id="users"></a>
 
 * [Query](users/user-guide-query/README.md)
   * [Querying Pinot](users/user-guide-query/querying-pinot.md)
@@ -112,6 +125,7 @@
       * [Colocated join strategy](users/user-guide-query/multi-stage-query/join-strategies/colocated-join-strategy.md)
       * [Lookup join strategy](users/user-guide-query/multi-stage-query/join-strategies/lookup-join-strategy.md)
     * [Hints](users/user-guide-query/multi-stage-query/hints.md)
+    * [Default Disabled Rules](users/user-guide-query/default-disabled-rules.md)
     * [Operator Types](users/user-guide-query/multi-stage-query/operator-types/README.md)
       * [Aggregate](users/user-guide-query/multi-stage-query/operator-types/aggregate.md)
       * [Filter](users/user-guide-query/multi-stage-query/operator-types/filter.md)
@@ -153,7 +167,7 @@
   * [Batch Data Ingestion In Practice](users/tutorials/batch-data-ingestion-in-practice.md)
   * [Schema Evolution](users/tutorials/schema-evolution.md)
 
-## For Developers <a href="#developers" id="developers"></a>
+## Develop and Extend Pinot <a href="#developers" id="developers"></a>
 
 * [Basics](developers/developers-and-contributors/README.md)
   * [Extending Pinot](developers/developers-and-contributors/extending-pinot/README.md)
@@ -181,7 +195,7 @@
 * [Design Documents](developers/design-documents/README.md)
   * [Segment Writer API](developers/design-documents/segment-writer-api.md)
 
-## For Operators <a href="#operators" id="operators"></a>
+## Operate Pinot <a href="#operators" id="operators"></a>
 
 * [Deployment and Monitoring](operators/operating-pinot/README.md)
   * [Set up cluster](operators/operating-pinot/setup-cluster.md)
@@ -201,7 +215,9 @@
     * [Using multiple directories](operators/operating-pinot/separating-data-storage-by-age/using-multiple-directories.md)
   * [Pinot managed Offline flows](operators/operating-pinot/pinot-managed-offline-flows.md)
   * [Minion merge rollup task](operators/operating-pinot/minion-merge-rollup-task.md)
+  * [Upsert Compaction Task](operators/operating-pinot/upsert-compaction-task.md)
   * [Upsert Compact Merge Task](operators/operating-pinot/upsert-compact-merge-task.md)
+  * [Purge Task](operators/operating-pinot/purge-task.md)
   * [Consistent Push and Rollback](operators/operating-pinot/consistent-push-and-rollback.md)
   * [Access Control](operators/operating-pinot/access-control.md)
   * [Monitoring](operators/operating-pinot/monitoring.md)
@@ -256,39 +272,7 @@
   * [STDDEV\_SAMP](configuration-reference/plugin-reference/stddev_samp.md)
 * [Dynamic Environment](configuration-reference/dynamic-environment.md)
 
-## Manage Data
-
-* [Import Data](manage-data/data-import/README.md)
-  * [SQL Insert Into From Files](manage-data/data-import/from-query-console.md)
-  * [Upload Pinot segment Using CommandLine](manage-data/data-import/segment-upload.md)
-  * [Batch Ingestion](manage-data/data-import/batch-ingestion/README.md)
-    * [Spark](manage-data/data-import/batch-ingestion/spark.md)
-    * [Flink](manage-data/data-import/batch-ingestion/flink.md)
-    * [Hadoop](manage-data/data-import/batch-ingestion/hadoop.md)
-    * [Backfill Data](manage-data/data-import/batch-ingestion/backfill-data.md)
-    * [Dimension table](manage-data/data-import/batch-ingestion/dim-table.md)
-  * [Stream Ingestion](manage-data/data-import/pinot-stream-ingestion/README.md)
-    * [Ingest streaming data from Apache Kafka](manage-data/data-import/pinot-stream-ingestion/import-from-apache-kafka.md)
-    * [Ingest streaming data from Amazon Kinesis](manage-data/data-import/pinot-stream-ingestion/amazon-kinesis.md)
-    * [Ingest streaming data from Apache Pulsar](manage-data/data-import/pinot-stream-ingestion/apache-pulsar.md)
-    * [Configure indexes](manage-data/data-import/pinot-stream-ingestion/configure-indexes.md)
-    * [Stream ingestion with CLP](manage-data/data-import/pinot-stream-ingestion/clp.md)
-  * [Upsert and Dedup](manage-data/data-import/upsert-and-dedup/README.md)
-    * [Offline Table Upsert](manage-data/data-import/upsert-and-dedup/offline-table-upsert.md)
-    * [Stream ingestion with Upsert](manage-data/data-import/upsert-and-dedup/upsert.md)
-    * [Segment compaction on upserts](manage-data/data-import/upsert-and-dedup/segment-compaction-on-upserts.md)
-    * [Stream ingestion with Dedup](manage-data/data-import/upsert-and-dedup/dedup.md)
-  * [Supported Data Formats](manage-data/data-import/pinot-input-formats.md)
-  * [File Systems](manage-data/data-import/pinot-file-system/README.md)
-    * [Amazon S3](manage-data/data-import/pinot-file-system/amazon-s3.md)
-    * [Azure Data Lake Storage](manage-data/data-import/pinot-file-system/import-from-adls-azure.md)
-    * [HDFS](manage-data/data-import/pinot-file-system/import-from-hdfs.md)
-    * [Google Cloud Storage](manage-data/data-import/pinot-file-system/import-from-gcp.md)
-  * [Complex Type (Array, Map) Handling](manage-data/data-import/complex-type/README.md)
-    * [Complex Type Examples (Unnest)](manage-data/data-import/complex-type/complex-type-examples.md)
-  * [Ingest records with dynamic schemas](manage-data/data-import/schema-conforming-transformer.md)
-
-## Functions
+## SQL Function Reference
 
 * [Aggregation Functions](users/user-guide-query/supported-aggregations.md)
 * [Transformation Functions](users/user-guide-query/supported-transformations.md)
@@ -499,7 +483,32 @@
   * [Troubleshoot issues with ZooKeeper znodes](reference/troubleshooting/troubleshoot-zookeeper.md)
   * [Realtime Ingestion Stopped](reference/troubleshooting/realtime-ingestion-stopped.md)
 
-## RESOURCES <a href="#community-1" id="community-1"></a>
+## Release Notes
+
+* [Release notes](basics/releases/README.md)
+  * [1.4.0](basics/releases/1.4.0.md)
+  * [1.3.0](basics/releases/1.3.0.md)
+  * [1.2.0](basics/releases/1.2.0.md)
+  * [1.1.0](basics/releases/1.1.0.md)
+  * [1.0.0](basics/releases/1.0.0.md)
+  * [0.12.1](basics/releases/0.12.1.md)
+  * [0.12.0](basics/releases/0.12.0.md)
+  * [0.11.0](basics/releases/0.11.0.md)
+  * [0.10.0](basics/releases/0.10.0.md)
+  * [0.9.3](basics/releases/0.9.3.md)
+  * [0.9.2](basics/releases/0.9.2.md)
+  * [0.9.1](basics/releases/0.9.1.md)
+  * [0.9.0](basics/releases/0.9.0.md)
+  * [0.8.0](basics/releases/0.8.0.md)
+  * [0.7.1](basics/releases/0.7.1.md)
+  * [0.6.0](basics/releases/0.6.0.md)
+  * [0.5.0](basics/releases/0.5.0.md)
+  * [0.4.0](basics/releases/0.4.0.md)
+  * [0.3.0](basics/releases/0.3.0.md)
+  * [0.2.0](basics/releases/0.2.0.md)
+  * [0.1.0](basics/releases/0.1.0.md)
+
+## Community <a href="#community-1" id="community-1"></a>
 
 * [Community](community-1/community.md)
 * [Team](community-1/team.md)

--- a/configuration-reference/functions/jsonpathexists.md
+++ b/configuration-reference/functions/jsonpathexists.md
@@ -8,7 +8,7 @@ Checks if specified jsonPath exists in jsonField.
 
 ## Signature
 
-> JSONPATH(jsonField, 'jsonPath')
+> JSONPATHEXISTS(jsonField, 'jsonPath')
 
 | Arguments    | Description                                                                                            |
 | ------------ | ------------------------------------------------------------------------------------------------------ |

--- a/operators/operating-pinot/README.md
+++ b/operators/operating-pinot/README.md
@@ -26,6 +26,28 @@ You can then proceed to the more advanced Pinot setup in production environment.
 [running-pinot-in-production.md](../tutorials/running-pinot-in-production.md)
 {% endcontent-ref %}
 
+After your cluster is running, the most common next steps are monitoring, tuning, and lifecycle tasks:
+
+{% content-ref url="monitoring.md" %}
+[monitoring.md](monitoring.md)
+{% endcontent-ref %}
+
+{% content-ref url="tuning/" %}
+[README.md](tuning/)
+{% endcontent-ref %}
+
+{% content-ref url="upsert-compaction-task.md" %}
+[upsert-compaction-task.md](upsert-compaction-task.md)
+{% endcontent-ref %}
+
+{% content-ref url="upsert-compact-merge-task.md" %}
+[upsert-compact-merge-task.md](upsert-compact-merge-task.md)
+{% endcontent-ref %}
+
+{% content-ref url="purge-task.md" %}
+[purge-task.md](purge-task.md)
+{% endcontent-ref %}
+
 ### Related blog posts
 
 Here are some related blog posts from the Apache Pinot community. You can find all of our blog posts on our [developer blog on Medium](https://medium.com/apache-pinot-developer-blog).

--- a/users/user-guide-query/multi-stage-query/README.md
+++ b/users/user-guide-query/multi-stage-query/README.md
@@ -5,3 +5,21 @@ description: Learn more about multi-stage query engine and how to troubleshoot i
 # Multi-stage query
 
 The general explanation of the multi-stage query engine is provided in the [Multi-stage query engine](../../../reference/multi-stage-engine.md) reference documentation. This section provides a deep dive into the multi-stage query engine. Most of the concepts explained here are related to the internals of the multi-stage query engine and users don't need to know about them in order to write queries. However, understanding these concepts can help you to take advantage of the engine's capabilities and to troubleshoot issues.
+
+Start with these guides if you are evaluating or tuning the multi-stage engine:
+
+{% content-ref url="physical-optimizer.md" %}
+[physical-optimizer.md](physical-optimizer.md)
+{% endcontent-ref %}
+
+{% content-ref url="hints.md" %}
+[hints.md](hints.md)
+{% endcontent-ref %}
+
+{% content-ref url="../default-disabled-rules.md" %}
+[default-disabled-rules.md](../default-disabled-rules.md)
+{% endcontent-ref %}
+
+{% content-ref url="../../../reference/troubleshooting/troubleshoot-multi-stage-query-engine.md" %}
+[troubleshoot-multi-stage-query-engine.md](../../../reference/troubleshooting/troubleshoot-multi-stage-query-engine.md)
+{% endcontent-ref %}


### PR DESCRIPTION
## Summary
- reorganize the GitBook navigation around user tasks instead of internal buckets
- expose source-backed but under-discoverable pages for planner rules and minion tasks
- improve the main landing pages for getting started, operating Pinot, and multi-stage query tuning
- add a repo-specific CLAUDE.md so Claude Code can manage this repo with the right GitBook and source-of-truth workflow
- fix the JSONPATHEXISTS signature typo in the function reference

## What changed
- SUMMARY.md
  - promotes Get Started and Ingest and Model Data to first-class top-level sections
  - renames top-level sections to be task-oriented: Query and Build Applications, Develop and Extend Pinot, Operate Pinot, SQL Function Reference, and Community
  - adds missing nav entries for Default Disabled Rules, Upsert Compaction Task, and Purge Task
  - moves release notes into their own top-level section
- README.md
  - adds clearer entrypoints for building applications, operating Pinot, and extending Pinot
- operators/operating-pinot/README.md
  - adds direct links to monitoring, tuning, and common lifecycle tasks
- users/user-guide-query/multi-stage-query/README.md
  - adds direct links for physical optimizer, hints, planner rules, and troubleshooting
- configuration-reference/functions/jsonpathexists.md
  - fixes the function signature from JSONPATH(...) to JSONPATHEXISTS(...)
- CLAUDE.md
  - documents repo-specific workflow for GitBook navigation, redirects, source cross-checks against apache/pinot, validation, and PR hygiene

## Validation
- git diff --check
- local link/path validation for all edited files
- source cross-checks against apache/pinot for planner rules and task pages

## Follow-up ideas
- split the docs further into a stricter lifecycle: evaluate, ingest/model, query/build, operate, extend, reference
- consolidate duplicate function surfaces across functions, functions-1, and config-reference function pages
- generate more of the source-backed docs directly from Apache Pinot metadata/classes to reduce drift
