### PR TITLE
docs: standardize MSE terminology and reframe as production-ready engine

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -510,7 +510,7 @@
   * [Debugging Pinot](operate-pinot/troubleshooting/troubleshooting-pinot.md)
     * [General FAQ](operate-pinot/troubleshooting/general-faq.md)
   * [Query FAQ](operate-pinot/troubleshooting/query-faq.md)
-    * [Troubleshoot Multi-Stage Query Engine (v2)](operate-pinot/troubleshooting/troubleshoot-multi-stage-query-engine.md)
+    * [Troubleshoot Multi-Stage Engine (MSE)](operate-pinot/troubleshooting/troubleshoot-multi-stage-query-engine.md)
   * [Ingestion FAQ](operate-pinot/troubleshooting/ingestion-faq.md)
     * [Realtime Ingestion Stopped](operate-pinot/troubleshooting/realtime-ingestion-stopped.md)
   * [Operations FAQ](operate-pinot/troubleshooting/operations-faq.md)

--- a/build-with-pinot/ingestion/batch-ingestion/dim-table.md
+++ b/build-with-pinot/ingestion/batch-ingestion/dim-table.md
@@ -155,7 +155,7 @@ LIMIT 10
 
 ### Multi-stage engine
 
-In the multi-stage query engine (v2), use a standard `JOIN` with the lookup join strategy hint instead of the `LOOKUP` UDF:
+In the multi-stage engine (MSE), use a standard `JOIN` with the lookup join strategy hint instead of the `LOOKUP` UDF:
 
 ```sql
 SELECT /*+ lookupJoinStrategy(dim_billing) */

--- a/build-with-pinot/querying-and-sql/function-index.md
+++ b/build-with-pinot/querying-and-sql/function-index.md
@@ -412,7 +412,7 @@ For full details, see [Type Conversion Functions](../../functions/type-conversio
 For full details, see [Window Functions](../../functions/window).
 
 {% hint style="info" %}
-Window functions require the [multi-stage query engine (v2)](../../reference/configuration-reference/cluster.md).
+Window functions require the [multi-stage engine (MSE)](../../reference/configuration-reference/cluster.md).
 {% endhint %}
 
 | Function | Signature | Return Type | Description | Engine |

--- a/build-with-pinot/querying-and-sql/joins.md
+++ b/build-with-pinot/querying-and-sql/joins.md
@@ -10,7 +10,7 @@ description: >-
 This page explains the syntax used to write join. In order to get a more in deep knowledge of how joins work it is recommended to read [Optimizing joins](multi-stage-query/optimizing-joins.md) and also [this blog](https://startree.ai/resources/query-time-joins-in-apache-pinot-1-0) from Star Tree.
 
 {% hint style="info" %}
-**Important:** To query using JOINs, you must [use Pinot's multi-stage query engine (v2).](../../build-with-pinot/querying-and-sql/sse-vs-mse.md)
+**Important:** To query using JOINs, you must [use Pinot's multi-stage engine (MSE).](../../build-with-pinot/querying-and-sql/sse-vs-mse.md)
 {% endhint %}
 
 ## INNER JOIN

--- a/build-with-pinot/querying-and-sql/multi-stage-query/README.md
+++ b/build-with-pinot/querying-and-sql/multi-stage-query/README.md
@@ -1,7 +1,7 @@
 ---
-description: Learn more about multi-stage query engine and how to troubleshoot issues.
+description: Deep dive into the multi-stage engine (MSE) internals, execution model, and troubleshooting.
 ---
 
 # Multi-stage query
 
-The general explanation of the multi-stage query engine is provided in the [Multi-stage query engine](../../../build-with-pinot/querying-and-sql/sse-vs-mse.md) reference documentation. This section provides a deep dive into the multi-stage query engine. Most of the concepts explained here are related to the internals of the multi-stage query engine and users don't need to know about them in order to write queries. However, understanding these concepts can help you to take advantage of the engine's capabilities and to troubleshoot issues.
+For an overview of when to use the multi-stage engine (MSE) versus the single-stage engine (SSE), see [Query Engines (SSE vs MSE)](../../../build-with-pinot/querying-and-sql/sse-vs-mse.md). This section provides a deep dive into MSE internals. Most of the concepts explained here are related to the engine's execution model and are not required for writing queries. However, understanding them can help you take advantage of MSE's capabilities and troubleshoot issues.

--- a/build-with-pinot/querying-and-sql/multi-stage-query/operator-types/leaf.md
+++ b/build-with-pinot/querying-and-sql/multi-stage-query/operator-types/leaf.md
@@ -12,7 +12,7 @@ The leaf operator is not a relational operator itself but a meta-operator that i
 
 As a result, leaf stage operators can use all the optimizations and indices that the single-stage engine can use but it also means that there may be slight differences when an operator is executed in a leaf stage compared to when it is executed in an intermediate stage. For example, operations pushed down to the leaf stage may use indexes (see [how to know if indexes are used](filter.md#how-to-know-if-indexes-are-used)) or the semantics can be slightly different.
 
-You can read [Troubleshoot issues with the multi-stage query engine (v2)](../../../../operate-pinot/troubleshooting/troubleshoot-multi-stage-query-engine.md) for more information on the differences between the leaf and intermediate stages, but the main ones are:
+You can read [Troubleshoot issues with the multi-stage engine (MSE)](../../../../operate-pinot/troubleshooting/troubleshoot-multi-stage-query-engine.md) for more information on the differences between the leaf and intermediate stages, but the main ones are:
 
 * Null handling is different.
 * Some functions are only supported in multi-stage and some others only in single-stage.

--- a/build-with-pinot/querying-and-sql/querying-pinot.md
+++ b/build-with-pinot/querying-and-sql/querying-pinot.md
@@ -48,7 +48,7 @@ Use multi-stage execution when you need features that are not available in singl
 - window functions
 - more complex distributed query shapes
 
-If you are unsure, start with the single-stage engine and switch only when the query requires it.
+As a rule of thumb: use SSE for simple filtering, aggregation, and top-K queries; use MSE when your query shape requires joins, subqueries, window functions, or other advanced relational operators.
 
 ## What this page covered
 
@@ -79,14 +79,14 @@ Pinot provides a SQL interface for querying, which uses the **Calcite SQL** pars
 For a complete reference of all supported SQL statements, clauses, operators, and engine compatibility, see the [SQL Syntax and Operators Reference](../../build-with-pinot/querying-and-sql/sql-reference.md).
 {% endhint %}
 
-## Pinot 1.0
+## Multi-stage engine (MSE)
 
-In Pinot 1.0, the multi-stage query engine supports inner join, left-outer, semi-join, and nested queries out of the box. It's optimized for in-memory process and latency. For more information, see how to [enable and use the multi-stage query engine](../../build-with-pinot/querying-and-sql/sse-vs-mse.md).
+The multi-stage engine (MSE) supports inner join, left-outer, semi-join, window functions, and nested queries. It is optimized for in-memory, low-latency execution. For more information, see [Query Engines (SSE vs MSE)](../../build-with-pinot/querying-and-sql/sse-vs-mse.md).
 
-Pinot also supports using simple Data Definition Language (DDL) to insert data into a table from file directly. For details, see [programmatically access the multi-stage query engine](../../build-with-pinot/querying-and-sql/sse-vs-mse.md#programmatically-access-the-multi-stage-query-engine). More DDL supports will be added in the future. But for now, the most common way for data definition is using the [Controller Admin API](../../reference/api-reference/controller-admin-api.md).
+Pinot also supports using simple Data Definition Language (DDL) to insert data into a table from file directly. For details, see [programmatically access the multi-stage engine](../../build-with-pinot/querying-and-sql/sse-vs-mse.md#programmatically-access-the-multi-stage-query-engine). More DDL support will be added in the future. For now, the most common way for data definition is using the [Controller Admin API](../../reference/api-reference/controller-admin-api.md).
 
 {% hint style="info" %}
-**Note:** For queries that require a large amount of data shuffling, require spill-to-disk, or are hitting any other limitations of the multi-stage query engine (v2), we recommend using **Trino** as a federated query engine.
+**Note:** For queries that require a large amount of data shuffling or spill-to-disk, consider using **Trino** as a federated query engine. See [Workloads better served by SSE or external query engines](../../build-with-pinot/querying-and-sql/sse-vs-mse.md#workloads-better-served-by-sse-or-external-query-engines) for guidance.
 {% endhint %}
 
 ## Identifier vs Literal

--- a/build-with-pinot/querying-and-sql/sse-vs-mse.md
+++ b/build-with-pinot/querying-and-sql/sse-vs-mse.md
@@ -1,10 +1,14 @@
 ---
-description: Understand the differences between the single-stage (v1) and multi-stage (v2) query engines and when to use each.
+description: Understand the differences between the single-stage engine (SSE) and multi-stage engine (MSE) and when to use each.
 ---
 
 # Query Engines (SSE vs MSE)
 
-Pinot ships two query engines. The **single-stage engine (SSE, v1)** uses a scatter-gather model and is the default for simple analytic queries. The **multi-stage engine (MSE, v2)**, released in Pinot 1.0.0, adds distributed joins, window functions, and other multi-stage operators.
+Pinot ships two supported query engines. The **single-stage engine (SSE)** uses a scatter-gather model and is the default for simple analytic queries. The **multi-stage engine (MSE)** supports distributed joins, window functions, subqueries, and other advanced SQL operations.
+
+SSE is the default because it has lower overhead for the most common Pinot workloads; that default does not imply that MSE is experimental. MSE is Pinot's supported engine for queries that require relational operators beyond simple scatter-gather execution.
+
+> **History:** MSE was introduced as the "v2 query engine" in Pinot 1.0.0. You may still see references to "v1" and "v2" in configuration properties such as `useMultistageEngine`.
 
 ## Quick decision
 
@@ -16,13 +20,13 @@ Pinot ships two query engines. The **single-stage engine (SSE, v1)** uses a scat
 | Colocated or partitioned joins | MSE | These are multi-stage patterns |
 | Complex operator trees or advanced SQL | MSE | Built for distributed query planning |
 
-## Single-stage engine (v1)
+## Single-stage engine (SSE)
 
 The single-stage engine uses a scatter-gather execution model. The broker receives a query, fans it out to the relevant servers, each server processes its local segments, and the broker merges the partial results.
 
 ![](<../../.gitbook/assets/Multi-Stage-Pinot-Query-Engine-v1 (2).png>)
 
-*Single-stage query engine (v1)*
+*Single-stage query engine (SSE)*
 
 **Choose SSE when:**
 
@@ -32,7 +36,7 @@ The single-stage engine uses a scatter-gather execution model. The broker receiv
 
 SSE is the default fit for the most common Pinot workloads: filter, project, group, and aggregate.
 
-## Multi-stage engine (v2)
+## Multi-stage engine (MSE)
 
 The multi-stage engine decouples the data exchange layer from the query engine layer. It breaks queries into multiple sub-plans ("stages") that run across different sets of servers.
 
@@ -46,11 +50,11 @@ The multi-stage engine decouples the data exchange layer from the query engine l
 - You need distributed query execution with intermediate stages
 - You are running complex ANSI SQL
 
-**When not to use MSE:**
+**Workloads better served by SSE or external query engines:**
 
-- Large-scale, long-running queries that access entire datasets (MSE is pure in-memory)
-- Complex joins touching many tables with non-trivial join conditions
-- ETL-type workloads
+- Large-scale, long-running queries that scan entire datasets — MSE executes in-memory without spill-to-disk, so very large intermediate result sets can exceed available memory
+- Heavy ETL-style joins across many tables — consider an external engine such as Trino or Spark for batch-oriented workloads
+- Simple scatter-gather queries (filter, aggregate, top-K) — SSE handles these with lower overhead
 
 ### How queries are processed
 

--- a/developers/developers-and-contributors/code-modules-and-organization.md
+++ b/developers/developers-and-contributors/code-modules-and-organization.md
@@ -32,7 +32,7 @@ These modules define the interfaces, data types, and shared utilities that the r
 
 ## Query Engine (Multi-Stage)
 
-These modules power the multi-stage query engine (V2), which enables distributed joins and other advanced SQL operations.
+These modules power the multi-stage engine (MSE), which enables distributed joins and other advanced SQL operations.
 
 | Module | Description |
 | --- | --- |

--- a/functions/sketch/distinctcountcpcsketch.md
+++ b/functions/sketch/distinctcountcpcsketch.md
@@ -59,4 +59,4 @@ from baseballStats
 | ----- |
 | 58    |
 
-This function can also be used with the V2 query engine.
+This function can also be used with the multi-stage engine (MSE).

--- a/functions/sketch/distinctcountrawcpcsketch.md
+++ b/functions/sketch/distinctcountrawcpcsketch.md
@@ -55,4 +55,4 @@ from baseballStats
 | ---------------------------------- |
 | 0401100c000acc933a000000120000e... |
 
-This function can also be used with the V2 query engine.
+This function can also be used with the multi-stage engine (MSE).

--- a/functions/sketch/distinctcountrawintegersumtuplesketch.md
+++ b/functions/sketch/distinctcountrawintegersumtuplesketch.md
@@ -51,4 +51,4 @@ from baseballStats
 | ------------------------------------------- |
 | AwMJAQAKzJMQAAAAAAAAAK8pD3/6nBcAQWgQ6zI8... |
 
-This function can also be used with the V2 query engine.
+This function can also be used with the multi-stage engine (MSE).

--- a/functions/sketch/distinctcounttuplesketch.md
+++ b/functions/sketch/distinctcounttuplesketch.md
@@ -51,4 +51,4 @@ from baseballStats
 | ----- |
 | 17549 |
 
-This function can also be used with the V2 query engine.
+This function can also be used with the multi-stage engine (MSE).

--- a/functions/window/README.md
+++ b/functions/window/README.md
@@ -9,7 +9,7 @@ description: >-
 
 
 {% hint style="info" %}
-**Important:** To query using Windows functions, you must enable Pinot's [multi-stage query engine (v2)](../../reference/configuration-reference/cluster.md). See how to [enable and use the multi-stage query engine (v2](../../build-with-pinot/querying-and-sql/sse-vs-mse.md)).
+**Important:** To query using window functions, you must enable Pinot's [multi-stage engine (MSE)](../../reference/configuration-reference/cluster.md). See how to [enable and use the multi-stage engine (MSE)](../../build-with-pinot/querying-and-sql/sse-vs-mse.md).
 {% endhint %}
 
 ## Window Functions overview

--- a/operate-pinot/troubleshooting/README.md
+++ b/operate-pinot/troubleshooting/README.md
@@ -15,7 +15,7 @@ Queries returning errors, unexpected results, or timing out.
 | Symptom | Go to |
 |---|---|
 | `BrokerResourceMissingError`, reserved keyword errors, wrong results, slow queries | [Query FAQ](query-faq.md) |
-| Errors or limitations specific to the multi-stage query engine (v2), including type mismatches, unsupported functions, or timeout errors | [Troubleshoot Multi-Stage Query Engine](troubleshoot-multi-stage-query-engine.md) |
+| Errors or limitations specific to the multi-stage engine (MSE), including type mismatches, unsupported functions, or timeout errors | [Troubleshoot Multi-Stage Engine (MSE)](troubleshoot-multi-stage-query-engine.md) |
 
 ### Ingestion issues
 

--- a/operate-pinot/troubleshooting/troubleshoot-multi-stage-query-engine.md
+++ b/operate-pinot/troubleshooting/troubleshoot-multi-stage-query-engine.md
@@ -1,10 +1,10 @@
 ---
-description: Troubleshoot issues with the multi-stage query engine (v2).
+description: Troubleshoot issues with the multi-stage engine (MSE).
 ---
 
-# Troubleshoot issues with the multi-stage query engine (v2)
+# Troubleshoot issues with the multi-stage engine (MSE)
 
-Learn how to [troubleshoot errors](troubleshoot-multi-stage-query-engine.md#troubleshoot-errors) when using the multi-stage query engine (v2), and see [multi-stage query engine limitations](troubleshoot-multi-stage-query-engine.md#limitations-of-the-multi-stage-query-engine).
+Learn how to [troubleshoot errors](troubleshoot-multi-stage-query-engine.md#troubleshoot-errors) when using the multi-stage engine (MSE), and see [multi-stage engine limitations](troubleshoot-multi-stage-query-engine.md#limitations-of-the-multi-stage-query-engine).
 
 Find instructions on [how to enable the multi-stage query engine](../../build-with-pinot/querying-and-sql/sse-vs-mse.md), or see a high-level overview of [how the multi-stage query engine works](../../build-with-pinot/querying-and-sql/sse-vs-mse.md).
 
@@ -258,4 +258,4 @@ Troubleshoot semantic/runtime errors and timeout errors.
 * Try executing part of the subquery or a simplified version of the query first.
   * This helps to determine the selectivity and scale of the query being executed.
 * Try adding more servers.
-  * The new multi-stage engine runs distributed across the entire cluster, so adding more servers to partitioned queries such as GROUP BY aggregates, and equality JOINs help speed up the query runtime.
+  * The multi-stage engine (MSE) runs distributed across the entire cluster, so adding more servers to partitioned queries such as GROUP BY aggregates, and equality JOINs help speed up the query runtime.


### PR DESCRIPTION
## Summary
- Replace transitional "v2 query engine" and "new multi-stage" phrasing with consistent "multi-stage engine (MSE)" / "single-stage engine (SSE)" terminology across 16 files
- Reframe MSE as Pinot's supported engine for joins, window functions, and complex SQL — not a preview-era "new v2 option"
- Add explicit sentence: SSE is the default for lower-overhead simple queries; that default does NOT imply MSE is experimental
- Replace "If you are unsure, start with SSE" with workload-fit guidance (SSE for filter/aggregate/top-K, MSE for joins/subqueries/windows)
- Rename "When not to use MSE" → "Workloads better served by SSE or external query engines"
- Retain "v2" only as a historical/configuration note on the main SSE-vs-MSE page
- Release notes intentionally untouched (historical records)

## Test plan
- [ ] Verify all internal links resolve correctly (no broken anchors from renamed headings)
- [ ] Confirm no core MSE page describes MSE as "new"
- [ ] Confirm consistent use of "single-stage engine (SSE)" and "multi-stage engine (MSE)" on core pages
- [ ] Review that technical caveats (in-memory resource model, unsupported cases) are preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)