### PR TITLE
docs: remove Spark 2 references after EOL removal

### DIFF
--- a/configuration-reference/plugin-reference/README.md
+++ b/configuration-reference/plugin-reference/README.md
@@ -56,7 +56,7 @@ Filesystem plugins provide a `PinotFS` storage abstraction so that segments can 
 
 ## Batch Ingestion
 
-Batch ingestion plugins run ingestion jobs on different execution frameworks: Standalone, Hadoop, Spark 2.4, and Spark 3.
+Batch ingestion plugins run ingestion jobs on different execution frameworks: Standalone, Hadoop, and Spark 3.
 
 {% content-ref url="../../manage-data/data-import/batch-ingestion/" %}
 [batch-ingestion](../../manage-data/data-import/batch-ingestion/)

--- a/developers/developers-and-contributors/code-modules-and-organization.md
+++ b/developers/developers-and-contributors/code-modules-and-organization.md
@@ -66,7 +66,6 @@ The `pinot-connectors` module contains integrations for ingesting data from exte
 | Module | Description |
 | --- | --- |
 | `pinot-spark-common` | Shared code for Spark-based segment generation. |
-| `pinot-spark-2-connector` | Connector for Apache Spark 2.x batch segment generation. |
 | `pinot-spark-3-connector` | Connector for Apache Spark 3.x batch segment generation. |
 | `pinot-flink-connector` | Connector for Apache Flink segment generation and real-time ingestion. |
 

--- a/developers/plugin-architecture/README.md
+++ b/developers/plugin-architecture/README.md
@@ -13,7 +13,7 @@ Plugins are collected in folders, based on their purpose. Pinot organizes its pl
 | **Input Format** | `RecordReader` / `StreamMessageDecoder` | Avro, CSV, JSON, ORC, Parquet, Thrift, Protobuf, Arrow, CLP-Log, Confluent Avro, Confluent JSON, Confluent Protobuf |
 | **Filesystem** | `PinotFS` | S3, GCS, HDFS, ADLS |
 | **Stream Ingestion** | `StreamConsumerFactory` | Kafka 3.0, Kafka 4.0, Kinesis, Pulsar |
-| **Batch Ingestion** | `IngestionJobRunner` | Standalone, Hadoop, Spark 2.4, Spark 3 |
+| **Batch Ingestion** | `IngestionJobRunner` | Standalone, Hadoop, Spark 3 |
 | **Metrics** | `PinotMetricsFactory` | Dropwizard, Yammer, Compound |
 | **Segment Writer** | `SegmentWriter` | File-based |
 | **Segment Uploader** | `SegmentUploader` | Default |

--- a/manage-data/data-import/batch-ingestion/README.md
+++ b/manage-data/data-import/batch-ingestion/README.md
@@ -16,7 +16,6 @@ Pinot provides several batch ingestion modes. Use the table below to pick the on
 |------|----------|---------------|------------|--------|
 | Standalone | Dev/test, small jobs, scripted pipelines | None (single JVM) | Up to a few GB | Recommended for dev |
 | Spark 3 | Production batch ingestion | Spark 3.x cluster | GB to TB+ | Recommended for production |
-| Spark 2.4 | Legacy Spark 2.4 environments | Spark 2.4 cluster | GB to TB+ | Maintenance mode |
 | Hadoop | Existing MapReduce pipelines | Hadoop cluster | GB to TB+ | Legacy |
 | Flink | Streaming-first orgs, backfill, upsert bootstrap | Flink cluster | GB to TB+ | Active |
 | LaunchDataIngestionJob | CLI wrapper for Standalone | None | Up to a few GB | Convenience tool |
@@ -26,8 +25,6 @@ Pinot provides several batch ingestion modes. Use the table below to pick the on
 **Standalone** is the simplest option and requires no distributed computing framework. It runs segment generation in a single JVM process, making it ideal for development, testing, and small production jobs where data volumes are modest (up to a few GB). It is also well suited for scripted CI/CD pipelines.
 
 **Spark 3** is the recommended choice for production batch ingestion at scale. It distributes segment generation across a Spark 3.x cluster, enabling you to process datasets ranging from gigabytes to terabytes and beyond. If you are setting up a new Spark-based pipeline, use this mode.
-
-**Spark 2.4** provides the same distributed capabilities but targets legacy Spark 2.4 environments. It is in maintenance mode; new projects should prefer Spark 3.
 
 **Hadoop** uses MapReduce to generate segments on a Hadoop cluster. It is considered legacy and is primarily useful if you have existing MapReduce infrastructure and pipelines that you cannot migrate away from.
 
@@ -43,7 +40,6 @@ All artifacts use the group ID `org.apache.pinot`. Replace `${pinot.version}` wi
 |------|------------|-------|
 | Standalone | `pinot-batch-ingestion-standalone` | Included in the Pinot binary distribution |
 | Spark 3 | `pinot-batch-ingestion-spark-3` | Located in `plugins-external/pinot-batch-ingestion/` |
-| Spark 2.4 | `pinot-batch-ingestion-spark-2.4` | Located in `plugins-external/pinot-batch-ingestion/` |
 | Hadoop | `pinot-batch-ingestion-hadoop` | Located in `plugins-external/pinot-batch-ingestion/` |
 | Flink | `pinot-flink-connector` | Located in `pinot-connectors/` |
 | Common | `pinot-batch-ingestion-common` | Shared library used by all modes |

--- a/manage-data/data-import/batch-ingestion/spark.md
+++ b/manage-data/data-import/batch-ingestion/spark.md
@@ -4,7 +4,7 @@ description: Batch ingestion of data into Apache Pinot using Apache Spark.
 
 # Spark
 
-Pinot supports Apache Spark (2.x and 3.x) as a processor to create and push segment files to the database. Pinot distribution is bundled with the Spark code to process your files and convert and upload them to Pinot.
+Pinot supports Apache Spark 3.x as a processor to create and push segment files to the database. Pinot distribution is bundled with the Spark code to process your files and convert and upload them to Pinot.
 
 To set up Spark, do one of the following:
 
@@ -72,8 +72,8 @@ spark-submit //
 --class org.apache.pinot.tools.admin.command.LaunchDataIngestionJobCommand //
 --master local --deploy-mode client //
 --conf "spark.driver.extraJavaOptions=-Dplugins.dir=${PINOT_DISTRIBUTION_DIR}/plugins" //
---conf "spark.driver.extraClassPath=${PINOT_DISTRIBUTION_DIR}/plugins-external/pinot-batch-ingestion/pinot-batch-ingestion-spark-2.4/pinot-batch-ingestion-spark-2.4-${PINOT_VERSION}-shaded.jar:${PINOT_DISTRIBUTION_DIR}/lib/pinot-all-${PINOT_VERSION}-jar-with-dependencies.jar" //
--conf "spark.executor.extraClassPath=${PINOT_DISTRIBUTION_DIR}/plugins-external/pinot-batch-ingestion/pinot-batch-ingestion-spark-2.4/pinot-batch-ingestion-spark-2.4-${PINOT_VERSION}-shaded.jar:${PINOT_DISTRIBUTION_DIR}/lib/pinot-all-${PINOT_VERSION}-jar-with-dependencies.jar" //
+--conf "spark.driver.extraClassPath=${PINOT_DISTRIBUTION_DIR}/plugins-external/pinot-batch-ingestion/pinot-batch-ingestion-spark-3/pinot-batch-ingestion-spark-3-${PINOT_VERSION}-shaded.jar:${PINOT_DISTRIBUTION_DIR}/lib/pinot-all-${PINOT_VERSION}-jar-with-dependencies.jar" //
+-conf "spark.executor.extraClassPath=${PINOT_DISTRIBUTION_DIR}/plugins-external/pinot-batch-ingestion/pinot-batch-ingestion-spark-3/pinot-batch-ingestion-spark-3-${PINOT_VERSION}-shaded.jar:${PINOT_DISTRIBUTION_DIR}/lib/pinot-all-${PINOT_VERSION}-jar-with-dependencies.jar" //
 local://${PINOT_DISTRIBUTION_DIR}/lib/pinot-all-${PINOT_VERSION}-jar-with-dependencies.jar -jobSpecFile /path/to/spark_job_spec.yaml
 ```
 
@@ -102,20 +102,13 @@ spark-submit //
 --class org.apache.pinot.tools.admin.command.LaunchDataIngestionJobCommand //
 --master yarn --deploy-mode cluster //
 --conf "spark.driver.extraJavaOptions=-Dplugins.dir=${PINOT_DISTRIBUTION_DIR}/plugins" //
---conf "spark.driver.extraClassPath=pinot-batch-ingestion-spark-2.4/pinot-batch-ingestion-spark-2.4-${PINOT_VERSION}-shaded.jar:pinot-all-${PINOT_VERSION}-jar-with-dependencies.jar" //
---conf "spark.executor.extraClassPath=pinot-batch-ingestion-spark-2.4/pinot-batch-ingestion-spark-2.4-${PINOT_VERSION}-shaded.jar:pinot-all-${PINOT_VERSION}-jar-with-dependencies.jar" //
---jars "${PINOT_DISTRIBUTION_DIR}/plugins-external/pinot-batch-ingestion/pinot-batch-ingestion-spark-2.4/pinot-batch-ingestion-spark-2.4-${PINOT_VERSION}-shaded.jar,${PINOT_DISTRIBUTION_DIR}/lib/pinot-all-${PINOT_VERSION}-jar-with-dependencies.jar"
+--conf "spark.driver.extraClassPath=pinot-batch-ingestion-spark-3/pinot-batch-ingestion-spark-3-${PINOT_VERSION}-shaded.jar:pinot-all-${PINOT_VERSION}-jar-with-dependencies.jar" //
+--conf "spark.executor.extraClassPath=pinot-batch-ingestion-spark-3/pinot-batch-ingestion-spark-3-${PINOT_VERSION}-shaded.jar:pinot-all-${PINOT_VERSION}-jar-with-dependencies.jar" //
+--jars "${PINOT_DISTRIBUTION_DIR}/plugins-external/pinot-batch-ingestion/pinot-batch-ingestion-spark-3/pinot-batch-ingestion-spark-3-${PINOT_VERSION}-shaded.jar,${PINOT_DISTRIBUTION_DIR}/lib/pinot-all-${PINOT_VERSION}-jar-with-dependencies.jar"
 --files s3://path/to/spark_job_spec.yaml
 local://pinot-all-${PINOT_VERSION}-jar-with-dependencies.jar -jobSpecFile spark_job_spec.yaml
 ```
 
-{% hint style="success" %}
-For Spark 3.x, replace `pinot-batch-ingestion-spark-2.4` with `pinot-batch-ingestion-spark-3.2` in all places in the commands.\
-\
-Also, ensure the classpath in ingestion spec is changed from `org.apache.pinot.plugin.ingestion.batch.spark.`\
-to\
-`org.apache.pinot.plugin.ingestion.batch.spark3.`
-{% endhint %}
 
 ### FAQ
 

--- a/tutorials/data-ingestion/batch-data-ingestion-in-practice.md
+++ b/tutorials/data-ingestion/batch-data-ingestion-in-practice.md
@@ -247,9 +247,9 @@ After job finished, segments are stored in `examples/batch/airlineStats/segments
 Below example is running in a spark local mode. You can download spark distribution and start it by running:
 
 ```
-wget https://downloads.apache.org/spark/spark-2.4.6/spark-2.4.6-bin-hadoop2.7.tgz
-tar xvf spark-2.4.6-bin-hadoop2.7.tgz
-cd spark-2.4.6-bin-hadoop2.7
+wget https://downloads.apache.org/spark/spark-3.2.0/spark-3.2.0-bin-hadoop2.7.tgz
+tar xvf spark-3.2.0-bin-hadoop2.7.tgz
+cd spark-3.2.0-bin-hadoop2.7
 ./bin/spark-shell --master 'local[2]'
 ```
 

--- a/tutorials/data-ingestion/ingest-parquet-files-from-s3-using-spark.md
+++ b/tutorials/data-ingestion/ingest-parquet-files-from-s3-using-spark.md
@@ -14,7 +14,7 @@ You can check out [Batch Ingestion](../../manage-data/data-import/batch-ingestio
 
 We are using the following tools and frameworks for this tutorial -
 
-* [Apache Spark](https://spark.apache.org) 2.4.0 (Although any spark 2.X should work)
+* [Apache Spark](https://spark.apache.org) 3.2.0 (Although any Spark 3.x should work)
 * [Apache Parquet](https://parquet.apache.org) 1.8.2
 * [Amazon S3](https://aws.amazon.com/s3/)
 * [Apache Pinot](http://pinot.apache.org) (1.4.0 or later recommended)


### PR DESCRIPTION
Documentation for apache/pinot#17950 - removes Spark 2 references

This PR removes all references to Spark 2.4 and pinot-spark-2-connector from the documentation following the EOL removal in the upstream PR.

Changes:
- Updated batch ingestion decision guide (removed Spark 2.4 row)
- Updated Maven artifact coordinates (removed Spark 2.4)
- Updated code module documentation (removed pinot-spark-2-connector)
- Updated plugin architecture reference (removed Spark 2.4)
- Updated Spark tutorial to use Spark 3.2.0
- Removed Spark 2 classpath examples and replaced with Spark 3