### PR TITLE
Normalize query cross-links and remove outdated PQL references

### DIFF
--- a/basics/components/exploring-pinot.md
+++ b/basics/components/exploring-pinot.md
@@ -96,7 +96,7 @@ from baseballStats
 order by league
 ```
 
-Pinot supports a subset of standard SQL. For more information, see [Pinot Query Language](../../users/user-guide-query/querying-pinot.md).
+Pinot uses SQL for querying. For the complete syntax reference, see the [SQL Syntax and Operators Reference](../../users/user-guide-query/sql-reference.md). For query options, examples, and engine details, see [Querying Pinot](../../users/user-guide-query/querying-pinot.md).
 
 ### Time-series query execution
 

--- a/basics/indexing/text-search-support.md
+++ b/basics/indexing/text-search-support.md
@@ -402,7 +402,7 @@ The words should be **comma separated** and in **lowercase**. Words appearing in
 
 ## Writing text search queries
 
-The `TEXT_MATCH` function enables using text search in SQL/PQL.
+The `TEXT_MATCH` function enables using text search in SQL.
 
 TEXT\_MATCH(text\_column\_name, search\_expression)
 

--- a/developers/advanced/ingestion-level-transformations.md
+++ b/developers/advanced/ingestion-level-transformations.md
@@ -107,7 +107,7 @@ Letters that are not part of Simple Date Time legend ([https://docs.oracle.com/j
 
 | Function name | Description                                                                                                                                                                                                                                                                                                       |
 | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| json\_format  | <p>Converts a JSON/AVRO complex object to a string. This json map can then be queried using <a href="../../users/user-guide-query/querying-pinot.md#transform-function-in-aggregation-and-grouping">jsonExtractScalar</a> function.</p><p><code>"json_format(jsonMapField)"</code></p> |
+| json\_format  | <p>Converts a JSON/AVRO complex object to a string. This json map can then be queried using <a href="../../users/user-guide-query/supported-transformations.md">jsonExtractScalar</a> function.</p><p><code>"json_format(jsonMapField)"</code></p> |
 
 ## Types of transformation
 

--- a/developers/developers-and-contributors/extending-pinot/custom-aggregation-function.md
+++ b/developers/developers-and-contributors/extending-pinot/custom-aggregation-function.md
@@ -1,6 +1,6 @@
 # Writing Custom Aggregation Function
 
-Pinot has many built-in Aggregation Functions such as MIN, MAX, SUM, AVG etc. See [PQL](../../../users/user-guide-query/querying-pinot.md) page for the list of aggregation functions.
+Pinot has many built-in Aggregation Functions such as MIN, MAX, SUM, AVG etc. See the [Querying Pinot](../../../users/user-guide-query/querying-pinot.md) page for the list of aggregation functions.
 
 Adding a new AggregationFunction requires two things
 

--- a/users/clients/golang.md
+++ b/users/clients/golang.md
@@ -116,7 +116,7 @@ type BrokerResponse struct {
 }
 ```
 
-Note that `AggregationResults` and `SelectionResults` are holders for Pinot query language (PQL) queries.
+Note that `AggregationResults` and `SelectionResults` are holders for legacy PQL (Pinot Query Language) queries, which have been deprecated since Pinot 0.7.1. Use the SQL API and `ResultTable` instead.
 
 Meanwhile, `ResultTable` is the holder for SQL queries. `ResultTable` is defined as:
 


### PR DESCRIPTION
## Summary
- Replace "subset of standard SQL" and "Pinot Query Language" wording on the Data Explorer page with links to the canonical SQL Syntax and Operators Reference
- Drop deprecated PQL mentions from non-historical pages (text-search-support, custom-aggregation-function, Go client)
- Fix broken anchor link in ingestion-level-transformations.md that pointed to a section moved to supported-transformations.md

## Changed files
| File | What changed |
|------|-------------|
| `basics/components/exploring-pinot.md` | "Pinot supports a subset of standard SQL… see Pinot Query Language" → "Pinot uses SQL for querying" with links to SQL reference and Querying Pinot |
| `developers/.../custom-aggregation-function.md` | Link text "PQL" → "Querying Pinot" (same target, drops deprecated term) |
| `users/clients/golang.md` | Clarified `AggregationResults`/`SelectionResults` are legacy PQL holders deprecated since 0.7.1 |
| `basics/indexing/text-search-support.md` | "SQL/PQL" → "SQL" |
| `developers/advanced/ingestion-level-transformations.md` | Fixed broken anchor `querying-pinot.md#transform-function-in-aggregation-and-grouping` → `supported-transformations.md` |

## Cross-checked against source
- PQL deprecation confirmed in Pinot 0.7.1 release notes
- Release-notes pages with historical PQL references intentionally left untouched

## Validation
- All link targets verified to exist (sql-reference.md, querying-pinot.md, supported-transformations.md)
- `git diff --check` clean — no whitespace issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)