### PR TITLE
docs: add MSE production posture and runbook page

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -499,6 +499,7 @@
   * [Reload a Table Segment](operate-pinot/segment-reload.md)
 * [Production Guides](operate-pinot/production-guides.md)
   * [Running Pinot in Production](operate-pinot/running-pinot-in-production.md)
+  * [Run MSE in Production](operate-pinot/production-guides/run-multi-stage-engine-in-production.md)
 * [Kubernetes Production](operate-pinot/kubernetes-production.md)
   * [Kubernetes Deployment](operate-pinot/kubernetes/deployment-pinot-on-kubernetes.md)
   * [Helm Chart Values Reference](operate-pinot/kubernetes/helm-chart-reference.md)

--- a/build-with-pinot/querying-and-sql/sse-vs-mse.md
+++ b/build-with-pinot/querying-and-sql/sse-vs-mse.md
@@ -110,6 +110,10 @@ The function index uses an engine column to indicate availability:
 - `Multi-stage only` — requires MSE
 - `Varies` — depends on the specific implementation
 
+## Running MSE in production
+
+For operational guidance on resource planning, guardrails, and known limitations when running MSE in production, see [Run the Multi-Stage Engine in Production](../../operate-pinot/production-guides/run-multi-stage-engine-in-production.md).
+
 {% embed url="https://www.youtube.com/watch?v=wbo_vPVIBkA" fullWidth="false" %}
 Apache Pinot 1.0 Multi-Stage Query Engine overview
 {% endembed %}

--- a/operate-pinot/production-guides.md
+++ b/operate-pinot/production-guides.md
@@ -30,6 +30,16 @@ This section collects the guides you need to run Apache Pinot reliably in produc
 - **Backup and disaster recovery** -- ZooKeeper state backup, deep store durability, and table config versioning.
 - **Operational runbooks** -- links to segment lifecycle, rebalance, and real-time ingestion troubleshooting.
 
+### Run the Multi-Stage Engine in Production
+
+[Run the Multi-Stage Engine in Production](production-guides/run-multi-stage-engine-in-production.md) covers operational guidance specific to the multi-stage engine (MSE). It includes:
+
+- **Intended use-cases** -- interactive joins, window functions, subqueries, and advanced SQL with distributed stages.
+- **Resource model** -- in-memory execution, stage-based distribution, and why MSE is not a batch engine.
+- **Operational guardrails** -- query quotas, workload isolation, join/window overflow limits, concurrency controls, and broker pruning.
+- **Standard MSE vs Lite Mode** -- when to use each execution mode.
+- **Known limitations vs workload misfit** -- current implementation gaps vs design boundaries.
+
 ### Managing logs
 
 [Managing Logs](../operators/operating-pinot/managing-logs.md) documents the REST APIs for inspecting and changing Log4J log levels at runtime and for downloading log files from any component, including remote log download through the controller. These capabilities are essential for debugging transient production issues without restarting services.

--- a/operate-pinot/production-guides/run-multi-stage-engine-in-production.md
+++ b/operate-pinot/production-guides/run-multi-stage-engine-in-production.md
@@ -1,0 +1,191 @@
+---
+description: Operational guidance for running the multi-stage engine (MSE) in production, including resource model, guardrails, and known limitations.
+---
+
+# Run the Multi-Stage Engine in Production
+
+This page provides operator-level guidance for running the multi-stage engine (MSE) in production. It covers the intended use-cases, the execution and resource model, operational guardrails, and known limitations.
+
+For a high-level comparison of the two query engines, see [Query Engines (SSE vs MSE)](../../build-with-pinot/querying-and-sql/sse-vs-mse.md). For MSE internals, see the [Multi-Stage Query](../../build-with-pinot/querying-and-sql/multi-stage-query/README.md) section.
+
+## What MSE is for
+
+MSE is Pinot's supported engine for queries that require relational operators beyond scatter-gather execution. It was introduced in Pinot 1.0.0 and has continued to mature across subsequent releases.
+
+MSE is **not** a general-purpose batch query engine. It is designed for interactive-latency queries that need SQL features unavailable in the single-stage engine (SSE).
+
+## Recommended production use-cases
+
+MSE is well-suited for the following workloads:
+
+| Use-case | Why MSE |
+| --- | --- |
+| Interactive joins | Joining a fact table with a dimension table or between two fact tables at interactive latency. Supports hash joins, lookup joins, colocated joins, and partition-based joins. |
+| Window functions | `ROW_NUMBER`, `RANK`, `SUM OVER`, and other window functions require multi-stage execution. |
+| Subqueries and CTEs | Common table expressions and correlated subqueries are planned as separate stages. |
+| Advanced SQL with distributed stages | `INTERSECT`, `EXCEPT`, `UNION`, and complex multi-table queries that SSE cannot express. |
+
+**Workloads that are a poor fit for MSE:**
+
+- Large-scale ETL or batch joins that scan entire tables without selective filters. MSE executes in-memory without spill-to-disk, so unbounded intermediate result sets can exceed available memory. Use an external engine such as Trino or Spark for these workloads.
+- Simple scatter-gather queries (filter, aggregate, top-K) where SSE has lower overhead.
+
+## Resource model
+
+Understanding how MSE uses cluster resources is essential for capacity planning and incident response.
+
+### In-memory execution
+
+All intermediate data in MSE is held in memory. There is no spill-to-disk mechanism. This means:
+
+- The memory footprint of a query is proportional to the size of intermediate result sets (join build sides, window partitions, shuffle buffers).
+- A single query with large intermediates can put memory pressure on the servers processing its stages.
+- Operators should set overflow limits (see [Operational guardrails](#operational-guardrails)) to bound memory consumption.
+
+### Stage-based distributed execution
+
+MSE breaks a query into a tree of stages. Each stage runs on one or more servers in parallel:
+
+- **Leaf stages** scan table segments on the servers that host them, similar to SSE.
+- **Intermediate stages** perform joins, aggregations, window functions, and sorts. They run on servers selected by the broker and exchange data via mailbox channels.
+- **Root stage** collects final results and returns them to the client through the broker.
+
+Data moves between stages through network shuffles. The number of stages, the parallelism of each stage, and the volume of data shuffled all affect query latency and resource consumption.
+
+For details on stage mechanics, see [Understanding Stages](../../build-with-pinot/querying-and-sql/multi-stage-query/understanding-stages.md).
+
+### Not a spill-heavy batch engine
+
+Unlike Trino or Spark, MSE does not write intermediate results to disk when memory is exhausted. If a stage exceeds available memory, the query fails with an out-of-memory error or is killed by overflow guards. This is by design: MSE targets interactive latency, not unbounded batch processing.
+
+## Operational guardrails
+
+The controls below help operators protect cluster stability when MSE is enabled.
+
+### Query quotas
+
+Use [Query Quotas](../../build-with-pinot/querying-and-sql/query-execution-controls/query-quotas.md) to rate-limit queries at the table, database, or application level. Quotas apply to both SSE and MSE queries and prevent a single tenant or application from monopolizing broker capacity.
+
+### Workload isolation
+
+The `workloadName` and `isSecondaryWorkload` query options assign queries to named workloads with resource budgets. Combined with the `workload` or `binary_workload` query scheduler, this lets operators isolate MSE traffic from latency-sensitive SSE traffic on the same servers.
+
+See [Workload-Based Query Resource Isolation](../../operators/operating-pinot/tuning/workload-query-isolation.md) for configuration details.
+
+### Join and window overflow controls
+
+These query options bound the memory consumed by join and window operations:
+
+| Option | Default | Description |
+| --- | --- | --- |
+| `maxRowsInJoin` | 1,048,576 (2^20) | Maximum rows in a join hash table and joined output. |
+| `joinOverflowMode` | `THROW` | `THROW` fails the query; `BREAK` returns partial results. |
+| `maxRowsInWindow` | 1,048,576 (2^20) | Maximum rows in a window function partition. |
+| `windowOverflowMode` | `THROW` | `THROW` fails the query; `BREAK` returns partial results. |
+
+Set these at the cluster level via `pinot.query.join.max.rows` and `pinot.query.window.max.rows`, or override per-query using query options.
+
+For production clusters, review whether the defaults are appropriate for your data volumes. Lowering these limits reduces the blast radius of expensive queries.
+
+### Concurrency and thread controls
+
+| Control | Description |
+| --- | --- |
+| `maxExecutionThreads` | Per-query option that limits the number of CPU threads used by a single query. Useful for preventing a heavy MSE query from consuming all server threads. |
+| `timeoutMs` | Per-query timeout. Set this to a value appropriate for interactive workloads (e.g. 10-30 seconds) to prevent runaway queries from holding resources indefinitely. |
+
+### Broker pruning and routing
+
+The MSE query optimizer supports broker-side segment pruning (`useBrokerPruning`, enabled by default). This allows the broker to skip segments that cannot match the query predicates before dispatching work to servers.
+
+For tables with time-based or partition-based segment boundaries, broker pruning significantly reduces the number of segments scanned by leaf stages.
+
+### Explain plan and stage stats for debugging
+
+Use these tools to understand and optimize MSE query behavior in production:
+
+- **`EXPLAIN PLAN FOR`** shows the logical and physical query plan, including stage boundaries, join strategies, and shuffle types. See [Explain Plan](../../build-with-pinot/querying-and-sql/multi-stage-query/explain-plan-1.md).
+- **Stage stats** provide per-stage runtime metrics (rows processed, time spent, memory used) after query execution. See [Understanding Stage Stats](../../build-with-pinot/querying-and-sql/multi-stage-query/understanding-stage-stats.md).
+- **`EXPLAIN IMPLEMENTATION PLAN FOR`** returns the physical plan as executed by the servers, useful for verifying that the physical optimizer is making expected decisions.
+
+## Choosing between standard MSE and Lite Mode
+
+MSE supports two execution modes:
+
+| | Standard MSE | Lite Mode (Beta, since 1.4.0) |
+| --- | --- | --- |
+| **Execution model** | Fully distributed stages across servers with network shuffles. | Scatter-gather leaf stages (like SSE) with non-leaf stages running single-threaded in the broker. |
+| **Join execution** | Distributed across servers. | Runs in the broker. |
+| **Leaf stage row limit** | No built-in limit. | Configurable per-instance limit (default 100,000 rows). |
+| **Target workload** | Queries that need distributed joins or large intermediate result sets. | High-QPS use-cases that need window functions, subqueries, or small joins without the risk of full table scans. |
+| **Activation** | `SET useMultistageEngine=true;` | `SET useMultistageEngine=true; SET usePhysicalOptimizer=true; SET useLiteMode=true;` |
+
+{% hint style="warning" %}
+Lite Mode is currently in Beta. It requires the Physical Optimizer (`usePhysicalOptimizer=true`), which is also Beta.
+{% endhint %}
+
+**When to use Lite Mode:**
+
+- You want to expose window functions or subqueries to users at high QPS without the risk of unbounded full-table scans.
+- Your joins operate on small, pre-filtered datasets that fit comfortably in broker memory.
+- You want scatter-gather routing guarantees (segment pruning, replica-group routing) that standard MSE does not fully support.
+
+**When to use standard MSE:**
+
+- You need distributed joins across large datasets.
+- You need parallelism across servers for intermediate stages.
+- Your queries exceed the Lite Mode leaf-stage row limit.
+
+See [Multistage Lite Mode](../../build-with-pinot/querying-and-sql/multi-stage-query/multistage-lite-mode.md) for configuration details.
+
+## Known limitations vs workload misfit
+
+Some behaviors are current limitations of the MSE implementation. Others reflect a genuine workload misfit where a different tool is a better choice.
+
+### Current limitations
+
+These are areas where MSE behavior differs from SSE or from standard SQL expectations. They may be addressed in future releases:
+
+- **Multi-value column support is limited.** Predicates and GROUP BY on multi-value columns require wrapping with `arrayToMv()`. See [Troubleshoot MSE](../troubleshooting/troubleshoot-multi-stage-query-engine.md).
+- **Schema prefixes are not supported.** Queries like `SELECT * FROM schema.table` are not valid.
+- **Table and column names are case-sensitive** in MSE (unlike SSE).
+- **Type casting is stricter.** Implicit type conversions that work in SSE may require explicit `CAST` in MSE.
+- **Some custom functions are unsupported.** `histogram`, `timeConvert`, and `dateTimeConvertWindowHop` are not available in MSE. See the [troubleshooting page](../troubleshooting/troubleshoot-multi-stage-query-engine.md) for the full list.
+- **Default projection names differ.** Function-call projections return names like `EXPR$0` instead of `count(*)`.
+- **No spill-to-disk.** Intermediate results that exceed memory cause query failure.
+
+### Workload misfit
+
+These are not bugs or planned improvements. They reflect design boundaries:
+
+- **Full-table-scan ETL joins** -- MSE is not designed for joins that scan billions of rows without selective predicates. Use Trino, Spark, or a similar batch engine.
+- **Long-running batch aggregations** -- Queries that run for minutes or hours are outside MSE's design point. Set `timeoutMs` to enforce this boundary.
+- **High-concurrency simple queries** -- If the query does not need joins, window functions, or subqueries, SSE is the better choice. It has lower per-query overhead.
+
+## Version milestones
+
+MSE has matured steadily since its introduction:
+
+| Release | Notable MSE changes |
+| --- | --- |
+| 1.0.0 | MSE introduced as the v2 query engine with support for joins, window functions, and distributed stages. |
+| 1.1.0 | Null handling support added for MSE when column-based null storing is enabled. |
+| 1.2.0 | Explain plan improvements and additional join strategy support. |
+| 1.3.0 | Application-level query quotas added, applicable to MSE workloads. |
+| 1.4.0 | Physical Optimizer (Beta), Lite Mode (Beta), workload-based query isolation, stage-level spooling, and broker pruning for MSE. |
+
+Refer to the [Release Notes](../../reference/release-notes/README.md) for the complete changelog for each version.
+
+## Related pages
+
+- [Query Engines (SSE vs MSE)](../../build-with-pinot/querying-and-sql/sse-vs-mse.md)
+- [Multi-Stage Query (internals)](../../build-with-pinot/querying-and-sql/multi-stage-query/README.md)
+- [Understanding Stages](../../build-with-pinot/querying-and-sql/multi-stage-query/understanding-stages.md)
+- [Multistage Lite Mode](../../build-with-pinot/querying-and-sql/multi-stage-query/multistage-lite-mode.md)
+- [Physical Optimizer](../../build-with-pinot/querying-and-sql/multi-stage-query/physical-optimizer.md)
+- [Query Options](../../build-with-pinot/querying-and-sql/query-execution-controls/query-options.md)
+- [Query Quotas](../../build-with-pinot/querying-and-sql/query-execution-controls/query-quotas.md)
+- [Workload-Based Query Resource Isolation](../../operators/operating-pinot/tuning/workload-query-isolation.md)
+- [Optimizing Joins](../../build-with-pinot/querying-and-sql/multi-stage-query/optimizing-joins.md)
+- [Troubleshoot MSE](../troubleshooting/troubleshoot-multi-stage-query-engine.md)
+- [Running Pinot in Production](../running-pinot-in-production.md)

--- a/operate-pinot/troubleshooting/troubleshoot-multi-stage-query-engine.md
+++ b/operate-pinot/troubleshooting/troubleshoot-multi-stage-query-engine.md
@@ -6,7 +6,7 @@ description: Troubleshoot issues with the multi-stage engine (MSE).
 
 Learn how to [troubleshoot errors](troubleshoot-multi-stage-query-engine.md#troubleshoot-errors) when using the multi-stage engine (MSE), and see [multi-stage engine limitations](troubleshoot-multi-stage-query-engine.md#limitations-of-the-multi-stage-query-engine).
 
-Find instructions on [how to enable the multi-stage query engine](../../build-with-pinot/querying-and-sql/sse-vs-mse.md), or see a high-level overview of [how the multi-stage query engine works](../../build-with-pinot/querying-and-sql/sse-vs-mse.md).
+Find instructions on [how to enable the multi-stage query engine](../../build-with-pinot/querying-and-sql/sse-vs-mse.md), or see a high-level overview of [how the multi-stage query engine works](../../build-with-pinot/querying-and-sql/sse-vs-mse.md). For operational guidance on running MSE in production, see [Run the Multi-Stage Engine in Production](../production-guides/run-multi-stage-engine-in-production.md).
 
 ## Limitations of the multi-stage query engine
 


### PR DESCRIPTION
## Summary
- Add `operate-pinot/production-guides/run-multi-stage-engine-in-production.md` — a production runbook covering MSE resource model, operational guardrails (quotas, workload isolation, join/window overflow limits, concurrency controls), standard MSE vs Lite Mode comparison, known limitations vs workload misfit, and version milestones.
- Cross-link from `sse-vs-mse.md`, `troubleshoot-multi-stage-query-engine.md`, and `production-guides.md`.
- Add entry to `SUMMARY.md` under Production Guides.

## Test plan
- [ ] Verify new page renders correctly in GitBook
- [ ] Verify SUMMARY.md entry appears under Operate Pinot > Production Guides
- [ ] Verify cross-links from SSE vs MSE page, troubleshooting page, and production guides landing page
- [ ] Review content for factual accuracy against Pinot source code

🤖 Generated with [Claude Code](https://claude.com/claude-code)