### PR TITLE
Fix YAML front matter tab that breaks GitBook sync

### DIFF
--- a/functions/sketch/distinctcountrawintegersumtuplesketch.md
+++ b/functions/sketch/distinctcountrawintegersumtuplesketch.md
@@ -1,7 +1,7 @@
 ---
 description: >-
   This section contains reference documentation for the
-	DISTINCTCOUNTRAWINTEGERSUMTUPLESKETCH function.
+  DISTINCTCOUNTRAWINTEGERSUMTUPLESKETCH function.
 ---
 
 # DISTINCTCOUNTRAWINTEGERSUMTUPLESKETCH


### PR DESCRIPTION
## Summary

- Replaces a tab character with spaces on line 4 of `functions/sketch/distinctcountrawintegersumtuplesketch.md`
- YAML forbids tabs for indentation, which caused GitBook to fail with: `Failed to parse YAML front matter`
- No other function docs had this issue

## Cross-check
- Scanned all files under `functions/` for tabs in YAML front matter — this was the only affected file

## Validation
- `git diff --check` passes cleanly
- Only the front matter line is changed; code block content is untouched