### PR TITLE
docs: flatten cluster configuration reference

### DIFF
--- a/reference/configuration-reference/README.md
+++ b/reference/configuration-reference/README.md
@@ -4,13 +4,13 @@ description: Dense reference for Pinot configuration surfaces.
 
 # Configuration Reference
 
-This section reorganizes the configuration surface into the core objects operators reach for most often: cluster, schema, table, ingestion, job specs, metrics, and plugin settings. The detailed source pages still live in the existing `configuration-reference/` tree, so this landing page acts as a stable map rather than a rewrite.
+This section reorganizes the configuration surface into the core objects operators reach for most often: cluster, schema, table, ingestion, job specs, metrics, and plugin settings. Cluster configuration is flattened directly into this section, while the other detailed source pages still live in the existing `configuration-reference/` tree.
 
 ## Reference Map
 
-| Area | Use it for | Source page |
+| Area | Use it for | Reference page |
 | --- | --- | --- |
-| Cluster | Cluster-wide knobs, query protection, and broker behavior | [Cluster](../../configuration-reference/cluster.md) |
+| Cluster | Cluster-wide knobs, query protection, and broker behavior | [Cluster](cluster.md) |
 | Schema | Column definitions, null handling, and data types | [Schema](../../configuration-reference/schema.md) |
 | Table | Offline, real-time, hybrid, routing, query, and indexing config | [Table](../../configuration-reference/table.md) |
 | Ingestion | Stream and batch ingestion settings embedded in table config | [Ingestion](../../configuration-reference/ingestion.md) |

--- a/reference/configuration-reference/cluster.md
+++ b/reference/configuration-reference/cluster.md
@@ -4,28 +4,107 @@ description: Cluster-level configuration reference.
 
 # Cluster Configuration
 
-This page is the reference entry point for cluster-level settings: controller-backed configs, broker safeguards, query-engine toggles, and resource-accounting controls. The canonical field-by-field definitions remain in the existing cluster config page.
+Cluster configuration values are stored centrally and applied across Pinot components. Use this page when the setting should affect the cluster as a whole instead of a single broker, server, or controller process.
 
 ## Key Areas
 
-| Area | Why it matters | Source |
+| Area | Why it matters | Jump to |
 | --- | --- | --- |
-| Cluster configs | Global config values stored in ZK and read by Pinot components | [Cluster](../../configuration-reference/cluster.md) |
-| Query safety | Broker query limits, query-console visibility, and MSE enablement | [Cluster](../../configuration-reference/cluster.md) |
-| Resource accounting | CPU and memory sampling plus automatic query killing | [Cluster](../../configuration-reference/cluster.md) |
+| [Cluster configs](#cluster-configs) | Global config values stored in ZooKeeper and read by Pinot components | Core cluster behavior |
+| [Query safety](#query-safety) | Broker query limits, query-console visibility, and multi-stage engine controls | Query guardrails |
+| [Resource accounting](#resource-accounting) | CPU and memory sampling plus automatic query killing | Workload isolation |
+| [Cluster config APIs](#cluster-config-apis) | Controller endpoints for reading and updating cluster config | Operational workflows |
 
-## What this page covered
+## Cluster Configs
 
-- The cluster-level settings you are most likely to touch.
-- The source page that holds the full property table and REST examples.
-- The operational areas affected by cluster config.
+These settings control baseline cluster behavior and compatibility semantics.
 
-## Next step
+| Property | Default | Description |
+| --- | --- | --- |
+| allowParticipantAutoJoin | true | Helix property that allows Pinot servers, brokers, and controllers to automatically join the cluster. When set to `false`, you must explicitly invoke the `/Instance/addInstance` API. Pinot checks this property only when a node starts and it has no effect once the node is already connected. |
+| enable.case.insensitive | true | Pinot queries are case insensitive by default, including table and column names. If you set this to `false`, Pinot uses the exact case defined in the schema. This property is applicable to brokers and is read only when the broker starts, so changing it requires a broker restart. |
+| default.hyperloglog.log2m | 8 | Default `log2m` value for HyperLogLog-based approximate distinct-count functions. |
 
-Use the controller API or cluster config page to verify the exact property name before changing a live cluster.
+## Query Safety
 
-## Related pages
+These settings control broker-side query protection, query-console exposure, and cluster-wide query engine behavior.
+
+| Property | Default | Description |
+| --- | --- | --- |
+| pinot.broker.enable.query.limit.override | false | Protects the cluster from queries with very large `LIMIT` values. When enabled, Pinot brokers override query limits that exceed the broker config `pinot.broker.query.response.limit` (default `2147483647`). For example, if `pinot.broker.query.response.limit=1000`, then `SELECT * FROM myTable LIMIT 25000` is rewritten to use `LIMIT 1000`. |
+| queryConsoleOnlyView | false | Shows only the query console in the controller web UI. Use this when you do not want to expose cluster or ZooKeeper UI pages to end users. |
+| hideQueryConsoleTab | false | Hides the query console tab from the controller web UI. |
+| pinot.multistage.engine.tls.enabled | false | Enables TLS on brokers and servers for the multi-stage query engine. When enabled, Pinot uses TLS for gRPC connections between brokers and servers for plan dispatch and final results, and between servers for data shuffle and exchange. |
+| pinot.lucene.max.clause.count | 1024 | Maximum number of clauses allowed in Lucene text-search queries. Increase this value when complex text queries hit Lucene `TooManyClauses` exceptions. |
+| pinot.multistage.engine.enabled | true | Enables the multi-stage query engine for the cluster. When set to `false`, all queries use the single-stage engine. |
+
+## Resource Accounting
+
+These settings enable per-query CPU and memory tracking plus optional protection against runaway queries.
+
+| Property | Default | Description |
+| --- | --- | --- |
+| accounting.factory.name |  | Fully qualified class name for the resource-accounting factory. Resource accounting tracks CPU time and memory allocation per query for workload isolation. |
+| accounting.enable.thread.cpu.sampling | false | Enables per-thread CPU time sampling for resource accounting. This adds visibility into CPU usage per query, but also adds measurement overhead. |
+| accounting.enable.thread.memory.sampling | false | Enables per-thread memory-allocation sampling for resource accounting. |
+| accounting.oom.enable.killing.query | false | When `true` and resource accounting is enabled, Pinot can kill queries that consume excessive memory in order to prevent `OutOfMemoryError`. |
+| accounting.cpu.time.based.killing.enabled | false | When `true`, Pinot can kill queries that exceed the CPU time threshold configured by `accounting.cpu.time.based.killing.threshold.ms`. |
+| accounting.cpu.time.based.killing.threshold.ms | 30000 | CPU time threshold in milliseconds beyond which a query may be killed when CPU-based killing is enabled. |
+
+## Cluster Config APIs
+
+Use the controller APIs to inspect or update cluster-level configuration.
+
+### List All Cluster Configs
+
+<mark style="color:blue;">`GET`</mark> `http://<controller>:<port>/cluster/configs`
+
+**Description**
+
+- Lists all configurations set at the cluster level.
+
+{% tabs %}
+{% tab title="200 " %}
+```json
+{
+  "allowParticipantAutoJoin": "true",
+  "enable.case.insensitive": "false",
+  "pinot.broker.enable.query.limit.override": "false",
+  "default.hyperloglog.log2m": "8"
+}
+```
+{% endtab %}
+{% endtabs %}
+
+### Update Cluster Configs
+
+<mark style="color:green;">`POST`</mark> `http://<controller>:<port>/cluster/configs`
+
+Add new cluster configs or update existing ones.
+
+#### Request Body
+
+| Name | Type | Description |
+| --- | --- | --- |
+|  | string | JSON body containing the configs map for new or updated values. Example: `{\"queryConsoleOnlyView\":\"true\"}` |
+
+{% tabs %}
+{% tab title="200 " %}
+```json
+{
+  "status": "Updated cluster config."
+}
+```
+{% endtab %}
+{% endtabs %}
+
+Example:
+
+<!-- Image removed: swagger-cluster-config screenshot was missing from the repository -->
+
+## Related Pages
 
 - [Configuration Reference](README.md)
-- [Table](../../configuration-reference/table.md)
-- [Query Using Cursors](../../users/user-guide-query/query-using-cursors.md)
+- [Table Configuration](table.md)
+- [Broker](../../configuration-reference/broker.md)
+- [Multi-Stage Query Engine](../multi-stage-engine.md)


### PR DESCRIPTION
## Summary
- replace the stubbed cluster configuration reference page with a flat, self-contained reference
- turn the key area links into same-page anchors and inline the cluster config tables and controller API examples
- update the configuration reference landing page so the cluster entry points at the flattened page

## Testing
- python scripts/validate-docs.py --changed-only <(printf "reference/configuration-reference/cluster.md
reference/configuration-reference/README.md
")