### PR TITLE
Enforce link validation in CI with ratchet and reverse-dep detection

### DIFF
--- a/.github/workflows/validate-docs.yml
+++ b/.github/workflows/validate-docs.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install dependencies
         run: pip install pyyaml
 
-      - name: Get changed markdown files
+      - name: Get changed and deleted markdown files
         id: changed
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
@@ -43,23 +43,40 @@ jobs:
           else
             BASE="${{ github.event.before }}"
           fi
+
+          # Changed files (added, copied, modified, renamed — i.e. still exist)
           git diff --name-only --diff-filter=ACMR "$BASE" HEAD -- '*.md' \
             > /tmp/changed-files.txt || true
-          COUNT=$(wc -l < /tmp/changed-files.txt | tr -d ' ')
-          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
-          echo "Changed markdown files: $COUNT"
-          cat /tmp/changed-files.txt
 
-      - name: Validate changed files
-        if: steps.changed.outputs.count != '0'
-        run: python scripts/validate-docs.py --changed-only=/tmp/changed-files.txt
+          # Deleted or renamed-away files (targets that no longer exist)
+          git diff --name-only --diff-filter=D "$BASE" HEAD -- '*.md' \
+            > /tmp/deleted-files.txt || true
+
+          CHANGED=$(wc -l < /tmp/changed-files.txt | tr -d ' ')
+          DELETED=$(wc -l < /tmp/deleted-files.txt | tr -d ' ')
+          echo "changed=$CHANGED" >> "$GITHUB_OUTPUT"
+          echo "deleted=$DELETED" >> "$GITHUB_OUTPUT"
+          echo "Changed markdown files: $CHANGED"
+          echo "Deleted markdown files: $DELETED"
+          cat /tmp/changed-files.txt
+          if [ "$DELETED" -gt 0 ]; then
+            echo "--- deleted ---"
+            cat /tmp/deleted-files.txt
+          fi
+
+      - name: Validate changed files (+ reverse dependents of deleted files)
+        if: steps.changed.outputs.changed != '0' || steps.changed.outputs.deleted != '0'
+        run: |
+          python scripts/validate-docs.py \
+            --changed-only=/tmp/changed-files.txt \
+            --deleted=/tmp/deleted-files.txt
 
       - name: Skip (no markdown changes)
-        if: steps.changed.outputs.count == '0'
+        if: steps.changed.outputs.changed == '0' && steps.changed.outputs.deleted == '0'
         run: echo "No markdown files changed — skipping validation"
 
   validate-full:
-    name: Full docs audit (informational)
+    name: Full docs link audit
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -73,5 +90,7 @@ jobs:
       - name: Install dependencies
         run: pip install pyyaml
 
-      - name: Run full validation (warn-only)
-        run: python scripts/validate-docs.py --warn-only --summary-only
+      # Ratchet: fail if broken links exceed the baseline count.
+      # As broken links are fixed, lower this number.  Goal: 0.
+      - name: Run full validation (ratchet)
+        run: python scripts/validate-docs.py --max-broken-links=299

--- a/scripts/validate-docs.py
+++ b/scripts/validate-docs.py
@@ -24,6 +24,13 @@ Modes:
   --summary-only       — print counts only, no per-file details.
   --changed-only=FILE  — only check files listed in FILE (one path per line).
                           Useful in CI to check only files changed in a PR.
+  --deleted=FILE       — file listing deleted paths (one per line). Used
+                          together with --changed-only to detect links in
+                          *unchanged* files that reference a deleted target.
+  --max-broken-links=N — ratchet: fail only when broken file links exceed N.
+                          This lets CI enforce "no new broken links" while
+                          the existing backlog is fixed incrementally.  Set
+                          to 0 once all links are clean.
 
 Exit codes:
   0  all enforced checks pass (or --warn-only)
@@ -243,6 +250,42 @@ def check_orphan_pages(md_files: set[Path]) -> list[str]:
     return orphans
 
 
+def find_reverse_dependents(
+    all_files: set[Path], deleted_paths: set[str]
+) -> set[Path]:
+    """
+    Given a set of deleted file paths (relative to REPO_ROOT), find every
+    markdown file in the repo that contains a link resolving to one of
+    those deleted paths.  These are files that were *not* changed in the
+    PR but are now broken because their link target was removed/renamed.
+    """
+    if not deleted_paths:
+        return set()
+
+    # Normalise deleted paths to resolved absolute paths
+    deleted_resolved: set[Path] = set()
+    for dp in deleted_paths:
+        dp = dp.strip()
+        if not dp:
+            continue
+        p = (REPO_ROOT / dp).resolve()
+        deleted_resolved.add(p)
+        # Also consider the README.md inside a deleted directory
+        deleted_resolved.add(p / "README.md")
+
+    dependents: set[Path] = set()
+    for filepath in all_files:
+        for raw_link, _ in extract_links(filepath):
+            resolved, _ = resolve_link(filepath, raw_link)
+            if resolved is None:
+                continue
+            # resolve() on a non-existent path still returns an absolute path
+            if resolved.resolve() in deleted_resolved:
+                dependents.add(filepath)
+                break  # one hit is enough to include the file
+    return dependents
+
+
 def check_redirects() -> tuple[list[str], int]:
     """Verify redirect targets in .gitbook.yaml exist."""
     if not GITBOOK_YAML.exists():
@@ -283,6 +326,14 @@ def main() -> int:
                         help="Print counts only, no per-file details")
     parser.add_argument("--changed-only", metavar="FILE",
                         help="Only check files listed in FILE (one per line)")
+    parser.add_argument("--deleted", metavar="FILE",
+                        help="File listing deleted paths (one per line); "
+                             "used with --changed-only to also check files "
+                             "that linked to the deleted targets")
+    parser.add_argument("--max-broken-links", metavar="N", type=int,
+                        default=None,
+                        help="Ratchet: allow up to N broken file links before "
+                             "failing.  Set to 0 once the backlog is clean.")
     args = parser.parse_args()
 
     print("=" * 64)
@@ -292,7 +343,7 @@ def main() -> int:
 
     md_files = all_md_files(REPO_ROOT)
 
-    # Optionally filter to only changed files
+    # Optionally filter to only changed files (+ reverse dependents)
     if args.changed_only:
         try:
             changed = set()
@@ -300,8 +351,29 @@ def main() -> int:
                 p = (REPO_ROOT / line.strip()).resolve()
                 if p.exists() and p.suffix == ".md":
                     changed.add(p)
-            md_files = changed
-            print(f"  Checking {len(md_files)} changed file(s)\n")
+
+            # If a --deleted list is provided, find files that linked to
+            # the deleted targets so we catch newly-broken links even in
+            # files the PR didn't touch directly.
+            reverse_deps: set[Path] = set()
+            if args.deleted:
+                try:
+                    deleted_paths = set(
+                        Path(args.deleted).read_text().strip().splitlines()
+                    )
+                    reverse_deps = find_reverse_dependents(
+                        md_files, deleted_paths
+                    )
+                except Exception as e:
+                    print(f"  Warning: could not read {args.deleted}: {e}")
+
+            combined = changed | reverse_deps
+            print(f"  Changed markdown files: {len(changed)}")
+            if reverse_deps:
+                added = reverse_deps - changed
+                print(f"  Reverse-dependent files added: {len(added)}")
+            md_files = combined
+            print(f"  Total files to check: {len(md_files)}\n")
         except Exception as e:
             print(f"  Warning: could not read {args.changed_only}: {e}")
             print(f"  Falling back to all {len(md_files)} files\n")
@@ -329,9 +401,22 @@ def main() -> int:
     print("CHECK 2: Broken file links")
     print("-" * 64)
     file_errors, anchor_warnings, total_links = check_broken_links(md_files)
+    broken_count = len(file_errors)
     if file_errors:
-        has_error = True
-        print(f"FAIL — {len(file_errors)} broken file link(s) / {total_links} checked")
+        if args.max_broken_links is not None:
+            if broken_count > args.max_broken_links:
+                has_error = True
+                label = "FAIL"
+            else:
+                label = "RATCHET OK"
+            print(
+                f"{label} — {broken_count} broken file link(s) / "
+                f"{total_links} checked "
+                f"(threshold: {args.max_broken_links})"
+            )
+        else:
+            has_error = True
+            print(f"FAIL — {broken_count} broken file link(s) / {total_links} checked")
         if not args.summary_only:
             print("\n".join(file_errors))
     else:
@@ -386,7 +471,10 @@ def main() -> int:
     print("=" * 64)
     print(f"  Files checked:        {len(md_files)}")
     print(f"  Links checked:        {total_links}")
-    print(f"  Broken file links:    {len(file_errors)}")
+    print(f"  Broken file links:    {len(file_errors)}", end="")
+    if args.max_broken_links is not None:
+        print(f"  (threshold: {args.max_broken_links})", end="")
+    print()
     print(f"  Broken anchors:       {len(anchor_warnings)}")
     print(f"  Orphan pages:         {len(orphans)}")
     print(f"  Broken SUMMARY refs:  {len(summary_errors)}")


### PR DESCRIPTION
## Summary

- **Ratchet mechanism**: Added `--max-broken-links=N` flag to `validate-docs.py`. The full-audit CI job now runs with `--max-broken-links=299` (the current baseline) instead of `--warn-only`. CI passes at or below the threshold, fails above it. As broken links are fixed, lower the number toward 0.

- **Reverse-dependency detection**: Added `--deleted=FILE` flag and `find_reverse_dependents()` function. The changed-only CI job now collects deleted file paths (`git diff --diff-filter=D`) and scans the repo for files that linked to those deleted targets. Those reverse-dependent files are added to the check set, catching breakage in files the PR didn't directly touch.

### Why

The existing CI had two gaps:
1. The full-audit job used `--warn-only`, so 299 known broken links never failed CI — new broken links could be merged silently.
2. The changed-only job only checked files modified in a PR. If a file was renamed/deleted, files linking to the old path would silently break.

### Validation

Cross-checked against current repo state on `latest`:
- 299 broken file links (ratchet set to match)
- 116 broken anchors (warning only)
- 7 orphan pages (info only)
- 0 broken SUMMARY refs
- 0 broken redirects

## Test plan

- [ ] CI runs and both jobs pass on this PR
- [ ] Introducing a new broken link in a follow-up branch causes CI to fail
- [ ] Deleting a file that is linked from other pages causes CI to flag the reverse dependents

🤖 Generated with [Claude Code](https://claude.com/claude-code)