### PR TITLE
docs: refactor MSE troubleshooting into operator support structure

### DIFF
--- a/operate-pinot/troubleshooting/troubleshoot-multi-stage-query-engine.md
+++ b/operate-pinot/troubleshooting/troubleshoot-multi-stage-query-engine.md
@@ -4,212 +4,87 @@ description: Troubleshoot issues with the multi-stage engine (MSE).
 
 # Troubleshoot issues with the multi-stage engine (MSE)
 
-Learn how to [troubleshoot errors](troubleshoot-multi-stage-query-engine.md#troubleshoot-errors) when using the multi-stage engine (MSE), and see [multi-stage engine limitations](troubleshoot-multi-stage-query-engine.md#limitations-of-the-multi-stage-query-engine).
+This page covers behavior differences between the single-stage engine (SSE) and multi-stage engine (MSE), current limitations, and a troubleshooting checklist for diagnosing query issues.
 
-Find instructions on [how to enable the multi-stage query engine](../../build-with-pinot/querying-and-sql/sse-vs-mse.md), or see a high-level overview of [how the multi-stage query engine works](../../build-with-pinot/querying-and-sql/sse-vs-mse.md). For operational guidance on running MSE in production, see [Run the Multi-Stage Engine in Production](../production-guides/run-multi-stage-engine-in-production.md).
+For instructions on enabling the MSE, see [SSE vs MSE](../../build-with-pinot/querying-and-sql/sse-vs-mse.md). For operational guidance on running MSE in production, see [Run the Multi-Stage Engine in Production](../production-guides/run-multi-stage-engine-in-production.md).
 
-## Limitations of the multi-stage query engine
+## Operator checklist
 
-We are continuously improving the multi-stage query engine. A few limitations to call out:
+Run through these steps before investigating further:
 
-### Support for multi-value columns is limited
+1. **Confirm MSE is enabled.** Verify `useMultistageEngine=true` is set in the query options or broker configuration.
+2. **Confirm query options.** Check that all required query options (timeouts, resource limits) are set appropriately for your workload.
+3. **Inspect the explain plan.** Run `EXPLAIN PLAN FOR <query>` to verify the query compiles and the plan looks reasonable.
+4. **Inspect stage stats.** Review stage-level statistics in the query response to identify which stage is slow or producing unexpected results.
+5. **Verify guardrail and query-limit settings.** Check that server-side limits (max rows in join, max rows in window, stage timeout) are not causing premature termination.
 
-Support for multi-value columns is limited to projections, and predicates must use the `arrayToMv` function. For example, to successfully run the following query:
+## Behavior differences from SSE
 
-{% code overflow="wrap" %}
-```sql
--- example 1: used in GROUP-BY
-SELECT count(*), RandomAirports FROM airlineStats 
-GROUP BY RandomAirports
+The MSE enforces stricter SQL semantics than the SSE. The following sections describe specific differences that can affect query results or compatibility.
 
--- example 2: used in PREDICATE
-SELECT * FROM airlineStats WHERE RandomAirports IN ('SFO', 'JFK')
+### Case sensitivity
 
--- example 3: used in ORDER-BY
-SELECT count(*), RandomAirports FROM airlineStats 
-GROUP BY RandomAirports
-ORDER BY RandomAirports DESC
-```
-{% endcode %}
-
-You must include `arrayToMv` in the query as follows:
-
-{% code overflow="wrap" %}
-```sql
--- example 1: used in GROUP-BY
-SELECT count(*), arrayToMv(RandomAirports) FROM airlineStats 
-GROUP BY arrayToMv(RandomAirports)
-
--- example 2: used in PREDICATE
-SELECT * FROM airlineStats WHERE arrayToMv(RandomAirports) IN ('SFO', 'JFK')
-
--- example 3: used in ORDER-BY
-SELECT count(*), arrayToMV(RandomAirports) FROM airlineStats 
-GROUP BY arrayToMV(RandomAirports)
-ORDER BY arrayToMV(RandomAirports) DESC
-```
-{% endcode %}
-
-### Schema and other prefixes are not supported
-
-Schema and other prefixes are not supported in queries. For example, the following queries are _**not**_ supported:
-
-```
-SELECT* from default.myTable;
-SELECT * from schemaName.myTable;
-```
-
-Queries _**without prefixes are supported**_:
-
-```
-SELECT * from myTable;
-```
-
-### Modifying query behavior based on the cluster config is not supported
-
-Modifying query behavior based on the cluster configuration is not supported. `distinctcounthll`, `distinctcounthllmv`, `distinctcountrawhll`, and `distinctcountrawhllmv` will always use the default value for `log2m` in the multi-stage engine unless the value is explicitly defined in the query itself. Therefore, the following query may produce different results in single-stage and multi-stage engine depending on your cluster configuration (`default.hyperloglog.log2m`):
-
-```sql
-select distinctcounthll(col) from myTable
-```
-
-To ensure same results across both query engines, specify the `log2m` param value explicitly in your query:
-
-```sql
-select distinctcounthll(col, 8) from myTable
-```
-
-### Ambiguous reference to a projected column in statement clauses
-
-If a column is repeated more than once in SELECT statement, that column requires disambiguate aliasing. For example, in the following query, the reference to `colA` is ambiguous whether it's to the first or second projected `colA`:
-
-```sql
-SELECT colA, colA, COUNT(*)
-FROM myTable GROUP BY colA ORDER BY colA
-```
-
-The solution is to rewrite the query either use aliasing:
-
-```sql
-SELECT colA AS tmpA, colA as tmpB, COUNT(*) 
-FROM myTable GROUP BY tmpA, tmpB ORDER BY tmpA
-```
-
-Or use index-based referencing:
-
-```sql
-SELECT colA, colA, COUNT(*) 
-FROM myTable GROUP BY 1, 2 ORDER BY 1
-```
-
-### Tightened restriction on function signature and type matching
-
-Pinot single-stage query engine automatically do implicit type casts in many of the situations, for example when running the following:
-
-```
-timestampCol >= longCol
-```
-
-it will automatically convert both values to long datatypes before comparison. This behavior however could cause issues and thus it is not so widely applied in the multi-stage engine where a stricter datatype conformance is enforced. the example above should be explicitly written as:
-
-```
-CAST(timestampCol AS BIGINT) >= longCol 
-```
-
-### Default names for projections with function calls
-
-Default names for projections with function calls are different between single and multi-stage.
-
-* For example, in multi-stage, the following query:
-
-```sql
-  SELECT count(*) from mytable 
-```
-
-Returns the following result:
-
-```
-    "columnNames": [
-        "EXPR$0"
-      ],
-```
-
-* In single-stage, the following function:
-
-```sql
-  SELECT count(*) from mytable
-```
-
-Returns the following result:
-
-```
-      "columnNames": [
-        "count(*)"
-      ],
-```
-
-### Table names and column names are case sensitive
-
-In multi-stage, table and column names and are case sensitive. In single-stage they were not. For example, the following two queries are not equivalent in multi-stage engine:
+In the MSE, table and column names are case sensitive. In the SSE, they were not. The following two queries are **not** equivalent in the MSE:
 
 `select * from myTable`
 
 `select * from mytable`
 
 {% hint style="info" %}
-**Note:** Function names are not case sensitive in neither single nor multi-stage.
+**Note:** Function names are not case sensitive in either engine.
 {% endhint %}
 
-### Arbitrary number of arguments isn't supported
+### Stricter type matching
 
-An arbitrary number of arguments is no longer supported in multi-stage. For example, in single-stage, the following query worked:
-
-```
-select add(1,2,3,4,5) from table
-```
-
-In multi-stage, this query must be rewritten as follows:
+The SSE automatically performs implicit type casts in many situations. For example:
 
 ```
-select add(1, add(2,add(3, add(4,5)))) from table
+timestampCol >= longCol
 ```
 
-{% hint style="info" %}
-**Note:** Remember that `select 1 + 2 + 3 + 4 + 5 from table` is still valid in multi-stage
-{% endhint %}
+The SSE converts both values to long before comparison. The MSE enforces stricter datatype conformance, so the query above should be explicitly written as:
 
-### Return type for binary arithmetic operators (+, -, \*, /)
+```
+CAST(timestampCol AS BIGINT) >= longCol
+```
 
-In the single-stage engine, these operators would always result in a `DOUBLE` value being returned, no matter the operand types. In the multi-stage engine, however, the result type depends on the input operand types - for instance, adding two `LONG` values will result in a `LONG` and so on.
+### Projection naming differences
 
-### Return type for aggregations like SUM, MIN, MAX
+Default names for projections with function calls differ between the two engines.
 
-In the single-stage engine, these aggregations would always result in a `DOUBLE` value being returned, no matter the operand types. In the multi-stage engine, however, the result type depends on the data type of the column being aggregated.
+In the MSE, the following query:
 
-### NULL function support
+```sql
+SELECT count(*) from myTable
+```
 
-Null handling is not supported when tables use table based null storing. You have to use column based null storing instead. See [null handling support](../../build-with-pinot/querying-and-sql/null-value-support.md).
+Returns:
 
-### Custom transform function support
+```
+"columnNames": [
+    "EXPR$0"
+  ],
+```
 
-In multi-stage:
+In the SSE, the same query returns:
 
-* The `histogram` function is not supported.
-* The `timeConvert` function is not supported, see `dateTimeConvert` for more details.
-* The `dateTimeConvertWindowHop` function is not supported.
-* Array & Map-related functions are not supported.
+```
+"columnNames": [
+    "count(*)"
+  ],
+```
 
-### Custom aggregate function support
+If downstream code depends on column names in the response, use explicit aliases:
 
-* Aggregate functions that requires literal input (such as `percentile`, `firstWithTime`) might result in a non-compilable query plan.
+```sql
+SELECT count(*) AS total_count FROM myTable
+```
 
-### Different type names
+### CAST and type-name differences
 
-The multi-stage engine uses different type names than the single-stage engine. Although the classical names must still be used in schemas and some SQL expressions, the new names must be used in CAST expressions.
+The MSE uses SQL-standard type names. Although the original names are still required in schemas and some SQL expressions, the MSE names must be used in `CAST` expressions.
 
-The following table shows the differences in type names:
-
-| Single-stage engine | Multi-stage engine |
+| SSE type name       | MSE type name      |
 | ------------------- | ------------------ |
 | NULL                | NULL               |
 | BOOLEAN             | BOOLEAN            |
@@ -227,35 +102,171 @@ The following table shows the differences in type names:
 
 ### Varbinary literals
 
-VARBINARY literals in multi-stage engine must be prefixed with `X` or `x`. For example, the following query:
+VARBINARY literals in the MSE must be prefixed with `X` or `x`:
 
 ```sql
-SELECT col1, col2 FROM myTable where bytesCol = X'4a220e6096b25eadb88358cb44068a3248254675'
+SELECT col1, col2 FROM myTable WHERE bytesCol = X'4a220e6096b25eadb88358cb44068a3248254675'
 ```
 
-In single-stage engine the same query would be:
+In the SSE, the same query used an unprefixed hex string:
 
 ```sql
--- not supported in multi-stage
-SELECT col1, col2 FROM myTable where bytesCol = '4a220e6096b25eadb88358cb44068a3248254675'
+-- not supported in MSE
+SELECT col1, col2 FROM myTable WHERE bytesCol = '4a220e6096b25eadb88358cb44068a3248254675'
 ```
 
-## Troubleshoot errors
+### Return types for arithmetic operators (+, -, \*, /)
 
-Troubleshoot semantic/runtime errors and timeout errors.
+In the SSE, binary arithmetic operators always return `DOUBLE` regardless of operand types. In the MSE, the result type depends on the input types. For example, adding two `LONG` values returns a `LONG`.
 
-### Semantic/runtime errors
+### Return types for aggregations (SUM, MIN, MAX)
 
-* Try downloading the latest docker image or building from the latest master commit.
-  * We continuously push bug fixes for the multi-stage engine so bugs you encountered might have already been fixed in the latest master build.
-* Try rewriting your query.
-  * Some functions previously supported in the single-stage query engine (v1) may have a new way to express in the multi-stage engine (v2). Check and see if you are using any non-standard SQL functions or semantics.
+In the SSE, these aggregations always return `DOUBLE`. In the MSE, the result type matches the data type of the column being aggregated.
+
+### NULL handling and storage
+
+Null handling is not supported when tables use table-based null storing. Use column-based null storing instead. See [null handling support](../../build-with-pinot/querying-and-sql/null-value-support.md).
+
+### Cluster config does not modify query behavior
+
+The MSE does not read cluster-level configuration overrides for function parameters. `distinctcounthll`, `distinctcounthllmv`, `distinctcountrawhll`, and `distinctcountrawhllmv` always use the default value for `log2m` unless the value is explicitly provided in the query. The following query may produce different results between SSE and MSE depending on your cluster configuration (`default.hyperloglog.log2m`):
+
+```sql
+SELECT distinctcounthll(col) FROM myTable
+```
+
+To get consistent results across both engines, specify the `log2m` parameter explicitly:
+
+```sql
+SELECT distinctcounthll(col, 8) FROM myTable
+```
+
+### Multi-value column behavior
+
+Support for multi-value columns in the MSE is limited to projections. Predicates, GROUP BY, and ORDER BY clauses that reference multi-value columns must use the `arrayToMv` function. For example, to run:
+
+{% code overflow="wrap" %}
+```sql
+-- example 1: GROUP BY
+SELECT count(*), RandomAirports FROM airlineStats
+GROUP BY RandomAirports
+
+-- example 2: predicate
+SELECT * FROM airlineStats WHERE RandomAirports IN ('SFO', 'JFK')
+
+-- example 3: ORDER BY
+SELECT count(*), RandomAirports FROM airlineStats
+GROUP BY RandomAirports
+ORDER BY RandomAirports DESC
+```
+{% endcode %}
+
+Rewrite the query using `arrayToMv`:
+
+{% code overflow="wrap" %}
+```sql
+-- example 1: GROUP BY
+SELECT count(*), arrayToMv(RandomAirports) FROM airlineStats
+GROUP BY arrayToMv(RandomAirports)
+
+-- example 2: predicate
+SELECT * FROM airlineStats WHERE arrayToMv(RandomAirports) IN ('SFO', 'JFK')
+
+-- example 3: ORDER BY
+SELECT count(*), arrayToMV(RandomAirports) FROM airlineStats
+GROUP BY arrayToMV(RandomAirports)
+ORDER BY arrayToMV(RandomAirports) DESC
+```
+{% endcode %}
+
+## Current limitations
+
+The following are known limitations of the MSE.
+
+### Schema and other prefixes are not supported
+
+Queries cannot use schema or database prefixes. The following queries are **not** supported:
+
+```
+SELECT * FROM default.myTable;
+SELECT * FROM schemaName.myTable;
+```
+
+Use unqualified table names instead:
+
+```
+SELECT * FROM myTable;
+```
+
+### Ambiguous reference to a projected column
+
+If a column appears more than once in the SELECT list, subsequent clauses cannot reference it by name without aliasing. The following query is ambiguous:
+
+```sql
+SELECT colA, colA, COUNT(*)
+FROM myTable GROUP BY colA ORDER BY colA
+```
+
+Use aliases to disambiguate:
+
+```sql
+SELECT colA AS tmpA, colA AS tmpB, COUNT(*)
+FROM myTable GROUP BY tmpA, tmpB ORDER BY tmpA
+```
+
+Or use index-based referencing:
+
+```sql
+SELECT colA, colA, COUNT(*)
+FROM myTable GROUP BY 1, 2 ORDER BY 1
+```
+
+### Arbitrary number of arguments is not supported
+
+Variadic arguments are not supported for functions that accept a fixed signature. For example, the following query works in the SSE but not in the MSE:
+
+```
+SELECT add(1,2,3,4,5) FROM myTable
+```
+
+In the MSE, rewrite with nested calls:
+
+```
+SELECT add(1, add(2, add(3, add(4, 5)))) FROM myTable
+```
+
+{% hint style="info" %}
+**Note:** `SELECT 1 + 2 + 3 + 4 + 5 FROM myTable` is valid in the MSE.
+{% endhint %}
+
+### Unsupported transform functions
+
+* `histogram` is not supported.
+* `timeConvert` is not supported; use `dateTimeConvert` instead.
+* `dateTimeConvertWindowHop` is not supported.
+* Array and map-related functions are not supported.
+
+### Aggregate functions with literal inputs
+
+Aggregate functions that require literal input (such as `percentile`, `firstWithTime`) may produce a non-compilable query plan.
+
+## Troubleshooting checklist
+
+### Semantic and runtime errors
+
+1. **Reproduce on your current stable release.** Confirm the issue is present on the latest stable release you run in production.
+2. **Capture diagnostics.** Collect the following before investigating further:
+   * The full query text and query options
+   * `EXPLAIN PLAN FOR <query>` output
+   * Stage-level statistics from the query response
+3. **Check for behavior differences.** Review the [behavior differences from SSE](#behavior-differences-from-sse) section above. Many errors result from stricter SQL semantics in the MSE.
+4. **Rewrite the query.** Some functions supported in the SSE have different syntax in the MSE. Check whether you are using any non-standard SQL functions or semantics.
+5. **Search existing issues.** Check the [Apache Pinot issue tracker](https://github.com/apache/pinot/issues) for known issues matching your error.
+6. **File a new issue.** If no existing issue matches, file a new one with the query text, query options, EXPLAIN output, and stage stats attached.
 
 ### Timeout errors
 
-* Try reducing the size of the table(s) used.
-  * Add higher selectivity filters to the tables.
-* Try executing part of the subquery or a simplified version of the query first.
-  * This helps to determine the selectivity and scale of the query being executed.
-* Try adding more servers.
-  * The multi-stage engine (MSE) runs distributed across the entire cluster, so adding more servers to partitioned queries such as GROUP BY aggregates, and equality JOINs help speed up the query runtime.
+* **Reduce the data scanned.** Add higher-selectivity filters to reduce the volume of data processed.
+* **Simplify the query.** Execute a subquery or simplified version of the query first to determine the scale and selectivity of each stage.
+* **Add more servers.** The MSE distributes work across the cluster. Adding servers helps with partitioned queries such as GROUP BY aggregates and equality JOINs.
+* **Review stage stats.** Identify which stage is the bottleneck and whether it is CPU-bound, memory-bound, or waiting on data transfer.


### PR DESCRIPTION
## Summary
- Restructure the MSE troubleshooting page from a beta-style limitations list into operator support documentation
- Add operator checklist at top of page (confirm MSE enabled, query options, explain plan, stage stats, guardrails)
- Split content into three sections: behavior differences from SSE, current limitations, and troubleshooting checklist
- Replace nightly/master guidance with stable-release diagnostics workflow
- Reorganize compatibility differences (case sensitivity, type matching, projection naming, CAST types, null handling, multi-value columns) for scannability

## Test plan
- [ ] Verify all internal links resolve correctly
- [ ] Confirm no technical content was lost from the original page
- [ ] Review that the page reads as operator support docs, not a beta landing page

🤖 Generated with [Claude Code](https://claude.com/claude-code)