### PR TITLE
docs: fix contradictory upgrade order across operations pages

### DIFF
--- a/operate-pinot/kubernetes/helm-chart-reference.md
+++ b/operate-pinot/kubernetes/helm-chart-reference.md
@@ -888,10 +888,10 @@ kubectl rollout status statefulset/pinot-server -n pinot-quickstart
 
 Upgrade components in this order to minimize disruption:
 
-1. **Minion** -- has no live query traffic.
-2. **Controller** -- manages metadata; upgrading first ensures the newest controller manages segment assignment.
-3. **Broker** -- routes queries; rolling restart briefly shifts traffic to remaining brokers.
-4. **Server** -- serves data; PDB ensures availability during rollout.
+1. **Controller** -- manages metadata; upgrading first ensures the newest controller handles segment assignment during the rollout.
+2. **Broker** -- routes queries; rolling restart briefly shifts traffic to remaining brokers.
+3. **Server** -- serves data; PDB ensures availability during rollout.
+4. **Minion** -- runs background tasks with no live query traffic; upgrading last avoids interference with critical-path components.
 
 {% hint style="warning" %}
 Avoid upgrading all components simultaneously. Use `updateStrategy.type: RollingUpdate` (the default) so pods restart one at a time.

--- a/operate-pinot/running-pinot-in-production.md
+++ b/operate-pinot/running-pinot-in-production.md
@@ -25,16 +25,9 @@ A production Pinot cluster requires the following infrastructure:
 
 ## Deployment and upgrade order
 
-When deploying or upgrading Pinot components, follow this order to avoid protocol or compatibility issues during the rollout:
+When deploying or upgrading Pinot components, follow this order to avoid protocol or compatibility issues during the rollout: **Controller → Broker → Server → Minion**. When rolling back, reverse the order. Each component connects to ZooKeeper independently, so the ordering is a best-practice precaution rather than a hard dependency.
 
-1. Controller
-2. Broker
-3. Server
-4. Minion
-
-When rolling back, reverse the order (Minion → Server → Broker → Controller). Each component connects to ZooKeeper independently, so the ordering is a best-practice precaution rather than a hard dependency.
-
-For detailed upgrade testing with the cross-version compatibility suite, see [Upgrading Pinot](../operators/operating-pinot/upgrading-pinot-cluster.md).
+For the full upgrade procedure, compatibility testing, and per-release notes, see [Upgrades](upgrades.md).
 ## Capacity planning
 
 ### Servers

--- a/operate-pinot/upgrades.md
+++ b/operate-pinot/upgrades.md
@@ -21,10 +21,10 @@ Consult these guides when you are:
 
 Upgrade components in this order to minimize disruption. If you need to roll back, reverse the order.
 
-1. **Minion** -- No live query traffic; safest to upgrade first.
-2. **Controller** -- Manages metadata and segment assignment; upgrading early ensures the newest controller handles segment operations.
-3. **Broker** -- Routes queries; a rolling restart briefly shifts traffic to remaining brokers.
-4. **Server** -- Serves data; PodDisruptionBudgets ensure availability during rollout.
+1. **Pinot Controller** (and Helix Controller, if separate) -- Manages metadata and segment assignment; upgrading first ensures the newest controller handles segment operations during the rollout.
+2. **Broker** -- Routes queries; a rolling restart briefly shifts traffic to remaining brokers.
+3. **Server** -- Serves data; PodDisruptionBudgets ensure availability during rollout.
+4. **Minion** -- Runs background tasks with no live query traffic; upgrading last avoids interference with the critical-path components above.
 
 ### Rolling upgrade mechanics
 


### PR DESCRIPTION
## Summary
- Fixed contradictory component upgrade order: `upgrades.md` and `helm-chart-reference.md` recommended Minion-first, while `running-pinot-in-production.md`, `upgrading-pinot-cluster.md`, and the compatibility test suite all use Controller-first
- Aligned all three pages to the canonical order: **Controller → Broker → Server → Minion**
- Reduced duplication by having `running-pinot-in-production.md` link to `upgrades.md` instead of restating the numbered list

## Test plan
- [ ] Verify the upgrade order in `operate-pinot/upgrades.md` matches `operators/operating-pinot/upgrading-pinot-cluster.md`
- [ ] Verify the upgrade order in `operate-pinot/kubernetes/helm-chart-reference.md` matches
- [ ] Verify `operate-pinot/running-pinot-in-production.md` links to `upgrades.md` correctly
- [ ] Grep for "Minion.*Controller.*Broker.*Server" to confirm no remaining Minion-first ordering

🤖 Generated with [Claude Code](https://claude.com/claude-code)