### PR TITLE
Demote controller API reference to supplementary examples page

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -157,7 +157,7 @@
     * [Query Response Format](users/api/querying-pinot-using-standard-sql/response-format.md)
   * [Broker gRPC API](users/api/broker-grpc-api.md)
   * [Controller Admin API](users/api/pinot-rest-admin-interface.md)
-  * [Controller API Reference](users/api/controller-api-reference.md)
+  * [Controller API Examples](users/api/controller-api-reference.md)
 * [External Clients](users/clients/README.md)
   * [JDBC](users/clients/jdbc.md)
   * [Java](users/clients/java.md)

--- a/basics/concepts/segment-retention.md
+++ b/basics/concepts/segment-retention.md
@@ -22,4 +22,4 @@ If the retention period isn't specified, segments aren't purged from tables.
 
 The retention manager initially moves these segments into a _Deleted Segments_ area, from where they will eventually be permanently removed. The duration that deleted segments are kept is controlled by the `controller.deleted.segments.retentionInDays` configuration (default: 7 days).
 
-When deleting a table via the API, you can override this behavior by passing a `retention` query parameter. For example, `DELETE /tables/{tableName}?retention=0d` deletes all segments immediately without moving them to the deleted-segments area. See the [Controller API Reference](../../users/api/controller-api-reference.md#delete-tables-less-than-tablename-greater-than) for more details.
+When deleting a table via the API, you can override this behavior by passing a `retention` query parameter. For example, `DELETE /tables/{tableName}?retention=0d` deletes all segments immediately without moving them to the deleted-segments area. See the [Controller API Examples](../../users/api/controller-api-reference.md#delete-tables-less-than-tablename-greater-than) for more details.

--- a/basics/getting-started/create-and-update-table-config.md
+++ b/basics/getting-started/create-and-update-table-config.md
@@ -35,7 +35,7 @@ To update existing data and segments, after you update and save the changes to t
 
 **When you change the transform function used to populate a derived field** or **increase the number of partitions in an upsert-enabled table**, perform a table re-bootstrap. One way to do this is to delete and recreate the table:
 
-* Using the Pinot API, first send `DELETE /tables/{tableName}` followed by `POST /tables` with the new table configuration. To skip the default segment retention period and delete immediately, use `DELETE /tables/{tableName}?retention=0d`. See the [Controller API Reference](../../users/api/controller-api-reference.md#delete-tables-less-than-tablename-greater-than) for details.
+* Using the Pinot API, first send `DELETE /tables/{tableName}` followed by `POST /tables` with the new table configuration. To skip the default segment retention period and delete immediately, use `DELETE /tables/{tableName}?retention=0d`. See the [Controller API Examples](../../users/api/controller-api-reference.md#delete-tables-less-than-tablename-greater-than) for details.
 
 **When you change the stream topic** or **change the Kafka cluster** containing the Kafka topic you want to consume from, perform a real-time ingestion pause and resume. To pause and resume real-time ingestion:
 

--- a/users/api/README.md
+++ b/users/api/README.md
@@ -43,7 +43,7 @@ Schemas define the columns, data types, and field classifications (dimension, me
 
 **Detailed docs:**
 
-* [Controller API Reference](controller-api-reference.md#delete-schemas-less-than-schemaname-greater-than) -- delete schema details
+* [Controller API Examples](controller-api-reference.md#delete-schemas-less-than-schemaname-greater-than) -- delete schema curl examples
 
 ## Table Management
 
@@ -77,7 +77,7 @@ Logical tables provide a unified view over multiple physical tables with UNION s
 
 **Detailed docs:**
 
-* [Controller API Reference](controller-api-reference.md) -- table delete, rebalance, validation, and logical table details
+* [Controller API Examples](controller-api-reference.md) -- table delete, rebalance, validation, and logical table curl examples
 * [Controller Admin API](pinot-rest-admin-interface.md) -- walkthrough of the Swagger UI for table and schema operations
 
 ## Segment Management
@@ -142,7 +142,7 @@ These controller APIs manage cluster-wide configuration, tenants, instances, and
 
 **Detailed docs:**
 
-* [Controller API Reference](controller-api-reference.md) -- cluster config, leader, and tenant API details
+* [Controller API Examples](controller-api-reference.md) -- cluster config, leader, and tenant curl examples
 
 ## Task Management
 
@@ -190,7 +190,7 @@ Application-level query quotas limit the queries per second (QPS) for different 
 
 **Detailed docs:**
 
-* [Controller API Reference](controller-api-reference.md#application-quotas) -- full request/response examples
+* [Controller API Examples](controller-api-reference.md#application-quotas) -- full request/response curl examples
 * [Query Quotas](../user-guide-query/query-quotas.md) -- how application quotas interact with table and database quotas
 
 ## Monitoring and Debugging
@@ -210,5 +210,5 @@ These endpoints help you check the health of Pinot components and debug table-le
 
 * **Swagger UI**: Access the full interactive API documentation at `http://<controller-host>:<port>/help`
 * [Controller Admin API](pinot-rest-admin-interface.md) -- visual walkthrough of the admin interface
-* [Controller API Reference](controller-api-reference.md) -- detailed request/response examples for many endpoints
+* [Controller API Examples](controller-api-reference.md) -- detailed request/response curl examples for common endpoints
 * [External Clients](../clients/README.md) -- JDBC, Java, and Go client libraries for programmatic access

--- a/users/api/controller-api-reference.md
+++ b/users/api/controller-api-reference.md
@@ -1,10 +1,14 @@
 ---
-description: All user APIs available in Pinot
+description: Detailed curl examples for commonly used controller endpoints.
 ---
 
-# Controller API Reference
+# Controller API Examples
 
-The full up-to-date list of APIs can be viewed on Swagger.
+This page provides detailed `curl` request and response examples for commonly used controller endpoints. For a categorized overview of all Pinot APIs, see the main [API Reference](./).
+
+{% hint style="info" %}
+The complete and interactive list of every controller endpoint is available in the Swagger UI at `http://<controller-host>:<port>/help`. For a visual walkthrough of the Swagger UI, see [Controller Admin API](pinot-rest-admin-interface.md).
+{% endhint %}
 
 ## Cluster
 
@@ -667,5 +671,5 @@ The following APIs were added or enhanced in Pinot 1.4.0. Refer to Swagger for c
 | `/query_range`                                    | GET/POST | Prometheus-compatible time series query endpoint (Beta)                |
 
 {% hint style="info" %}
-For the complete and most current list of all controller APIs, always refer to the Swagger UI at `http://<controller-host>:<port>/help`.
+For the complete and interactive list of all controller APIs, refer to the Swagger UI at `http://<controller-host>:<port>/help`. For a categorized overview of every endpoint documented on this site, see the main [API Reference](./).
 {% endhint %}

--- a/users/api/pinot-rest-admin-interface.md
+++ b/users/api/pinot-rest-admin-interface.md
@@ -152,7 +152,7 @@ curl -X DELETE "http://localhost:9000/schemas/baseballStats" -H "accept: applica
 Using `retention=0d` permanently deletes all data immediately with no possibility of recovery. Only use this for development, testing, or cleanup scenarios where the data is no longer needed.
 {% endhint %}
 
-For more details on the delete table API and its parameters, see the [Controller API Reference](controller-api-reference.md#delete-tables-less-than-tablename-greater-than).
+For more details on the delete table API and its parameters, see the [Controller API Examples](controller-api-reference.md#delete-tables-less-than-tablename-greater-than).
 
 ### Using the Data Explorer UI
 


### PR DESCRIPTION
## Summary

- Renames "Controller API Reference" → "Controller API Examples" across the site (page title, SUMMARY.md nav, all cross-links)
- Reframes the page opening: instead of claiming to be the full reference ("The full up-to-date list of APIs can be viewed on Swagger"), it now clearly positions itself as supplementary curl examples that complement the main API Reference hub
- Makes the **API Reference hub** (`users/api/README.md`) the single authoritative entry point for all Pinot APIs

## Why

The site had two pages competing for the "API reference" role: a well-organized hub page with categorized endpoint tables, and a legacy-feeling page that opened by deferring to Swagger. This change resolves the ambiguity by making the hub authoritative and the old reference page a supporting resource.

Auto-generating from Swagger/OpenAPI was considered but ruled out — Pinot's spec is annotation-driven and generated at runtime (no static spec file), so it would require CI infrastructure to extract and convert.

## What was changed

| File | Change |
|------|--------|
| `users/api/controller-api-reference.md` | Title → "Controller API Examples"; opening rewritten to point back to hub and Swagger UI |
| `SUMMARY.md` | Nav entry renamed |
| `users/api/README.md` | 5 cross-links updated to new name |
| `users/api/pinot-rest-admin-interface.md` | 1 cross-link updated |
| `basics/getting-started/create-and-update-table-config.md` | 1 cross-link updated |
| `basics/concepts/segment-retention.md` | 1 cross-link updated |

**No file renames or URL changes** — the filename `controller-api-reference.md` is preserved to avoid breaking external links.

## Validation

- `git diff --check` clean
- Grep confirms zero remaining references to "Controller API Reference"
- All `content-ref` targets and relative links unchanged (only link text was updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)