### PR TITLE
Refresh Plugin Reference landing page into a full plugin hub

### DIFF
--- a/configuration-reference/plugin-reference/README.md
+++ b/configuration-reference/plugin-reference/README.md
@@ -1,8 +1,125 @@
 ---
 description: >-
-  This document maintains configs for each of the supported plugins in Apache
-  Pinot
+  Configuration and usage reference for every plugin family in Apache Pinot.
 ---
 
 # Plugin Reference
 
+Apache Pinot has a plug-and-play architecture organized into **ten plugin families**. Each family targets a specific extensibility need — from reading data in different formats to exporting metrics to your monitoring stack.
+
+This section covers the **configuration** side of each plugin family: which implementations ship with Pinot, what config keys they accept, and how to enable them. If you want to **write your own plugin**, see the [Plugin Architecture](../../developers/plugin-architecture/README.md) section in the Developer Guide.
+
+## Plugin Families at a Glance
+
+| Plugin Family | What It Does | Config Reference | Authoring Guide |
+| --- | --- | --- | --- |
+| **Stream Ingestion** | Consume data from real-time streaming platforms (Kafka, Kinesis, Pulsar) | [Stream Ingestion Connectors](stream-ingestion-connectors.md) · [Version Matrix](stream-connector-matrix.md) | [Stream Ingestion Plugin](../../developers/plugin-architecture/write-custom-plugins/write-your-stream.md) |
+| **Input Format** | Read records from files or streams during ingestion (Avro, JSON, Parquet, ORC, CSV, …) | [Input Formats](../../manage-data/data-import/pinot-input-formats.md) | [Input Format Plugin](../../developers/plugin-architecture/write-custom-plugins/record-reader.md) |
+| **Filesystem** | Store and fetch segments from pluggable storage backends (S3, GCS, HDFS, ADLS) | [Filesystem Plugins](../../manage-data/data-import/pinot-file-system/) | [Filesystem Plugin](../../developers/plugin-architecture/write-custom-plugins/pluggable-storage.md) |
+| **Batch Ingestion** | Run data ingestion jobs on different execution frameworks (Standalone, Hadoop, Spark) | [Batch Ingestion](../../manage-data/data-import/batch-ingestion/) | — |
+| **Metrics** | Collect and expose internal JMX metrics via Dropwizard, Yammer, or a compound backend | [Metrics Plugins](metrics-plugins.md) | [Metrics Plugin](../../developers/plugin-architecture/write-custom-plugins/metrics-plugin.md) |
+| **Segment Writer** | Programmatically build Pinot segments without a full batch ingestion job | — | [Segment Writer Plugin](../../developers/plugin-architecture/write-custom-plugins/segment-writer-plugin.md) |
+| **Segment Uploader** | Upload completed segment tar files to the Pinot cluster | — | [Segment Uploader Plugin](../../developers/plugin-architecture/write-custom-plugins/segment-uploader-plugin.md) |
+| **Minion Tasks** | Run background processing tasks on Pinot Minion nodes (merge, purge, compaction, …) | [Minion](../../basics/components/cluster/minion.md) · [Merge/Rollup Task](../../operators/operating-pinot/minion-merge-rollup-task.md) | [Minion Task Plugin](../../developers/plugin-architecture/write-custom-plugins/minion-task-plugin.md) |
+| **Environment** | Discover cloud-specific instance metadata for failure-domain–aware placement | [Environment Provider](environment-provider.md) | — |
+| **Time Series Language** | Support custom time series query languages (M3QL, PromQL) | — | [Time Series Language Plugin](../../developers/plugin-architecture/write-custom-plugins/time-series-language-plugin.md) |
+
+---
+
+## Stream Ingestion Connectors
+
+Pinot ships connectors for Apache Kafka (3.x and 4.x), Amazon Kinesis, and Apache Pulsar. Each connector supplies a `StreamConsumerFactory` implementation.
+
+{% content-ref url="stream-ingestion-connectors.md" %}
+[stream-ingestion-connectors.md](stream-ingestion-connectors.md)
+{% endcontent-ref %}
+
+{% content-ref url="stream-connector-matrix.md" %}
+[stream-connector-matrix.md](stream-connector-matrix.md)
+{% endcontent-ref %}
+
+## Input Format
+
+Input format plugins read data from files or streams during ingestion. Batch ingestion uses `RecordReader` implementations; real-time ingestion uses `StreamMessageDecoder` implementations. Pinot ships with readers for Avro, CSV, JSON, ORC, Parquet, Thrift, Protobuf, Arrow, CLP-Log, and Confluent Schema Registry variants.
+
+{% content-ref url="../../manage-data/data-import/pinot-input-formats.md" %}
+[pinot-input-formats.md](../../manage-data/data-import/pinot-input-formats.md)
+{% endcontent-ref %}
+
+## Filesystem
+
+Filesystem plugins provide a `PinotFS` storage abstraction so that segments can live on different backends — S3, GCS, HDFS, or ADLS.
+
+{% content-ref url="../../manage-data/data-import/pinot-file-system/" %}
+[pinot-file-system](../../manage-data/data-import/pinot-file-system/)
+{% endcontent-ref %}
+
+## Batch Ingestion
+
+Batch ingestion plugins run ingestion jobs on different execution frameworks: Standalone, Hadoop, Spark 2.4, and Spark 3.
+
+{% content-ref url="../../manage-data/data-import/batch-ingestion/" %}
+[batch-ingestion](../../manage-data/data-import/batch-ingestion/)
+{% endcontent-ref %}
+
+## Metrics
+
+Metrics plugins control which metrics library Pinot uses for internal JMX metrics. Pinot ships with Yammer (default), Dropwizard, and a Compound implementation that fans out to multiple registries.
+
+{% content-ref url="metrics-plugins.md" %}
+[metrics-plugins.md](metrics-plugins.md)
+{% endcontent-ref %}
+
+## Segment Writer
+
+The Segment Writer plugin provides an API for programmatically collecting `GenericRow` records and building Pinot segments without going through a full batch ingestion job. The built-in file-based implementation buffers rows as Avro records on local disk.
+
+{% content-ref url="../../developers/plugin-architecture/write-custom-plugins/segment-writer-plugin.md" %}
+[segment-writer-plugin.md](../../developers/plugin-architecture/write-custom-plugins/segment-writer-plugin.md)
+{% endcontent-ref %}
+
+## Segment Uploader
+
+The Segment Uploader plugin handles uploading completed segment tar files to the Pinot cluster. The default implementation supports all push modes configured via `batchConfigMaps` in the table config.
+
+{% content-ref url="../../developers/plugin-architecture/write-custom-plugins/segment-uploader-plugin.md" %}
+[segment-uploader-plugin.md](../../developers/plugin-architecture/write-custom-plugins/segment-uploader-plugin.md)
+{% endcontent-ref %}
+
+## Minion Tasks
+
+Minion task plugins define background processing tasks that run on Pinot Minion nodes. Built-in tasks include MergeRollup, Purge, RealtimeToOfflineSegments, SegmentGenerationAndPush, UpsertCompaction, UpsertCompactMerge, and RefreshSegment.
+
+{% content-ref url="../../basics/components/cluster/minion.md" %}
+[minion.md](../../basics/components/cluster/minion.md)
+{% endcontent-ref %}
+
+{% content-ref url="../../operators/operating-pinot/minion-merge-rollup-task.md" %}
+[minion-merge-rollup-task.md](../../operators/operating-pinot/minion-merge-rollup-task.md)
+{% endcontent-ref %}
+
+## Environment Provider
+
+Environment plugins allow Pinot to discover cloud-specific instance metadata at startup for failure-domain–aware data placement. The Azure provider is the only built-in implementation.
+
+{% content-ref url="environment-provider.md" %}
+[environment-provider.md](environment-provider.md)
+{% endcontent-ref %}
+
+## Time Series Language
+
+Time series language plugins let Pinot support custom time series query languages like M3QL and PromQL.
+
+{% content-ref url="../../developers/plugin-architecture/write-custom-plugins/time-series-language-plugin.md" %}
+[time-series-language-plugin.md](../../developers/plugin-architecture/write-custom-plugins/time-series-language-plugin.md)
+{% endcontent-ref %}
+
+---
+
+## Developing Custom Plugins
+
+Plugins implement interfaces from [pinot-spi](https://github.com/apache/pinot/tree/master/pinot-spi/src/main/java/org/apache/pinot/spi). See the developer guide for the full plugin authoring workflow:
+
+{% content-ref url="../../developers/plugin-architecture/write-custom-plugins/" %}
+[write-custom-plugins](../../developers/plugin-architecture/write-custom-plugins/)
+{% endcontent-ref %}


### PR DESCRIPTION
## Summary

- Rewrites the empty Plugin Reference landing page into a comprehensive hub covering all **ten plugin families** in Apache Pinot
- Adds a summary table mapping each plugin family to its config reference page and developer authoring guide
- Adds per-family sections with one-paragraph descriptions and GitBook content-ref navigation blocks
- Cross-links to the Plugin Architecture developer guide for custom plugin authoring

## What was cross-checked against apache/pinot

All ten plugin families and their built-in implementations were verified against the source tree:
- pinot-plugins/pinot-stream-ingestion/ — Kafka 3.0, Kafka 4.0, Kinesis, Pulsar
- pinot-plugins/pinot-input-format/ — Avro, CSV, JSON, ORC, Parquet, Thrift, Protobuf, Arrow, CLP-Log, Confluent variants
- pinot-plugins/pinot-file-system/ — S3, GCS, HDFS, ADLS
- pinot-plugins/pinot-batch-ingestion/ — Standalone, Hadoop, Spark 2.4, Spark 3
- pinot-plugins/pinot-metrics/ — Dropwizard, Yammer, Compound
- pinot-plugins/pinot-segment-writer/ — File-based
- pinot-plugins/pinot-segment-uploader/ — Default
- pinot-plugins/pinot-minion-tasks/ — MergeRollup, Purge, RealtimeToOfflineSegments, SegmentGenerationAndPush, UpsertCompaction, UpsertCompactMerge, RefreshSegment
- pinot-plugins/pinot-environment/ — Azure
- pinot-spi/ — all SPI interfaces confirmed

## Structural notes

- **No SUMMARY.md changes** — the four child pages under configuration-reference/plugin-reference/ remain as-is; the other six plugin families link to their existing pages elsewhere in the docs tree
- All 18 link targets validated — every relative link and content-ref target resolves to an existing file
- git diff --check passes clean

## Test plan

- [ ] Verify the page renders correctly in GitBook preview
- [ ] Confirm all content-ref blocks navigate to the correct pages
- [ ] Check the summary table renders properly with all links working