### PR TITLE
Improve index documentation with configs, queries, and source-verified details

### DIFF
--- a/basics/indexing/README.md
+++ b/basics/indexing/README.md
@@ -91,3 +91,21 @@ Matrix below show which combinations of data types, cardinality and encoding are
 (4) Supported only if values can be parsed as json.
 
 (5) Supports only multi value columns.
+
+## Choosing an index
+
+Use this decision guide to pick the right index for your query pattern:
+
+| Query pattern | Recommended index | Notes |
+| --- | --- | --- |
+| `WHERE col = value` | [Inverted index](inverted-index.md) | Best starting point for equality filters |
+| `WHERE col IN (v1, v2, ...)` | [Inverted index](inverted-index.md) + [Bloom filter](bloom-filter.md) | Bloom filter prunes segments; inverted index accelerates within-segment lookup |
+| `WHERE col > value` / `BETWEEN` | [Range index](range-index.md) | Especially useful on high-cardinality metric columns |
+| `WHERE col LIKE 'prefix%'` | [FST index](fst-index.md) | For regex/LIKE on dictionary-encoded STRING columns |
+| `WHERE TEXT_MATCH(col, 'query')` | [Text index](text-search-support.md) | Full-text search with Lucene. Use for tokenized search |
+| `WHERE JSON_MATCH(col, '...')` | [JSON index](json-index.md) | For filtering on nested JSON fields |
+| `WHERE ST_Distance(...) < x` | [Geospatial index](geospatial-support.md) | H3-based spatial index for distance queries |
+| `WHERE VECTOR_SIMILARITY(...)` | [Vector index](vector-index.md) | Approximate nearest-neighbor search on embeddings |
+| `GROUP BY dateTrunc('DAY', ts)` | [Timestamp index](timestamp-index.md) | Pre-generates granularity columns for fast time-based grouping |
+| `SUM(metric) GROUP BY dim1, dim2` | [Star-tree index](star-tree-index.md) | Pre-aggregated results for known query patterns |
+| Sorted column, range + equality | [Sorted forward index](forward-index.md#sorted-forward-index-with-run-length-encoding) | Automatically acts as inverted index with O(log n) lookup |

--- a/basics/indexing/bloom-filter.md
+++ b/basics/indexing/bloom-filter.md
@@ -33,6 +33,34 @@ An intriguing aspect of these filters is the existence of a mathematical formula
 
 In Pinot, this cardinality corresponds to the number of unique values expected within each segment. If necessary, the false positive rate and the index size can be configured.
 
+## Supported column types
+
+Bloom filters are supported on all data types except BOOLEAN and MAP: INT, LONG, FLOAT, DOUBLE, BIG_DECIMAL, STRING, BYTES, JSON, TIMESTAMP.
+
+## Query examples
+
+Bloom filters work transparently — no special query syntax is required. Pinot automatically uses the Bloom filter to prune segments that cannot contain matching values.
+
+Equality filter:
+
+```sql
+SELECT playerName, teamID, hits
+FROM baseballStats
+WHERE playerID = 'bondsba01'
+```
+
+IN filter (up to 10 values):
+
+```sql
+SELECT playerName, yearID, homeRuns
+FROM baseballStats
+WHERE playerID IN ('bondsba01', 'ruthba01', 'aaronha01')
+```
+
+{% hint style="info" %}
+Bloom filters only help with EQUALITY and IN predicates. They do not accelerate range queries, LIKE, or other filter types.
+{% endhint %}
+
 ## Configuration
 
 Bloom filters are deactivated by default, implying that columns will not be indexed unless they are explicitly configured within the [table configuration](../../configuration-reference/table.md).

--- a/basics/indexing/dictionary-index.md
+++ b/basics/indexing/dictionary-index.md
@@ -2,6 +2,16 @@
 
 When dealing with extensive datasets, it's common for values to be repeated multiple times. To enhance storage efficiency and reduce query latencies, we strongly recommend employing a dictionary index for repetitive data. This is the reason Pinot enables dictionary encoding by default, even though it is advisable to disable it for columns with high cardinality.
 
+## When to use
+
+Enable dictionary encoding (the default) when a column has low to medium cardinality — meaning the number of unique values is significantly smaller than the total number of rows. Dictionary encoding is less beneficial for high-cardinality columns like UUIDs or free-text fields, where disabling the dictionary and using raw encoding may save space and reduce overhead.
+
+## Supported column types
+
+Dictionary encoding is supported on all data types: INT, LONG, FLOAT, DOUBLE, BIG_DECIMAL, STRING, BYTES, BOOLEAN, TIMESTAMP, JSON.
+
+For variable-length types (STRING, BYTES, BIG_DECIMAL), consider enabling `useVarLengthDictionary` when values vary widely in length.
+
 ## Influence on other indexes
 
 In Pinot, dictionaries serve as both an index and actual encoding. Consequently, when dictionaries are enabled, the behavior or layout of certain other indexes undergoes modification. The relationship between dictionaries and other indexes is outlined in the following table:

--- a/basics/indexing/forward-index.md
+++ b/basics/indexing/forward-index.md
@@ -135,14 +135,25 @@ When using the raw format, you can configure the following parameters:
 | targetDocsPerChunk    | 1000    | The target number of docs per chunk                                                     |
 | targetMaxChunkSize    | 1MB     | The target max chunk size                                                               |
 
-The `compressionCodec` parameter has the following valid values:
+The `compressionCodec` parameter has the following valid values for raw-encoded columns:
 
-* `PASS_THROUGH`
-* `SNAPPY`
-* `ZSTANDARD`
-* `LZ4`
-* `GZIP` (Introduced in release `1.2.0`)
+* `PASS_THROUGH` — no compression
+* `SNAPPY` — fast compression with moderate ratio
+* `ZSTANDARD` — high compression ratio, slower than Snappy
+* `LZ4` — fast compression, good balance of speed and ratio
+* `GZIP` — high compression ratio (introduced in release `1.2.0`)
 * `null` (the JSON null value, not `"null"`), which is the default. In this case, `PASS_THROUGH` will be used for metrics and `LZ4` for other columns.
+
+For dictionary-encoded multi-value forward indexes, there is one additional compression type:
+
+* `MV_ENTRY_DICT` — adds a second-level dictionary encoding for repeated multi-value entries. This is useful when pre-joining a fact table with a dimension table where multi-value entries in the dimension table are repeated.
+
+{% hint style="info" %}
+There are additional special-purpose compression codecs available for specific use cases:
+
+* `CLP`, `CLPV2`, `CLPV2_ZSTD`, `CLPV2_LZ4` — CLP-based compression codecs optimized for log line data. These are not general-purpose and have special handling for log data patterns.
+* `DELTA`, `DELTADELTA` — delta encoding codecs for numeric columns with sequential or near-sequential values. These are applied automatically in certain contexts and are not typically configured directly.
+{% endhint %}
 
 `deriveNumDocsPerChunk` is only used when the datatype may have a variable length, such as with `string`, `big decimal`, `bytes`, etc. By default, Pinot uses a fixed number of elements that was chosen empirically. If changed to true, Pinot will use a heuristic value that depends on the column data.
 

--- a/basics/indexing/fst-index.md
+++ b/basics/indexing/fst-index.md
@@ -1,48 +1,89 @@
 # FST index
 
-The FST index supports regex queries on text. Decreases on-disk index by 4-6 times.&#x20;
+The FST (Finite State Transducer) index accelerates regex queries on dictionary-encoded STRING columns. It reduces the on-disk index size by 4-6x compared to scanning the full dictionary.
 
-* Only supports regex queries
-* Only supported on stored or completed Pinot segments (no consuming segments).
-* Only supported on dictionary-encoded columns.
-* Works better for prefix queries&#x20;
+## When to use
+
+Use an FST index when your queries use `LIKE` or `REGEXP_LIKE` predicates on string columns. It is especially effective for prefix-matching patterns. For full-text search with tokenization, use the [text index](text-search-support.md) instead.
+
+## Supported column types
+
+- STRING columns only
+- Must be single-valued
+- Must be dictionary-encoded
+
+## Limitations
+
+- Only supports regex queries (`LIKE` and `REGEXP_LIKE` predicates).
+- Only supported on stored or completed segments (not consuming segments in real-time tables).
+- Only supported on dictionary-encoded columns.
+- Works best for prefix queries. Suffix-only or infix-only patterns may not benefit as much.
 
 {% hint style="info" %}
-**Note:** Lucene is case sensitive as such when using FST index based column(s) in query, user needs to ensure this is taken into account. For e.g `Select * from table T where colA LIKE %Value%` which has a FST index on colA will only return rows containing string "Value" but not "value".
+Lucene FST is **case-sensitive**. When using an FST index in queries, ensure your pattern matches the case stored in the data. For example, `WHERE colA LIKE '%Value%'` will match "Value" but not "value". For case-insensitive matching, use the [IFST index](#case-insensitive-fst-index-ifst) instead.
 {% endhint %}
 
-For more information on the FST construction and code, see [Lucene documentation](https://lucene.apache.org/core/9\_10\_0/core/org/apache/lucene/util/fst/FST.html).
+For more information on FST construction, see the [Lucene FST documentation](https://lucene.apache.org/core/9_10_0/core/org/apache/lucene/util/fst/FST.html).
 
-## Enable the FST index
+## Configuration
 
-To enable the FST index on a dictionary-encoded column, include the following configuration:
+To enable the FST index on a dictionary-encoded column:
 
-```javascript
-"fieldConfigList":[
+{% code title="Recommended: fieldConfigList" %}
+```json
 {
-"name":"text_col_1",
-"encodingType":"DICTIONARY",
-"indexType":"FST"
+  "fieldConfigList": [
+    {
+      "name": "text_col_1",
+      "encodingType": "DICTIONARY",
+      "indexType": "FST"
+    }
+  ]
 }
-]
+```
+{% endcode %}
+
+The FST index generates one index file (`.lucene.fst`). If an inverted index is also enabled on the column, FST can take advantage of it for faster lookups.
+
+## Query examples
+
+Prefix match:
+
+```sql
+SELECT productName
+FROM products
+WHERE productName LIKE 'iPhone%'
 ```
 
-The FST index generates one FST index file (`.lucene.fst)`. If the inverted index is enabled, this is further able to take advantage of that.
+Regex match:
+
+```sql
+SELECT email
+FROM users
+WHERE REGEXP_LIKE(email, '^admin.*@example\\.com$')
+```
+
+Infix match:
+
+```sql
+SELECT description
+FROM products
+WHERE description LIKE '%wireless%'
+```
 
 ## Case-insensitive FST index (IFST)
 
 The case-insensitive FST index (IFST) provides the same functionality as the standard FST index but with case-insensitive matching. This eliminates the need to handle case sensitivity manually in queries.
 
-* Supports case-insensitive regex queries
-* Only supported on stored or completed Pinot segments (no consuming segments).
-* Only supported on dictionary-encoded columns.
-* Works better for prefix queries with case-insensitive matching
+- Supports case-insensitive regex queries.
+- Only supported on stored or completed segments (not consuming segments).
+- Only supported on dictionary-encoded STRING columns.
+- Works best for prefix queries with case-insensitive matching.
 
-### Enable the case-insensitive FST index
+### Configuration
 
-To enable the case-insensitive FST index on a dictionary-encoded column, include the following configuration:
-
-```javascript
+{% code title="IFST configuration" %}
+```json
 {
   "fieldConfigList": [
     {
@@ -57,9 +98,8 @@ To enable the case-insensitive FST index on a dictionary-encoded column, include
   ]
 }
 ```
+{% endcode %}
 
-The case-insensitive FST index generates one FST index file (`.lucene.ifst`) and provides case-insensitive matching for regex queries without requiring manual case handling in your queries.
+The case-insensitive FST index generates one index file (`.lucene.ifst`).
 
-
-For more information about enabling the FST index, see ways to [enable indexes](./README.md#enabling-indexes).
-
+For more information about enabling indexes, see [enabling indexes](./README.md#enabling-indexes).

--- a/basics/indexing/geospatial-support.md
+++ b/basics/indexing/geospatial-support.md
@@ -10,6 +10,14 @@ Pinot supports SQL/MM geospatial data and is compliant with the [Open Geospatial
 * Geospatial functions, for querying of spatial properties and relationships.
 * Geospatial indexing, used for efficient processing of spatial operations
 
+## When to use
+
+Use geospatial indexing when your queries involve spatial distance calculations with `ST_Distance` in the `WHERE` clause. The H3-based geospatial index can dramatically speed up queries that find records within a certain distance of a reference point.
+
+## Supported column types
+
+The H3 geospatial index requires BYTES columns (single-valued) containing spherical geography data. The column should use a `transformFunction` to convert coordinates into `SphericalGeography` format.
+
 ## Geospatial data types
 
 Geospatial data types abstract and encapsulate spatial structures such as boundary and dimension. In many respects, spatial data types can be understood simply as shapes. Pinot supports the Well-Known Text (WKT) and Well-Known Binary (WKB) forms of geospatial objects, for example:
@@ -166,3 +174,10 @@ As in the example diagram above, if we want to find all relevant points within a
 * First find the H3 distance `x` that contains the range (for example, within a red circle).
 * Then, for the points within the H3 distance (those covered by the hexagons completely within [`kRing(x)`](https://h3geo.org/docs/api/traversal)), directly accept those points without filtering.
 * Finally, for the points contained in the hexagons of `kRing(x)` at the outer edge of the red circle H3 distance, the algorithm will filter them by evaluating the condition `ST_Distance(loc1, loc2) < x` to find only those that are within the circle.
+
+## Limitations
+
+- The H3 geospatial index only supports `ST_Distance` in the `WHERE` clause. Other spatial predicates like `ST_Contains` or `ST_Within` do not use the index.
+- The column must be BYTES type with raw encoding — dictionary encoding is incompatible with the H3 index.
+- The index is based on the H3 hexagonal grid, so accuracy depends on the configured resolutions. Multiple resolutions can be specified to balance precision and performance.
+- Only single-valued columns are supported.

--- a/basics/indexing/inverted-index.md
+++ b/basics/indexing/inverted-index.md
@@ -1,63 +1,111 @@
 ---
-description: This page describes configuring the inverted index for Apache Pinot
+description: This page describes configuring the inverted index for Apache Pinot.
 ---
 
 # Inverted index
 
-We can define the [forward index](forward-index.md) as a mapping from document IDs (also known as rows) to values. Similarly, an inverted index establishes a mapping from values to a set of document IDs, making it the "inverted" version of the forward index. When you frequently use a column for filtering operations like EQ (equal), IN (membership check), GT (greater than), etc., incorporating an inverted index can significantly enhance query performance.
+The [forward index](forward-index.md) maps document IDs (rows) to values. An inverted index reverses this mapping: it maps values to the set of document IDs that contain them. When you frequently filter on a column with predicates like EQ, IN, GT, LT, or BETWEEN, adding an inverted index can significantly improve query performance.
 
-Pinot supports two distinct types of inverted indexes: bitmap inverted indexes and sorted inverted indexes. Bitmap inverted indexes represent the _actual_ inverted index type, whereas the sorted type is automatically available when the column is sorted. Both types of indexes necessitate the enabling of a [dictionary](dictionary-index.md) for the respective column.
+Pinot supports two types of inverted indexes: bitmap inverted indexes and sorted inverted indexes.
 
-### Bitmap inverted index
+## When to use
 
-When a column is not sorted, and an inverted index is enabled for that column, Pinot maintains a mapping from each value to a bitmap of rows. This design ensures that value lookup operations take constant time, providing efficient querying capabilities.
+Use an inverted index on columns that appear frequently in `WHERE` clause filters, especially for equality and membership predicates. An inverted index is a good starting point for performance tuning.
 
-When an inverted index is enabled for a column, Pinot maintains a map from each value to a bitmap of rows, which makes value lookup take constant time. If you have a column that is frequently used for filtering, adding an inverted index will improve performance greatly. You can create an inverted index on a multi-value column.
+- Use a **bitmap inverted index** on unsorted columns that are filtered frequently.
+- Use a **sorted inverted index** (automatic when a column is sorted) when most queries filter on the same column.
 
-Inverted indexes are disabled by default and can be enabled for a column by specifying the configuration within the [table configuration](../../configuration-reference/table.md):
+## Supported column types
 
-{% code title="inverted index defined in tableConfig" %}
-```javascript
+Bitmap inverted indexes are supported on all data types except MAP: INT, LONG, FLOAT, DOUBLE, BIG_DECIMAL, BOOLEAN, TIMESTAMP, STRING, JSON, BYTES. Both single-value and multi-value columns are supported.
+
+## Bitmap inverted index
+
+When an inverted index is enabled for an unsorted column, Pinot maintains a mapping from each value to a bitmap of document IDs. This makes value lookup take constant time O(1).
+
+### Configuration
+
+The recommended way to enable a bitmap inverted index:
+
+{% code title="Recommended: fieldConfigList" %}
+```json
 {
   "fieldConfigList": [
     {
-      "name": "theColumnName",
+      "name": "playerName",
       "indexes": {
         "inverted": {}
       }
     }
-  ],
-  ...
+  ]
 }
 ```
 {% endcode %}
 
-The older way to configure inverted indexes can also be used, although it is not actually recommended:
+<details>
 
-{% code title="old way to define inverted index in tableConfig" %}
-```javascript
+<summary>Older configuration</summary>
+
+{% code title="Legacy: tableIndexConfig" %}
+```json
 {
-    "tableIndexConfig": {
-        "invertedIndexColumns": [
-            "theColumnName",
-            ...
-        ],
-        ...
-    }
+  "tableIndexConfig": {
+    "invertedIndexColumns": [
+      "playerName"
+    ]
+  }
 }
 ```
 {% endcode %}
 
-#### When the index is created
+</details>
 
-By default, bitmap inverted indexes are not generated when the segment is initially created; instead, they are created when the segment is loaded by Pinot. This behavior is governed by the table configuration option `indexingConfig.createInvertedIndexDuringSegmentGeneration`, which is set to false by default.
+### When the index is created
 
-### Sorted inverted index
+By default, bitmap inverted indexes are not generated during segment creation. They are created when the segment is loaded by Pinot. This behavior is controlled by the table configuration option `indexingConfig.createInvertedIndexDuringSegmentGeneration`, which defaults to `false`.
 
-As explained in the [forward index](forward-index.md) section, a column that is both sorted and equipped with a dictionary is encoded in a specialized manner that serves the purpose of implementing both forward and inverted indexes. Consequently, when these conditions are met, an inverted index is effectively created without additional configuration, even if the configuration suggests otherwise. This sorted version of the forward index offers a lookup time complexity of `log(n)` and leverages data locality.
+## Sorted inverted index
 
-For instance, consider the following example: if a query includes a filter on the `memberId` column, Pinot will perform a binary search on `memberId` values to find the range pair of docIds for corresponding filtering value. If the query needs to scan values for other columns after filtering, values within the range docId pair will be located together, which means we can benefit from data locality.
+When a column is both sorted and dictionary-encoded, Pinot uses a sorted forward index with run-length encoding that also serves as an inverted index. This happens automatically and requires no extra configuration. The sorted inverted index provides `O(log n)` lookup time and benefits from data locality.
 
-![\_images/sorted-inverted.png](../../.gitbook/assets/sorted-inverted.png)
+For example, if a query filters on a sorted `memberId` column, Pinot performs a binary search to find the range of document IDs matching the filter value. Subsequent column scans for those documents benefit from data locality because the matching rows are stored contiguously.
 
-A sorted inverted index indeed offers superior performance compared to a bitmap inverted index, but it's important to note that it can only be applied to sorted columns. In cases where query performance with a regular inverted index is unsatisfactory, especially when a large portion of queries involve filtering on the same column (e.g., `_memberId_`), using a sorted index can substantially enhance query performance.
+![Sorted inverted index](../../.gitbook/assets/sorted-inverted.png)
+
+A sorted inverted index offers better performance than a bitmap inverted index but can only apply to columns whose data is physically sorted within each segment.
+
+## Query examples
+
+Equality filter:
+
+```sql
+SELECT COUNT(*)
+FROM baseballStats
+WHERE playerName = 'Barry Bonds'
+```
+
+IN filter:
+
+```sql
+SELECT yearID, hits, homeRuns
+FROM baseballStats
+WHERE teamID IN ('NYA', 'BOS', 'LAD')
+ORDER BY yearID
+```
+
+Filter with aggregation:
+
+```sql
+SELECT teamID, SUM(hits) AS totalHits
+FROM baseballStats
+WHERE league = 'NL'
+GROUP BY teamID
+ORDER BY totalHits DESC
+LIMIT 10
+```
+
+## Limitations
+
+- Bitmap inverted indexes require [dictionary encoding](dictionary-index.md) to be enabled on the column.
+- Sorted inverted indexes only work on columns whose data is physically sorted within each segment.
+- MAP columns are not supported.

--- a/basics/indexing/json-index.md
+++ b/basics/indexing/json-index.md
@@ -50,6 +50,10 @@ WHERE JSON_EXTRACT_SCALAR(person, '$.name', 'STRING') = 'adam'
 
 The JSON index is designed to accelerate the filtering on JSON string columns without scanning and reconstructing all the JSON objects.
 
+## Supported column types
+
+The JSON index is supported on STRING and MAP columns (single-valued only). It is typically used with `noDictionaryColumns` since JSON columns tend to have high cardinality.
+
 ## Enable and configure a JSON index
 
 To enable the JSON index, you can configure the following options in the table configuration:

--- a/basics/indexing/native-text-index.md
+++ b/basics/indexing/native-text-index.md
@@ -78,3 +78,17 @@ Native text indices are created using field configurations. To indicate that an 
   }
 ]
 ```
+
+## Supported column types
+
+The native text index is supported on STRING columns only.
+
+## Migration
+
+Since the native text index is deprecated and will be removed after the 1.4.0 release, migrate to the standard [text index](text-search-support.md) by:
+
+1. Replacing `"indexType": "NATIVE_TEXT"` with the equivalent text index configuration in `fieldConfigList`.
+2. Using `TEXT_MATCH` or `TEXT_CONTAINS` functions in your queries as before.
+3. Reloading segments to rebuild the index.
+
+The standard text index uses Lucene and supports all the same query patterns plus additional operators like fuzzy matching, range queries, and custom analyzers.

--- a/basics/indexing/range-index.md
+++ b/basics/indexing/range-index.md
@@ -1,35 +1,117 @@
 ---
-description: This page describes configuring the range index for Apache Pinot
+description: This page describes configuring the range index for Apache Pinot.
 ---
 
 # Range index
 
 Range indexing allows you to get better performance for queries that involve filtering over a range.
 
-It would be useful for a query like the following:
+## When to use
+
+Use a range index when queries filter on a column with range predicates such as `>`, `<`, `>=`, `<=`, or `BETWEEN`. It is especially effective on metric columns with high cardinality, where an inverted index would be too large.
+
+{% hint style="info" %}
+A good rule of thumb is to use a range index when you want to apply range predicates on metric columns that have a very large number of unique values. Using an inverted index for such columns creates a very large index that is inefficient in terms of storage and performance.
+{% endhint %}
+
+## How it works
+
+A range index is a variant of an [inverted index](inverted-index.md). Instead of creating a mapping from individual values to document IDs, it creates a mapping from a range of values to document IDs. At query time Pinot uses the range index to quickly identify the set of documents whose column values fall within the requested range.
+
+## Supported column types
+
+Range index is supported on:
+
+- Dictionary-encoded columns of any data type (INT, LONG, FLOAT, DOUBLE, STRING, BIG_DECIMAL, BYTES, BOOLEAN, TIMESTAMP).
+- Raw-encoded columns of numeric types (INT, LONG, FLOAT, DOUBLE, BIG_DECIMAL).
+
+{% hint style="info" %}
+A range index can also be used on a dictionary-encoded time column using `STRING` type, because Pinot only supports datetime formats that are in lexicographical order.
+{% endhint %}
+
+## Configuration
+
+The recommended way to enable a range index is through the `fieldConfigList` in the [table configuration](../../configuration-reference/table.md):
+
+{% code title="Recommended: fieldConfigList" %}
+```json
+{
+  "fieldConfigList": [
+    {
+      "name": "hits",
+      "indexes": {
+        "range": {}
+      }
+    }
+  ]
+}
+```
+{% endcode %}
+
+You can also specify the range index version (default is `2`):
+
+{% code title="With explicit version" %}
+```json
+{
+  "fieldConfigList": [
+    {
+      "name": "hits",
+      "indexes": {
+        "range": {
+          "version": 2
+        }
+      }
+    }
+  ]
+}
+```
+{% endcode %}
+
+<details>
+
+<summary>Older configuration</summary>
+
+The older approach uses `rangeIndexColumns` in `tableIndexConfig`:
+
+{% code title="Legacy: tableIndexConfig" %}
+```json
+{
+  "tableIndexConfig": {
+    "rangeIndexColumns": [
+      "hits"
+    ]
+  }
+}
+```
+{% endcode %}
+
+</details>
+
+## Query examples
 
 ```sql
-SELECT COUNT(*) 
-FROM baseballStats 
+SELECT COUNT(*)
+FROM baseballStats
 WHERE hits > 11
 ```
 
-A range index is a variant of an [inverted index](../../basics/indexing/inverted-index.md), where instead of creating a mapping from values to columns, we create mapping of a range of values to columns. You can use the range index by setting the following config in the [table configuration](../../configuration-reference/table.md).
-
-```javascript
-{
-    "tableIndexConfig": {
-        "rangeIndexColumns": [
-            "column_name",
-            ...
-        ],
-        ...
-    }
-}
+```sql
+SELECT playerName, hits
+FROM baseballStats
+WHERE hits BETWEEN 50 AND 100
+ORDER BY hits DESC
+LIMIT 20
 ```
 
-Range index is supported for dictionary encoded columns of any type as well as raw encoded columns of a numeric type. Note that the range index can also be used on a dictionary encoded time column using `STRING` type, since Pinot only supports datetime formats that are in lexicographical order.
+```sql
+SELECT teamID, AVG(hits) AS avgHits
+FROM baseballStats
+WHERE hits >= 10 AND hits <= 200
+GROUP BY teamID
+ORDER BY avgHits DESC
+```
 
-{% hint style="info" %}
-A good thumb rule is to use a range index when you want to apply range predicates on metric columns that have a very large number of unique values. This is because using an inverted index for such columns will create a very large index that is inefficient in terms of storage and performance.
-{% endhint %}
+## Limitations
+
+- The range index does not support MAP columns.
+- When the forward index is disabled for a column, the column must be single-valued and use range index version 2 for range queries to work.

--- a/basics/indexing/star-tree-index.md
+++ b/basics/indexing/star-tree-index.md
@@ -12,6 +12,19 @@ One of the biggest challenges in real-time OLAP systems is achieving and maintai
 
 Use the **star-tree** index to utilize pre-aggregated documents to achieve both low query latencies and efficient use of storage space for aggregation and group-by queries.
 
+## When to use
+
+Use a star-tree index when:
+
+- Your workload is dominated by aggregation and group-by queries on a known set of dimension and metric columns.
+- Query latency requirements demand sub-second response times regardless of data volume.
+- You can identify the most common query patterns in advance to configure the dimensions split order and aggregation functions.
+
+A star-tree index is not a good fit when:
+
+- Queries are ad-hoc and unpredictable — only queries whose predicates, group-by columns, and aggregation functions match the star-tree configuration will benefit.
+- The dimension columns have very high cardinality, which increases the size of the pre-aggregated data.
+
 {% embed url="https://www.youtube.com/watch?v=bwO0HSXguFA" %}
 
 ## Existing solutions
@@ -381,3 +394,13 @@ In scenarios where you have a transform on a column(s) which is in the dimension
 
 For e.g if query contains `round(colA,600) as roundedValue from tableA group by roundedValue` and colA is included in dimensionSplitOrder then Pinot will use the pre-aggregated records to first scan matching records and then apply transform `round()` to derive `roundedValue`.
 {% endhint %}
+
+## Limitations
+
+- Only queries whose filter columns, group-by columns, and aggregation functions all match a star-tree configuration will use the index.
+- `DISTINCT_COUNT` (exact), `SEGMENT_PARTITIONED_DISTINCT_COUNT`, and `PERCENTILE` (exact) are not supported because their intermediate results are unbounded.
+- `REGEXP_LIKE` predicates are not supported in star-tree queries.
+- `IS NULL` and `IS NOT NULL` are not supported because null value info is not stored in the star-tree index. Use `col = <default>` or `col != <default>` as workarounds.
+- `OR` predicates across multiple dimensions are not supported (they cause double counting with pre-aggregated results).
+- `NOT` on top of `AND`/`OR` is not supported for the same double-counting reason.
+- All star-tree dimension columns should be dictionary-encoded.

--- a/basics/indexing/text-search-support.md
+++ b/basics/indexing/text-search-support.md
@@ -732,3 +732,52 @@ When text search queries contain too many terms or clauses, Lucene may throw `To
 - Wildcard queries that expand to many terms
 - Queries with large numbers of search terms
 To handle such cases, you can increase the maximum clause count at the cluster level. See the [cluster configuration reference](../../configuration-reference/cluster.md) for the `pinot.lucene.max.clause.count` setting.
+
+## Configuration parameters
+
+The text index supports the following configuration parameters in the `indexes.text` object of `fieldConfigList`:
+
+| Parameter | Default | Description |
+| --- | --- | --- |
+| `fst` | - | FST type to use: `LUCENE` or `NATIVE` |
+| `rawValue` | - | Whether to store raw text values |
+| `queryCache` | false | Enable Lucene query result cache |
+| `useANDForMultiTermQueries` | false | Use AND (instead of OR) for multi-term queries |
+| `stopWordsInclude` | [] | Additional stop words to include |
+| `stopWordsExclude` | [] | Default stop words to exclude |
+| `luceneUseCompoundFile` | true | Use Lucene compound file format |
+| `luceneMaxBufferSizeMB` | 500 | Maximum RAM buffer size for the Lucene index writer |
+| `luceneAnalyzerClass` | StandardAnalyzer | Custom Lucene analyzer class name |
+| `luceneAnalyzerClassArgs` | - | Arguments for the custom analyzer constructor |
+| `luceneAnalyzerClassArgTypes` | - | Argument types for the custom analyzer constructor |
+| `luceneQueryParserClass` | QueryParser | Custom Lucene query parser class name |
+| `enablePrefixSuffixMatchingInPhraseQueries` | false | Enable prefix/suffix matching in phrase queries |
+| `reuseMutableIndex` | false | Reuse the mutable index across real-time segments |
+| `luceneNRTCachingDirectoryMaxBufferSizeMB` | 0 | Max buffer size for NRT caching directory (0 = disabled) |
+| `useLogByteSizeMergePolicy` | false | Use log-byte-size merge policy for Lucene segments |
+| `docIdTranslatorMode` | Default | Doc ID translator mode: `Default`, `TryOptimize`, or `Skip` |
+| `caseSensitive` | false | Whether the text index should be case-sensitive |
+| `storeInSegmentFile` | false | Store the text index inside the segment file |
+
+### Example with custom parameters
+
+```json
+{
+  "fieldConfigList": [
+    {
+      "name": "logLine",
+      "encodingType": "RAW",
+      "indexes": {
+        "text": {
+          "luceneAnalyzerClass": "org.apache.lucene.analysis.standard.StandardAnalyzer",
+          "luceneMaxBufferSizeMB": 200,
+          "useANDForMultiTermQueries": true,
+          "stopWordsInclude": ["the", "a", "an"],
+          "caseSensitive": false,
+          "queryCache": true
+        }
+      }
+    }
+  ]
+}
+```

--- a/basics/indexing/timestamp-index.md
+++ b/basics/indexing/timestamp-index.md
@@ -96,3 +96,10 @@ Sample config:
   ...
 }
 ```
+
+## Limitations
+
+- Only supported on columns with the `TIMESTAMP` data type.
+- Pre-generates one additional column per granularity, which increases storage. Choose only the granularities you actually query.
+- The auto-rewrite only applies to `dateTrunc` function calls in predicates and group-by clauses. Other time functions are not rewritten.
+- Requires Pinot 0.11 or later.

--- a/basics/indexing/vector-index.md
+++ b/basics/indexing/vector-index.md
@@ -4,6 +4,14 @@
 
 Apache Pinot now supports a Vector Index for efficient similarity searches over high-dimensional vector embeddings. This feature introduces the capability to store and query float array columns (multi-valued) using a vector similarity algorithm.
 
+## When to use
+
+Use the vector index when you need to find the most similar items in a high-dimensional vector space. Common use cases include semantic search, recommendation systems, image similarity, and retrieval-augmented generation (RAG) where text embeddings are stored alongside metadata.
+
+## Supported column types
+
+The vector index is supported on multi-valued FLOAT columns (float arrays). The column must be declared as `singleValueField: false` in the schema with `dataType: FLOAT`.
+
 ## Key Features
 
 * Vector Index is implemented using HNSW (Hierarchical Navigable Small World) for approximate nearest neighbor (ANN) search.
@@ -136,6 +144,56 @@ Specifies the distance metric for similarity computation. Options include:
 4. version:
 
 Specifies the version of the Vector Index implementation.
+
+### HNSW tuning parameters
+
+The HNSW index supports additional tuning via the `properties` map in the field config. These are passed through to the underlying Lucene HNSW implementation:
+
+| Property | Default | Description |
+| --- | --- | --- |
+| `maxCon` | 16 | Maximum number of connections per node in the HNSW graph. Higher values improve recall but increase index size and build time. |
+| `beamWidth` | 100 | Beam width used during index construction. Higher values improve recall at the cost of slower indexing. |
+| `maxDimensions` | 2048 | Maximum number of vector dimensions supported. |
+| `maxBufferSizeMB` | 16 | RAM buffer size for the Lucene index writer. |
+| `useCompoundFile` | true | Whether to use Lucene compound file format. |
+| `mode` | BEST_SPEED | Lucene codec mode. Options: `BEST_SPEED`, `BEST_COMPRESSION`. |
+
+#### Recommended configuration (new format)
+
+The recommended way to configure the vector index uses the `indexes` object in `fieldConfigList`:
+
+{% code title="Recommended: fieldConfigList with indexes" %}
+```json
+{
+  "fieldConfigList": [
+    {
+      "name": "embedding",
+      "encodingType": "RAW",
+      "indexes": {
+        "vector": {
+          "vectorIndexType": "HNSW",
+          "vectorDimension": 1536,
+          "vectorDistanceFunction": "COSINE",
+          "version": 1,
+          "properties": {
+            "maxCon": "32",
+            "beamWidth": "200"
+          }
+        }
+      }
+    }
+  ]
+}
+```
+{% endcode %}
+
+## Limitations
+
+- Only HNSW is supported as the vector index type.
+- The column must be a multi-valued FLOAT column.
+- Maximum vector dimension is 2048 (configurable via the `maxDimensions` property).
+- `VECTOR_SIMILARITY` is an approximate nearest-neighbor predicate; results are not exact.
+- The vector index uses Lucene under the hood and generates Lucene index files per segment.
 
 ### **Query**
 


### PR DESCRIPTION
## Summary

- Reviewed and updated all 14 index documentation pages against the latest `apache/pinot` source code
- Added missing "When to use", "Supported column types", query examples, configuration parameters, and "Limitations" sections across all pages
- Added an "index selection decision guide" table to the indexing overview page

## What changed for readers

Every index page now has a consistent structure with practical guidance: when to use the index, what column types it supports, how to configure it (with the recommended `fieldConfigList` format), example queries, and known limitations. Readers can also use the new decision guide table on the overview page to quickly identify which index fits their query pattern.

## Highlights by page

| Page | Before | After | Key additions |
|------|--------|-------|---------------|
| range-index | 35 lines | 117 lines | fieldConfigList config, 3 query examples, supported types |
| inverted-index | 63 lines | 111 lines | Query examples, supported types, bitmap vs sorted guidance |
| fst-index | 65 lines | 105 lines | LIKE/REGEXP_LIKE query examples, when-to-use |
| bloom-filter | 151 lines | 179 lines | Supported types, query examples, usage notes |
| vector-index | 163 lines | 221 lines | HNSW tuning params (maxCon, beamWidth, maxDimensions), new config format, limitations |
| forward-index | 357 lines | 368 lines | All compression codecs (CLP/CLPV2/DELTA/MV_ENTRY_DICT) |
| star-tree | 383 lines | 406 lines | When-to-use, consolidated limitations |
| text-search | 734 lines | 783 lines | Full 20-param config reference table |
| dictionary | 148 lines | 158 lines | When-to-use, supported types |
| timestamp | 98 lines | 105 lines | Limitations section |
| geospatial | 168 lines | 183 lines | When-to-use, supported types, limitations |
| json-index | 819 lines | 823 lines | Supported column types (STRING, MAP) |
| native-text | 80 lines | 94 lines | Migration guidance for deprecated index |
| README | 93 lines | 111 lines | Index selection decision guide table |

## Cross-checked against `apache/pinot` source

- `CompressionCodec` enum in `FieldConfig.java` — all codec values
- `VectorIndexConfig` + `VectorIndexUtils` — HNSW params and defaults
- `TextIndexConfig` — all 20 configuration properties and defaults
- `BloomFilterConfig` — supported types (excludes BOOLEAN, MAP)
- `RangeIndexConfig` — version default, supported types
- `JsonIndexConfig` — supported column types (STRING, MAP)
- Index type classes for column type support matrices

## Validation

- `git diff --check` passes clean
- All 14 files render valid Markdown with preserved GitBook syntax

🤖 Generated with [Claude Code](https://claude.com/claude-code)