### PR TITLE
Update community invite link to inviter.co

### DIFF
--- a/community-1/community.md
+++ b/community-1/community.md
@@ -1,6 +1,6 @@
 # Community
 
-Most Pinot related discussion happens on the [dev mailing list](https://lists.apache.org/list.html?dev@pinot.apache.org), [Github Issues](https://github.com/apache/pinot/issues) and [Slack](https://communityinviter.com/apps/apache-pinot/apache-pinot).
+Most Pinot related discussion happens on the [dev mailing list](https://lists.apache.org/list.html?dev@pinot.apache.org), [Github Issues](https://github.com/apache/pinot/issues) and [Slack](https://inviter.co/apache-pinot).
 
 ## Mailing lists
 


### PR DESCRIPTION
## Summary
- Updated the stale Slack invite link in the Community page intro from `https://communityinviter.com/apps/apache-pinot/apache-pinot` to `https://inviter.co/apache-pinot`
- The Slack Channel section on the same page already had the correct URL; this fix makes the page consistent

## Validation
- Only one occurrence of the old URL existed in the entire repo (`community-1/community.md` line 3)
- `git diff --check` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)