### PR TITLE
docs: add workload playbooks section

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -439,6 +439,15 @@
       * [Spark Pinot Connector Write Model](build-with-pinot/connectors-clients-apis/spark-pinot-connector/spark-pinot-connector-write-model.md)
   * [REST / gRPC APIs](build-with-pinot/connectors-clients-apis/rest-grpc-apis.md)
 
+## Workload Playbooks
+
+* [Overview](playbooks/README.md)
+* [Real-Time Product Analytics](playbooks/real-time-product-analytics.md)
+* [CDC / Upsert Pipeline](playbooks/cdc-upsert-pipeline.md)
+* [Hybrid Real-Time + Offline](playbooks/hybrid-offline-realtime.md)
+* [Multi-Tenant Analytics](playbooks/multi-tenant-analytics.md)
+* [Text Search Analytics](playbooks/text-search-analytics.md)
+
 ## Operate Pinot
 
 * [Deployment](operate-pinot/deployment.md)

--- a/playbooks/README.md
+++ b/playbooks/README.md
@@ -1,0 +1,40 @@
+---
+description: End-to-end guides for canonical Apache Pinot workloads.
+---
+
+# Workload Playbooks
+
+The rest of the Pinot documentation covers individual features: schema design, ingestion modes, indexes, query syntax, and operational knobs. These playbooks stitch those features together into **complete, production-ready patterns** for the workloads adopters ask about most often.
+
+Each playbook covers:
+
+| Section | What it answers |
+| --- | --- |
+| **When to use this pattern** | Is this the right fit for my workload? |
+| **Architecture sketch** | Which Pinot components are involved and how data flows |
+| **Schema and table config** | Concrete JSON you can adapt |
+| **Ingestion setup** | Stream and/or batch job configuration |
+| **Indexing strategy** | Which indexes to enable and why |
+| **Query patterns** | Representative SQL and performance tips |
+| **Operational checklist** | Monitoring, scaling, and common pitfalls |
+
+## Playbooks
+
+| Playbook | Typical use case |
+| --- | --- |
+| [Real-Time Product Analytics](real-time-product-analytics.md) | Sub-second dashboards over Kafka event streams (page views, clicks, transactions) |
+| [CDC / Upsert Pipeline](cdc-upsert-pipeline.md) | Keep Pinot in sync with a transactional database via Debezium and upserts |
+| [Hybrid Real-Time + Offline](hybrid-offline-realtime.md) | Combine low-latency streaming with high-quality batch backfills in a single logical table |
+| [Multi-Tenant Analytics](multi-tenant-analytics.md) | Serve many customers from one Pinot cluster with resource and data isolation |
+| [Text Search Analytics](text-search-analytics.md) | Full-text search over logs, product catalogs, or support tickets alongside OLAP aggregations |
+
+## How to use these playbooks
+
+1. **Pick the playbook** closest to your workload.
+2. **Copy the configs** and adjust field names, topic names, and resource sizes for your environment.
+3. **Cross-reference the feature docs** linked inside each playbook for deep dives on any single capability.
+4. **Check the operational checklist** before going to production.
+
+{% hint style="info" %}
+These playbooks target Pinot 1.x and assume familiarity with [Pinot's architecture](../basics/architecture.md) and [table types](../basics/components/table/README.md). If you are new to Pinot, start with the [10-Minute Quickstart](../basics/getting-started/ten-minute-quickstart.md) first.
+{% endhint %}

--- a/playbooks/cdc-upsert-pipeline.md
+++ b/playbooks/cdc-upsert-pipeline.md
@@ -1,0 +1,285 @@
+---
+description: End-to-end guide for keeping Pinot in sync with a transactional database using CDC and upserts.
+---
+
+# CDC / Upsert Pipeline
+
+This playbook covers the pattern of capturing row-level changes from a transactional database (PostgreSQL, MySQL, MongoDB, etc.) via Change Data Capture (CDC), streaming them through Kafka, and ingesting them into Pinot with upsert enabled so that Pinot always reflects the latest state of each row.
+
+## When to use this pattern
+
+Use this playbook when:
+
+- You need Pinot to mirror the current state of rows in an OLTP database (orders, user profiles, inventory, tickets).
+- Rows are frequently **updated** or **soft-deleted** after initial creation, and queries must see only the latest version.
+- You want real-time analytics on top of transactional data without adding read load to your primary database.
+- Your CDC tool (Debezium, Maxwell, AWS DMS) already produces events to Kafka.
+
+If your data is append-only and never updated, the simpler [Real-Time Product Analytics](real-time-product-analytics.md) pattern is a better fit.
+
+## Architecture sketch
+
+```
+OLTP DB ──▶ Debezium ──▶ Kafka topic ──▶ Pinot REALTIME table (upsert)
+  (WAL)      (CDC)        (per-table)          │
+                                      ┌────────┴────────┐
+                                      │ Servers with     │
+                                      │ primary key map  │
+                                      └─────────────────┘
+```
+
+Key components:
+
+- **Debezium** (or equivalent) reads the database WAL and produces a Kafka event for every INSERT, UPDATE, and DELETE.
+- **Kafka topic** is partitioned by the primary key so all mutations for the same row land on the same partition.
+- **Pinot real-time table with upsert** maintains an in-memory map from primary key to the latest segment/doc-id so queries skip stale versions.
+
+{% hint style="warning" %}
+Upsert requires that all events for the same primary key arrive at the **same Kafka partition**. Configure your Debezium connector or Kafka producer to partition by the primary key column.
+{% endhint %}
+
+## Schema
+
+Use the source table's primary key as Pinot's primary key. Include a comparison column (typically the event timestamp or database transaction sequence number) so Pinot can determine which version is newer.
+
+```json
+{
+  "schemaName": "orders",
+  "primaryKeyColumns": ["orderId"],
+  "dimensionFieldSpecs": [
+    { "name": "orderId",    "dataType": "STRING" },
+    { "name": "customerId", "dataType": "STRING" },
+    { "name": "status",     "dataType": "STRING" },
+    { "name": "region",     "dataType": "STRING" },
+    { "name": "product",    "dataType": "STRING" }
+  ],
+  "metricFieldSpecs": [
+    { "name": "amount",     "dataType": "DOUBLE" },
+    { "name": "quantity",   "dataType": "INT" }
+  ],
+  "dateTimeFieldSpecs": [
+    {
+      "name": "updatedAt",
+      "dataType": "TIMESTAMP",
+      "format": "1:MILLISECONDS:EPOCH",
+      "granularity": "1:MILLISECONDS"
+    }
+  ]
+}
+```
+
+{% hint style="info" %}
+`primaryKeyColumns` is required for upsert. Pinot uses this to look up existing rows in the primary key map. See [Schema and Table Shape](../build-with-pinot/data-modeling/schema.md).
+{% endhint %}
+
+## Table configuration
+
+```json
+{
+  "tableName": "orders",
+  "tableType": "REALTIME",
+  "segmentsConfig": {
+    "timeColumnName": "updatedAt",
+    "retentionTimeUnit": "DAYS",
+    "retentionTimeValue": "90",
+    "replication": "1"
+  },
+  "tableIndexConfig": {
+    "loadMode": "MMAP",
+    "invertedIndexColumns": ["status", "region", "customerId"],
+    "rangeIndexColumns": ["updatedAt"],
+    "sortedColumn": [],
+    "noDictionaryColumns": ["orderId", "customerId"],
+    "streamConfigs": {
+      "streamType": "kafka",
+      "stream.kafka.topic.name": "dbserver1.public.orders",
+      "stream.kafka.broker.list": "kafka:9092",
+      "stream.kafka.consumer.type": "lowlevel",
+      "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory",
+      "stream.kafka.decoder.class.name": "org.apache.pinot.plugin.stream.kafka.KafkaJSONMessageDecoder",
+      "realtime.segment.flush.threshold.rows": "100000",
+      "realtime.segment.flush.threshold.time": "4h"
+    }
+  },
+  "upsertConfig": {
+    "mode": "FULL",
+    "comparisonColumns": ["updatedAt"],
+    "hashFunction": "MURMUR3",
+    "enableSnapshot": true,
+    "enablePreload": true,
+    "metadataTTL": 0,
+    "deletedKeysTTL": 0
+  },
+  "routing": {
+    "instanceSelectorType": "strictReplicaGroup"
+  },
+  "tenants": {
+    "broker": "DefaultTenant",
+    "server": "DefaultTenant"
+  },
+  "metadata": {}
+}
+```
+
+### Configuration highlights
+
+| Setting | Why |
+| --- | --- |
+| `upsertConfig.mode: FULL` | Every update replaces the entire row. Use `PARTIAL` if CDC events contain only changed columns. See [Upsert Modes](../build-with-pinot/ingestion/upsert-and-dedup/upsert.md) |
+| `comparisonColumns: ["updatedAt"]` | Pinot uses this column to resolve out-of-order events — the row with the higher `updatedAt` wins |
+| `enableSnapshot: true` | Persists the primary key map to disk so server restarts do not require replaying the full Kafka topic |
+| `enablePreload: true` | Loads the snapshot into memory at startup for faster recovery |
+| `hashFunction: MURMUR3` | More memory-efficient than the default hash for the primary key map |
+| `replication: 1` | Upsert tables currently require replication factor 1. Use `strictReplicaGroup` routing to ensure consistency |
+| `routing.instanceSelectorType` | Routes all queries for a partition to the same server, required for correct upsert semantics |
+
+### Handling deletes
+
+If your CDC stream includes tombstone events for deleted rows, configure a `deleteRecordColumn`:
+
+```json
+"upsertConfig": {
+  "mode": "FULL",
+  "comparisonColumns": ["updatedAt"],
+  "deleteRecordColumn": "isDeleted",
+  "deletedKeysTTL": 86400
+}
+```
+
+Add `isDeleted` as a boolean dimension in your schema. Set it to `true` in your Debezium SMT (Single Message Transform) for delete events. Pinot will mark the row as deleted and stop returning it in queries.
+
+## Partial upsert
+
+When your CDC events contain only the changed columns (e.g., only `status` changed on an order), use partial upsert to merge the update into the existing row:
+
+```json
+"upsertConfig": {
+  "mode": "PARTIAL",
+  "partialUpsertStrategies": {
+    "status":     "OVERWRITE",
+    "amount":     "OVERWRITE",
+    "quantity":   "OVERWRITE",
+    "region":     "OVERWRITE"
+  },
+  "comparisonColumns": ["updatedAt"],
+  "defaultPartialUpsertStrategy": "IGNORE"
+}
+```
+
+With `IGNORE` as the default, any column not present in the incoming event retains its previous value. Columns listed with `OVERWRITE` are replaced when present.
+
+## Debezium configuration tips
+
+A minimal Debezium connector config for PostgreSQL:
+
+```json
+{
+  "name": "orders-connector",
+  "config": {
+    "connector.class": "io.debezium.connector.postgresql.PostgresConnector",
+    "database.hostname": "postgres",
+    "database.port": "5432",
+    "database.user": "debezium",
+    "database.password": "${DEBEZIUM_PASSWORD}",
+    "database.dbname": "app",
+    "topic.prefix": "dbserver1",
+    "table.include.list": "public.orders",
+    "key.converter": "org.apache.kafka.connect.json.JsonConverter",
+    "value.converter": "org.apache.kafka.connect.json.JsonConverter",
+    "transforms": "unwrap",
+    "transforms.unwrap.type": "io.debezium.transforms.ExtractNewRecordState",
+    "transforms.unwrap.drop.tombstones": "false",
+    "transforms.unwrap.delete.handling.mode": "rewrite"
+  }
+}
+```
+
+The `ExtractNewRecordState` transform flattens the Debezium envelope so Pinot receives a simple JSON object with the row's columns. The `delete.handling.mode: rewrite` adds a `__deleted` field that you can map to your `isDeleted` column via an [ingestion transformation](../build-with-pinot/ingestion/ingestion-level-transformations.md).
+
+## Query patterns
+
+### Current state aggregation
+
+```sql
+SELECT status, COUNT(*) AS order_count, SUM(amount) AS total_amount
+FROM orders
+WHERE region = 'US'
+GROUP BY status
+```
+
+Because upsert is enabled, this query automatically sees only the latest version of each order.
+
+### Point lookup
+
+```sql
+SELECT *
+FROM orders
+WHERE orderId = 'ORD-78901'
+LIMIT 1
+```
+
+### Time-range analysis over mutable data
+
+```sql
+SELECT
+  DATETRUNC('hour', updatedAt, 'MILLISECONDS') AS hour_bucket,
+  COUNT(*) AS updates
+FROM orders
+WHERE updatedAt > ago('PT24H')
+GROUP BY hour_bucket
+ORDER BY hour_bucket
+```
+
+## Segment compaction
+
+Over time, upsert tables accumulate stale row versions inside completed segments. These invalid records waste storage and slow full-table scans. Schedule the **Upsert Compaction Task** via Minion to rewrite segments and physically remove stale rows:
+
+```json
+{
+  "task": {
+    "taskTypeConfigsMap": {
+      "UpsertCompactionTask": {
+        "schedule": "0 0 2 * * ?",
+        "invalidRecordsThresholdPercent": "30",
+        "invalidRecordsThresholdCount": "100000"
+      }
+    }
+  }
+}
+```
+
+See [Segment Compaction on Upserts](../build-with-pinot/ingestion/upsert-and-dedup/segment-compaction-on-upserts.md) for tuning guidance.
+
+## Operational checklist
+
+### Before go-live
+
+- [ ] Verify Kafka topic is partitioned by primary key. Run a test with duplicate keys across partitions — queries will return wrong results if this is misconfigured.
+- [ ] Enable `enableSnapshot` and `enablePreload` to avoid full-topic replay on server restarts.
+- [ ] Set `replication: 1` and `strictReplicaGroup` routing. Multi-replica upsert is not supported in the current release.
+- [ ] Run an initial load of the full table snapshot before starting CDC to avoid missing historical data.
+- [ ] Set segment flush thresholds small enough that the primary key map fits in server memory. Monitor heap usage.
+
+### Monitoring
+
+- **Primary key map size**: Monitor `pinot.server.upsertPrimaryKeysCount`. If this exceeds available memory, consider TTL-based eviction or larger servers.
+- **Invalid record ratio**: Track the percentage of invalidated (stale) records per segment. Schedule compaction when this exceeds 30%.
+- **Kafka consumer lag**: Same as real-time tables — growing lag means Pinot queries show stale data.
+- **Debezium connector status**: Monitor via Kafka Connect REST API. A stopped connector means no updates flow to Pinot.
+
+### Common pitfalls
+
+| Pitfall | Fix |
+| --- | --- |
+| Out-of-order events cause old values to overwrite new ones | Use `comparisonColumns` with a monotonically increasing column (database sequence, event timestamp) |
+| Memory pressure from large primary key map | Enable `metadataTTL` to evict keys for rows not updated within a time window, or use `hashFunction: MURMUR3` to reduce per-key overhead |
+| Queries return deleted rows | Ensure `deleteRecordColumn` is configured and the CDC transform sets it correctly for delete events |
+| Server restart takes minutes | Enable `enableSnapshot` and `enablePreload` — without them, Pinot replays the Kafka topic from the last committed offset |
+
+## Further reading
+
+- [Stream Ingestion with Upsert](../build-with-pinot/ingestion/upsert-and-dedup/upsert.md)
+- [Offline Table Upsert](../build-with-pinot/ingestion/upsert-and-dedup/offline-table-upsert.md)
+- [Segment Compaction on Upserts](../build-with-pinot/ingestion/upsert-and-dedup/segment-compaction-on-upserts.md)
+- [Upsert Compaction Task](../operators/operating-pinot/upsert-compaction-task.md)
+- [Ingestion Transformations](../build-with-pinot/ingestion/ingestion-level-transformations.md)

--- a/playbooks/hybrid-offline-realtime.md
+++ b/playbooks/hybrid-offline-realtime.md
@@ -1,0 +1,264 @@
+---
+description: End-to-end guide for combining low-latency streaming with high-quality batch backfills in a single Pinot table.
+---
+
+# Hybrid Real-Time + Offline
+
+This playbook covers the hybrid table pattern: a single logical table backed by both a **real-time** table (for low-latency streaming data) and an **offline** table (for batch-corrected, deduplicated, or enriched historical data). Queries seamlessly span both, and Pinot's time boundary mechanism ensures each time range is served by the best-quality source.
+
+## When to use this pattern
+
+Use this playbook when:
+
+- You need real-time freshness (seconds of latency) **and** batch-quality historical data (deduplicated, enriched, or reprocessed) in the same query.
+- Nightly or hourly batch jobs produce higher-quality data than what arrives via the stream (e.g., after joining with dimension tables, fixing late-arriving data, or running ML enrichment).
+- You want to reduce storage costs by replacing many small real-time segments with fewer, optimized offline segments.
+- Your workload resembles a Lambda architecture, but you want a single query interface instead of querying two systems.
+
+If you only need real-time data and never backfill, use the [Real-Time Product Analytics](real-time-product-analytics.md) playbook. If your data mutates in place, see [CDC / Upsert Pipeline](cdc-upsert-pipeline.md).
+
+## Architecture sketch
+
+```
+                                ┌──────────────────┐
+Kafka topic ──────────────────▶ │  REALTIME table   │ (fresh, last few hours)
+                                └────────┬─────────┘
+                                         │
+                              Pinot query │  time boundary
+                              spans both  │
+                                         │
+                                ┌────────┴─────────┐
+Spark / Flink batch job ──────▶ │  OFFLINE table    │ (historical, optimized)
+                                └──────────────────┘
+```
+
+How the time boundary works:
+
+1. Pinot maintains a **time boundary** — a timestamp that separates offline from real-time data.
+2. For queries covering time ranges **before** the boundary, Pinot routes to offline segments.
+3. For time ranges **after** the boundary, Pinot routes to real-time segments.
+4. Each time a new offline segment is pushed that covers a recent time range, the boundary advances, and the overlapping real-time segments are automatically dropped.
+
+## Schema
+
+The schema is shared between the offline and real-time tables. Both must use exactly the same `schemaName`.
+
+```json
+{
+  "schemaName": "web_analytics",
+  "dimensionFieldSpecs": [
+    { "name": "pageUrl",    "dataType": "STRING" },
+    { "name": "userId",     "dataType": "STRING" },
+    { "name": "country",    "dataType": "STRING" },
+    { "name": "browser",    "dataType": "STRING" },
+    { "name": "campaign",   "dataType": "STRING" },
+    { "name": "enrichedSegment", "dataType": "STRING" }
+  ],
+  "metricFieldSpecs": [
+    { "name": "durationMs", "dataType": "LONG" },
+    { "name": "revenue",    "dataType": "DOUBLE" }
+  ],
+  "dateTimeFieldSpecs": [
+    {
+      "name": "eventTimestamp",
+      "dataType": "TIMESTAMP",
+      "format": "1:MILLISECONDS:EPOCH",
+      "granularity": "1:MILLISECONDS"
+    }
+  ]
+}
+```
+
+{% hint style="info" %}
+The `enrichedSegment` column is filled by the batch job but may be null in real-time data. This is fine — Pinot handles null values gracefully. See [Null Value Support](../build-with-pinot/querying-and-sql/null-value-support.md).
+{% endhint %}
+
+## Real-time table configuration
+
+```json
+{
+  "tableName": "web_analytics",
+  "tableType": "REALTIME",
+  "segmentsConfig": {
+    "timeColumnName": "eventTimestamp",
+    "retentionTimeUnit": "DAYS",
+    "retentionTimeValue": "3",
+    "replication": "2",
+    "segmentPushType": "APPEND"
+  },
+  "tableIndexConfig": {
+    "loadMode": "MMAP",
+    "invertedIndexColumns": ["country", "browser", "campaign"],
+    "rangeIndexColumns": ["eventTimestamp"],
+    "noDictionaryColumns": ["userId", "pageUrl"],
+    "streamConfigs": {
+      "streamType": "kafka",
+      "stream.kafka.topic.name": "web-analytics-events",
+      "stream.kafka.broker.list": "kafka:9092",
+      "stream.kafka.consumer.type": "lowlevel",
+      "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory",
+      "stream.kafka.decoder.class.name": "org.apache.pinot.plugin.stream.kafka.KafkaJSONMessageDecoder",
+      "realtime.segment.flush.threshold.rows": "500000",
+      "realtime.segment.flush.threshold.time": "6h"
+    }
+  },
+  "tenants": {
+    "broker": "DefaultTenant",
+    "server": "DefaultTenant"
+  },
+  "metadata": {}
+}
+```
+
+Set `retentionTimeValue` to a small window (e.g., 3 days). This is only the fallback — in normal operation, the time boundary mechanism drops real-time segments as offline segments replace them.
+
+## Offline table configuration
+
+```json
+{
+  "tableName": "web_analytics",
+  "tableType": "OFFLINE",
+  "segmentsConfig": {
+    "timeColumnName": "eventTimestamp",
+    "retentionTimeUnit": "DAYS",
+    "retentionTimeValue": "365",
+    "replication": "2",
+    "segmentPushType": "APPEND"
+  },
+  "tableIndexConfig": {
+    "loadMode": "MMAP",
+    "invertedIndexColumns": ["country", "browser", "campaign", "enrichedSegment"],
+    "rangeIndexColumns": ["eventTimestamp"],
+    "sortedColumn": ["country"],
+    "noDictionaryColumns": ["userId", "pageUrl"],
+    "starTreeIndexConfigs": [
+      {
+        "dimensionsSplitOrder": ["country", "browser", "campaign"],
+        "functionColumnPairs": ["COUNT__*", "SUM__revenue", "SUM__durationMs"],
+        "maxLeafRecords": 10000
+      }
+    ]
+  },
+  "tenants": {
+    "broker": "DefaultTenant",
+    "server": "DefaultTenant"
+  },
+  "metadata": {}
+}
+```
+
+### Why the offline table can be more aggressively indexed
+
+- **Star-tree index**: Batch segments are written once, so the star-tree build cost is paid once. Real-time consuming segments rebuild star-tree on every flush, which is more expensive.
+- **Sorted column**: Offline segments can be globally sorted during the batch job, yielding perfect sort order. Real-time segments are sorted only within each flush.
+- **Longer retention**: Historical data lives only in offline segments, so set retention to months or years.
+
+## Batch ingestion job
+
+Use Spark or a standalone ingestion job to push daily offline segments. Example Spark job spec:
+
+```yaml
+executionFrameworkSpec:
+  name: spark
+  segmentGenerationJobRunnerClassName: org.apache.pinot.plugin.ingestion.batch.spark3.SparkSegmentGenerationJobRunner
+  segmentTarPushJobRunnerClassName: org.apache.pinot.plugin.ingestion.batch.spark3.SparkSegmentTarPushJobRunner
+
+jobType: SegmentCreationAndTarPush
+
+inputDirURI: s3://data-lake/web_analytics/dt=2026-03-31/
+outputDirURI: s3://pinot-segments/web_analytics/
+overwriteOutput: true
+
+pinotFSSpecs:
+  - scheme: s3
+    className: org.apache.pinot.plugin.filesystem.S3PinotFS
+
+recordReaderSpec:
+  dataFormat: parquet
+  className: org.apache.pinot.plugin.inputformat.parquet.ParquetRecordReader
+
+tableSpec:
+  tableName: web_analytics
+  schemaURI: http://pinot-controller:9000/schemas/web_analytics
+  tableConfigURI: http://pinot-controller:9000/tables/web_analytics
+
+segmentNameGeneratorSpec:
+  type: normalizedDate
+  configs:
+    segment.name.prefix: web_analytics
+    exclude.sequence.id: false
+
+pushJobSpec:
+  pushAttempts: 3
+  pushParallelism: 2
+```
+
+Schedule this job to run daily (or hourly) after your data pipeline finishes. Each push advances the time boundary automatically.
+
+See [Batch Ingestion Guide](../build-with-pinot/ingestion/batch-ingestion/README.md) and [Spark Connector](../build-with-pinot/ingestion/batch-ingestion/spark.md) for details.
+
+## How the time boundary advances
+
+1. Controller computes the time boundary as the **maximum end time** across all offline segments.
+2. Broker uses this boundary at query time: segments with time ranges before the boundary come from offline; segments after come from real-time.
+3. When a new offline segment covers time that was previously served by real-time, the real-time segments for that time range become redundant and are dropped by the retention manager.
+
+You can inspect the current time boundary:
+
+```
+GET /tables/web_analytics/timeBoundary
+```
+
+See [Time Boundary](../basics/concepts/time-boundary.md) for the full algorithm.
+
+## Query patterns
+
+Queries are identical to single-table queries — the broker handles routing transparently:
+
+```sql
+SELECT
+  DATETRUNC('day', eventTimestamp, 'MILLISECONDS') AS day,
+  country,
+  COUNT(*) AS page_views,
+  SUM(revenue) AS total_revenue
+FROM web_analytics
+WHERE eventTimestamp > ago('P30D')
+GROUP BY day, country
+ORDER BY day
+LIMIT 10000
+```
+
+For recent data (last few hours), the query hits real-time segments. For older data, it hits offline segments. The result is merged seamlessly.
+
+## Operational checklist
+
+### Before go-live
+
+- [ ] Verify that both offline and real-time tables use the same `schemaName` and `tableName`.
+- [ ] Set real-time table retention to at least 2x the batch job interval (e.g., 3 days for a daily job) to handle batch delays.
+- [ ] Validate the time boundary advances after the first batch push by checking `GET /tables/{tableName}/timeBoundary`.
+- [ ] Ensure offline segments do not have time gaps — missing days cause the time boundary to stop advancing, and real-time data for that gap is lost when its retention expires.
+
+### Monitoring
+
+- **Time boundary freshness**: If the boundary is more than one batch interval behind, the batch pipeline may be failing.
+- **Segment overlap**: Check that real-time segments for time ranges covered by offline segments are being purged by retention.
+- **Offline segment push success**: Monitor the controller API for push failures. A failed push means stale data in the real-time table continues to serve — this is safe but lower quality.
+
+### Common pitfalls
+
+| Pitfall | Fix |
+| --- | --- |
+| Time boundary does not advance | Ensure offline segment time ranges are contiguous and cover up to the expected boundary |
+| Real-time segments are not dropped after offline push | Check that real-time retention is configured and the retention manager is running |
+| Double-counting for the boundary time range | This can happen if offline and real-time segments overlap for the same millisecond. Pinot's time boundary logic handles this, but verify with a COUNT query at the boundary |
+| Batch job produces segments with wrong time column | Ensure `timeColumnName` matches in both table configs and the batch job reads the same column |
+
+## Further reading
+
+- [Table Types (Offline, Real-Time, Hybrid)](../basics/components/table/README.md)
+- [Time Boundary](../basics/concepts/time-boundary.md)
+- [Batch Ingestion Guide](../build-with-pinot/ingestion/batch-ingestion/README.md)
+- [Spark Connector](../build-with-pinot/ingestion/batch-ingestion/spark.md)
+- [Backfill Data](../build-with-pinot/ingestion/batch-ingestion/backfill-data.md)
+- [Pinot Managed Offline Flows](../operators/operating-pinot/pinot-managed-offline-flows.md)

--- a/playbooks/multi-tenant-analytics.md
+++ b/playbooks/multi-tenant-analytics.md
@@ -1,0 +1,287 @@
+---
+description: End-to-end guide for serving multiple customers from a shared Pinot cluster with resource and data isolation.
+---
+
+# Multi-Tenant Analytics
+
+This playbook covers serving analytics to many customers (tenants) from a single Pinot cluster. The pattern is common in B2B SaaS products where each customer gets their own dashboard but the infrastructure is shared for cost efficiency. It combines Pinot's tenant tagging, workload isolation, and application-level row filtering to deliver per-customer data isolation and fair resource allocation.
+
+## When to use this pattern
+
+Use this playbook when:
+
+- You operate a SaaS product where each customer should only see their own data.
+- You want to run a single Pinot cluster (lower operational overhead) rather than one cluster per customer.
+- Different customers have different query volumes, and you need to prevent a heavy-hitter from degrading others.
+- You need to enforce data isolation at the query layer (row-level security) alongside resource isolation at the infrastructure layer.
+
+## Architecture sketch
+
+```
+Customer A ──▶ App backend ──▶ Broker pool A ──▶ Servers (tenant A)
+Customer B ──▶ App backend ──▶ Broker pool B ──▶ Servers (shared)
+Customer C ──▶ App backend ──▶ Broker pool B ──▶ Servers (shared)
+                  │
+          (injects tenant_id
+           filter into every query)
+```
+
+There are two complementary isolation layers:
+
+1. **Infrastructure isolation** via Pinot tenants — assign servers and brokers to named tenants so resource-hungry customers get dedicated compute.
+2. **Data isolation** via application-level row filtering — the application layer injects a `WHERE tenant_id = '<customer>'` predicate into every query.
+
+## Data model
+
+### Single-table approach (recommended for most cases)
+
+Store all tenants' data in one table with a `tenantId` dimension:
+
+```json
+{
+  "schemaName": "saas_events",
+  "dimensionFieldSpecs": [
+    { "name": "tenantId",   "dataType": "STRING" },
+    { "name": "eventType",  "dataType": "STRING" },
+    { "name": "userId",     "dataType": "STRING" },
+    { "name": "feature",    "dataType": "STRING" },
+    { "name": "plan",       "dataType": "STRING" }
+  ],
+  "metricFieldSpecs": [
+    { "name": "durationMs", "dataType": "LONG" },
+    { "name": "count",      "dataType": "INT" }
+  ],
+  "dateTimeFieldSpecs": [
+    {
+      "name": "eventTimestamp",
+      "dataType": "TIMESTAMP",
+      "format": "1:MILLISECONDS:EPOCH",
+      "granularity": "1:MILLISECONDS"
+    }
+  ]
+}
+```
+
+### Table-per-tenant approach (for extreme isolation)
+
+For customers with strict compliance requirements, create a separate table per tenant. This gives full isolation (separate segments, servers, retention) but increases operational complexity. Use this only when regulatory requirements demand it.
+
+## Table configuration
+
+```json
+{
+  "tableName": "saas_events",
+  "tableType": "REALTIME",
+  "segmentsConfig": {
+    "timeColumnName": "eventTimestamp",
+    "retentionTimeUnit": "DAYS",
+    "retentionTimeValue": "90",
+    "replication": "2",
+    "segmentPushType": "APPEND"
+  },
+  "tableIndexConfig": {
+    "loadMode": "MMAP",
+    "sortedColumn": ["tenantId"],
+    "invertedIndexColumns": ["eventType", "feature", "plan"],
+    "rangeIndexColumns": ["eventTimestamp"],
+    "noDictionaryColumns": ["userId"],
+    "bloomFilterColumns": ["tenantId"],
+    "streamConfigs": {
+      "streamType": "kafka",
+      "stream.kafka.topic.name": "saas-events",
+      "stream.kafka.broker.list": "kafka:9092",
+      "stream.kafka.consumer.type": "lowlevel",
+      "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory",
+      "stream.kafka.decoder.class.name": "org.apache.pinot.plugin.stream.kafka.KafkaJSONMessageDecoder",
+      "realtime.segment.flush.threshold.rows": "500000",
+      "realtime.segment.flush.threshold.time": "6h"
+    }
+  },
+  "tenants": {
+    "broker": "SharedTenant",
+    "server": "SharedTenant"
+  },
+  "metadata": {}
+}
+```
+
+### Why `tenantId` is the sorted column
+
+When `tenantId` is the sorted column, all rows for a single tenant are physically adjacent in each segment. This means a `WHERE tenantId = 'acme'` filter skips entire data pages without scanning, giving near-instant segment pruning. If a different column is a better sort key for your queries, use an inverted index on `tenantId` instead.
+
+## Infrastructure isolation with Pinot tenants
+
+### Assigning servers to tenants
+
+Tag servers when adding them to the cluster:
+
+```
+PUT /instances/Server_host1_8098
+{
+  "host": "host1",
+  "port": "8098",
+  "type": "SERVER",
+  "tags": ["PremiumTenant_REALTIME", "PremiumTenant_OFFLINE"]
+}
+```
+
+Then assign high-value customers' tables to the `PremiumTenant`:
+
+```json
+"tenants": {
+  "broker": "PremiumTenant",
+  "server": "PremiumTenant"
+}
+```
+
+Other customers share a `SharedTenant` pool. See [Tenant](../basics/components/cluster/tenant.md) for setup details.
+
+### Workload-based query isolation
+
+For finer-grained control within a shared tenant, use workload-based query resource isolation to limit CPU and memory per workload class:
+
+```json
+{
+  "workloadConfig": {
+    "workloads": {
+      "free_tier": {
+        "maxQueriesPerSecond": 10,
+        "maxServerThreads": 2
+      },
+      "enterprise": {
+        "maxQueriesPerSecond": 100,
+        "maxServerThreads": 8
+      }
+    }
+  }
+}
+```
+
+The application backend sets the workload class in the query option:
+
+```sql
+SET workload = 'free_tier';
+SELECT ...
+```
+
+See [Workload-Based Query Resource Isolation](../operators/operating-pinot/tuning/workload-query-isolation.md) for configuration details.
+
+### Broker-level query quotas
+
+Apply per-table query rate limits at the broker to prevent any single tenant from monopolizing query resources:
+
+```json
+{
+  "quotas": {
+    "maxQueriesPerSecond": 50
+  }
+}
+```
+
+See [Query Quotas](../build-with-pinot/querying-and-sql/query-execution-controls/query-quotas.md).
+
+## Data isolation (row-level security)
+
+Pinot does not have built-in row-level security. The standard approach is to enforce tenant filtering in the **application layer** that sits between the user and the Pinot broker.
+
+### Implementation pattern
+
+Your application backend should:
+
+1. Authenticate the user and determine their `tenantId`.
+2. Inject `AND tenantId = '<tenantId>'` into every SQL query before sending it to the Pinot broker.
+3. Never expose the Pinot broker directly to end users.
+
+Example backend pseudocode:
+
+```python
+def query_pinot(user_query: str, tenant_id: str) -> dict:
+    # Parse and inject tenant filter
+    safe_query = inject_tenant_filter(user_query, tenant_id)
+    # Send to Pinot broker
+    return pinot_client.execute(safe_query)
+
+def inject_tenant_filter(query: str, tenant_id: str) -> str:
+    # Use a SQL parser to safely inject the filter
+    # Never string-concatenate user input directly
+    parsed = parse_sql(query)
+    parsed.add_where_clause(f"tenantId = '{escape(tenant_id)}'")
+    return parsed.to_sql()
+```
+
+{% hint style="warning" %}
+Always use a SQL parser to inject the tenant filter. String concatenation is vulnerable to SQL injection. Validate that the rewritten query still contains the tenant filter before executing.
+{% endhint %}
+
+### Validating isolation
+
+Write integration tests that:
+
+1. Query with tenant A's filter and verify no tenant B data is returned.
+2. Attempt queries without a tenant filter and verify they are rejected by your backend.
+3. Attempt SQL injection in the tenant ID field and verify it is blocked.
+
+## Query patterns
+
+### Per-tenant dashboard aggregation
+
+```sql
+SELECT
+  DATETRUNC('hour', eventTimestamp, 'MILLISECONDS') AS hour,
+  eventType,
+  COUNT(*) AS event_count,
+  SUM(durationMs) AS total_duration
+FROM saas_events
+WHERE tenantId = 'acme'
+  AND eventTimestamp > ago('PT24H')
+GROUP BY hour, eventType
+ORDER BY hour
+LIMIT 1000
+```
+
+### Cross-tenant admin query (internal analytics)
+
+For your own internal dashboards, query without the tenant filter:
+
+```sql
+SELECT tenantId, COUNT(*) AS events, SUM(count) AS total_actions
+FROM saas_events
+WHERE eventTimestamp > ago('PT1H')
+GROUP BY tenantId
+ORDER BY events DESC
+LIMIT 100
+```
+
+Restrict access to this query pattern to internal admin users only.
+
+## Operational checklist
+
+### Before go-live
+
+- [ ] Verify that `tenantId` is always present in every event. Null `tenantId` values bypass row-level filtering.
+- [ ] Confirm the application backend injects the tenant filter for every query path — REST API, WebSocket, batch exports.
+- [ ] Load test with realistic per-tenant query rates. Ensure workload isolation caps prevent cascading slowdowns.
+- [ ] If using the single-table model, verify that `tenantId` as the sorted column delivers good pruning by running `EXPLAIN PLAN`.
+
+### Monitoring
+
+- **Per-tenant query rate**: Track via broker metrics, broken down by the `workload` query option. Alert if any tenant exceeds its quota.
+- **Query latency by tenant**: A spike for one tenant without an overall spike indicates that tenant's query pattern changed (e.g., missing time filter).
+- **Segment size per tenant**: If one tenant dominates the data volume, consider moving them to a dedicated tenant/server pool.
+
+### Common pitfalls
+
+| Pitfall | Fix |
+| --- | --- |
+| Tenant filter missing on one API endpoint | Add a centralized query middleware that rejects any query without `tenantId` in the WHERE clause |
+| One tenant's heavy queries slow everyone | Use workload isolation and per-table query quotas. Move the heavy tenant to a dedicated server tenant |
+| Sorted column on `tenantId` hurts time-range queries | Use inverted index on `tenantId` instead, and keep time as the sorted column if time-range performance is more critical |
+| Tenant data leaks via JOIN queries | If using multi-stage queries with JOINs, ensure the tenant filter is applied to both sides of the JOIN |
+
+## Further reading
+
+- [Tenant](../basics/components/cluster/tenant.md)
+- [Workload-Based Query Resource Isolation](../operators/operating-pinot/tuning/workload-query-isolation.md)
+- [Query Quotas](../build-with-pinot/querying-and-sql/query-execution-controls/query-quotas.md)
+- [Routing](../operators/operating-pinot/tuning/routing.md)
+- [Access Control](../operators/operating-pinot/access-control.md)

--- a/playbooks/real-time-product-analytics.md
+++ b/playbooks/real-time-product-analytics.md
@@ -1,0 +1,226 @@
+---
+description: End-to-end guide for building sub-second dashboards over Kafka event streams with Apache Pinot.
+---
+
+# Real-Time Product Analytics
+
+This playbook walks through a complete setup for powering user-facing or internal analytics dashboards with sub-second query latency over streaming data. Think page-view counters, transaction dashboards, click-through-rate monitors, or any workload where events arrive continuously and dashboards must refresh in real time.
+
+## When to use this pattern
+
+Use this playbook when:
+
+- Events are produced to Kafka (or Kinesis/Pulsar) and must be queryable within seconds of arrival.
+- Dashboards aggregate over time windows (last 1 hour, last 24 hours) with filters on dimensions such as country, device, or product category.
+- You need high query concurrency (hundreds of concurrent dashboard users) with P99 latency under one second.
+- Data is append-only; you do not need to update previously ingested rows. If you do, see the [CDC / Upsert Pipeline](cdc-upsert-pipeline.md) playbook instead.
+
+## Architecture sketch
+
+```
+Producers ──▶ Kafka topic ──▶ Pinot Real-Time Table ──▶ Broker ──▶ Dashboard
+                                    │
+                          ┌─────────┴─────────┐
+                          │  Real-time servers │
+                          │  (consuming segments)
+                          └───────────────────┘
+```
+
+Key components:
+
+- **Kafka topic** partitioned by a high-cardinality key (e.g., `userId`) to distribute load.
+- **Real-time table** with one consuming segment per Kafka partition per server.
+- **Star-tree index** for pre-aggregated rollups on the most common dashboard group-by/filter combinations.
+- **Brokers** that fan out queries to servers and merge results.
+
+## Schema
+
+Design the schema around the queries your dashboards will issue. A product-analytics event stream typically looks like this:
+
+```json
+{
+  "schemaName": "product_events",
+  "dimensionFieldSpecs": [
+    { "name": "eventType",  "dataType": "STRING" },
+    { "name": "userId",     "dataType": "STRING" },
+    { "name": "country",    "dataType": "STRING" },
+    { "name": "device",     "dataType": "STRING" },
+    { "name": "productId",  "dataType": "STRING" },
+    { "name": "category",   "dataType": "STRING" },
+    { "name": "sessionId",  "dataType": "STRING" }
+  ],
+  "metricFieldSpecs": [
+    { "name": "revenue",    "dataType": "DOUBLE" },
+    { "name": "quantity",   "dataType": "INT" }
+  ],
+  "dateTimeFieldSpecs": [
+    {
+      "name": "eventTimestamp",
+      "dataType": "TIMESTAMP",
+      "format": "1:MILLISECONDS:EPOCH",
+      "granularity": "1:MILLISECONDS"
+    }
+  ]
+}
+```
+
+{% hint style="info" %}
+Keep the schema narrow. Every dimension column you add increases segment size and potentially slows queries. Only include columns your dashboards actually filter or group on. See [Schema and Table Shape](../build-with-pinot/data-modeling/schema.md) for design guidance.
+{% endhint %}
+
+## Table configuration
+
+```json
+{
+  "tableName": "product_events",
+  "tableType": "REALTIME",
+  "segmentsConfig": {
+    "timeColumnName": "eventTimestamp",
+    "retentionTimeUnit": "DAYS",
+    "retentionTimeValue": "30",
+    "replication": "2",
+    "segmentPushType": "APPEND"
+  },
+  "tableIndexConfig": {
+    "loadMode": "MMAP",
+    "invertedIndexColumns": ["eventType", "country", "device", "category"],
+    "rangeIndexColumns": ["eventTimestamp"],
+    "sortedColumn": ["eventType"],
+    "bloomFilterColumns": ["userId"],
+    "noDictionaryColumns": ["sessionId", "userId"],
+    "starTreeIndexConfigs": [
+      {
+        "dimensionsSplitOrder": ["country", "device", "category", "eventType"],
+        "skipStarNodeCreationForDimensions": [],
+        "functionColumnPairs": [
+          "COUNT__*",
+          "SUM__revenue",
+          "SUM__quantity"
+        ],
+        "maxLeafRecords": 10000
+      }
+    ],
+    "streamConfigs": {
+      "streamType": "kafka",
+      "stream.kafka.topic.name": "product-events",
+      "stream.kafka.broker.list": "kafka:9092",
+      "stream.kafka.consumer.type": "lowlevel",
+      "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory",
+      "stream.kafka.decoder.class.name": "org.apache.pinot.plugin.stream.kafka.KafkaJSONMessageDecoder",
+      "realtime.segment.flush.threshold.rows": "500000",
+      "realtime.segment.flush.threshold.time": "6h"
+    }
+  },
+  "tenants": {
+    "broker": "DefaultTenant",
+    "server": "DefaultTenant"
+  },
+  "metadata": {}
+}
+```
+
+### Configuration highlights
+
+| Setting | Why |
+| --- | --- |
+| `invertedIndexColumns` on dimensions | Enables fast filtering on dashboard filter dropdowns |
+| `rangeIndexColumns` on `eventTimestamp` | Speeds up time-range predicates like `WHERE eventTimestamp > ago('PT1H')` |
+| `starTreeIndexConfigs` | Pre-aggregates the most common rollup queries so they return in single-digit milliseconds |
+| `bloomFilterColumns` on `userId` | Accelerates point lookups when a dashboard drills into a single user |
+| `noDictionaryColumns` on high-cardinality IDs | Saves memory; dictionary encoding is wasteful for columns with millions of unique values |
+| `retentionTimeValue: 30` | Automatically purges data older than 30 days. Adjust to your retention needs |
+
+## Indexing strategy
+
+Start with the indexes shown above and iterate:
+
+1. **Inverted indexes** on every column used in `WHERE` equality filters.
+2. **Range index** on the time column and any numeric column used in range filters.
+3. **Sorted index** on the column with the most common equality filter (only one sorted column per table).
+4. **Star-tree index** for the top 3-5 dashboard queries that dominate traffic. Profile your queries before adding more star-tree configs — each one adds ingestion overhead and segment size.
+5. **Bloom filter** on columns used for point lookups with very high cardinality.
+
+See [Choosing Indexes](../build-with-pinot/indexing/choosing-indexes.md) for a decision framework.
+
+## Query patterns
+
+### Dashboard time-series aggregation
+
+```sql
+SELECT
+  DATETIMECONVERT(eventTimestamp, '1:MILLISECONDS:EPOCH', '1:MINUTES:EPOCH', '5:MINUTES') AS ts_bucket,
+  country,
+  COUNT(*) AS event_count,
+  SUM(revenue) AS total_revenue
+FROM product_events
+WHERE eventTimestamp > ago('PT1H')
+  AND eventType = 'PURCHASE'
+GROUP BY ts_bucket, country
+ORDER BY ts_bucket
+LIMIT 1000
+```
+
+### Top-N with filters
+
+```sql
+SELECT
+  productId,
+  SUM(revenue) AS total_revenue,
+  COUNT(*) AS purchase_count
+FROM product_events
+WHERE eventTimestamp > ago('PT24H')
+  AND country = 'US'
+  AND eventType = 'PURCHASE'
+GROUP BY productId
+ORDER BY total_revenue DESC
+LIMIT 20
+```
+
+### Single-user drill-down
+
+```sql
+SELECT eventType, eventTimestamp, productId, revenue
+FROM product_events
+WHERE userId = 'u-123456'
+  AND eventTimestamp > ago('PT7D')
+ORDER BY eventTimestamp DESC
+LIMIT 100
+```
+
+{% hint style="info" %}
+Use `OPTION(timeoutMs=5000)` on dashboard queries so a single slow query does not hold the connection pool. See [Query Options](../build-with-pinot/querying-and-sql/query-execution-controls/query-options.md).
+{% endhint %}
+
+## Operational checklist
+
+### Before go-live
+
+- [ ] Confirm Kafka topic partitions match the desired parallelism. Pinot creates one consuming segment per partition per server.
+- [ ] Set `realtime.segment.flush.threshold.rows` and `realtime.segment.flush.threshold.time` so completed segments are a reasonable size (300 MB-1 GB). Overly small segments increase metadata overhead; overly large ones slow queries.
+- [ ] Validate that the star-tree index covers your most frequent queries by running `EXPLAIN PLAN` and checking for `StarTreeIndex` in the output.
+- [ ] Set table-level [query quotas](../build-with-pinot/querying-and-sql/query-execution-controls/query-quotas.md) if multiple teams share the cluster.
+
+### Monitoring
+
+- **`CONSUMING` segment lag**: Monitor Kafka consumer lag via `pinot.server.realtimeConsumptionCatchupRatio`. If lag grows, add more servers or partitions.
+- **Query latency P99**: Track via broker metrics. If P99 exceeds your SLA, consider adding star-tree indexes or scaling brokers.
+- **Segment count per table**: A very large number of small segments degrades query performance. Use the [Minion Merge Rollup Task](../operators/operating-pinot/minion-merge-rollup-task.md) to compact completed segments.
+- **Heap and direct memory**: Real-time servers hold consuming segments in memory. Monitor JVM heap and off-heap usage.
+
+See [Monitoring](../operate-pinot/monitoring.md) and [Running Pinot in Production](../operate-pinot/running-pinot-in-production.md) for a comprehensive metric list.
+
+### Common pitfalls
+
+| Pitfall | Fix |
+| --- | --- |
+| Dashboard queries scan all 30 days of data | Add a time-range predicate; without it, the broker routes the query to every segment |
+| Star-tree does not activate | Verify the query's GROUP BY and aggregation functions exactly match the star-tree config |
+| High GC pauses on servers | Move high-cardinality `noDictionary` columns out of the dictionary, or increase direct memory for MMAP |
+| Kafka rebalance causes brief query gaps | Set `replication: 2` so a second server can serve the data while one server is catching up |
+
+## Further reading
+
+- [Stream Ingestion Guide](../build-with-pinot/ingestion/stream-ingestion/README.md)
+- [Star-Tree Index](../build-with-pinot/indexing/star-tree-index.md)
+- [Real-Time Tuning](../operators/operating-pinot/tuning/realtime.md)
+- [Performance Optimization Configurations](../operate-pinot/performance-optimization-configurations.md)

--- a/playbooks/text-search-analytics.md
+++ b/playbooks/text-search-analytics.md
@@ -1,0 +1,296 @@
+---
+description: End-to-end guide for combining full-text search with OLAP aggregations in Apache Pinot.
+---
+
+# Text Search Analytics
+
+This playbook covers workloads that combine full-text search with OLAP-style aggregations — searching logs for error patterns and then aggregating by service, filtering a product catalog by description text and then ranking by sales, or triaging support tickets by keyword and then grouping by severity.
+
+## When to use this pattern
+
+Use this playbook when:
+
+- Your queries include both free-text predicates (keyword search, phrase match, fuzzy match) **and** structured filters/aggregations (GROUP BY, SUM, COUNT, time-range filters).
+- You want a single system for text search and analytics instead of maintaining both Elasticsearch and a separate OLAP store.
+- Text columns contain natural language (log messages, product descriptions, ticket bodies, user reviews) rather than short categorical values.
+- You need real-time ingestion of text data with immediate searchability.
+
+If your text columns are short, low-cardinality labels (e.g., status codes, country names), standard inverted indexes are sufficient — you do not need a text index.
+
+## Architecture sketch
+
+```
+Log / event stream ──▶ Kafka ──▶ Pinot REALTIME table
+                                      │
+                              ┌───────┴────────┐
+                              │ Servers with    │
+                              │ text index on   │
+                              │ message column  │
+                              └────────────────┘
+                                      │
+                              TEXT_MATCH + OLAP
+                              queries from app
+```
+
+Pinot supports two text index implementations:
+
+| Index | Engine | Best for |
+| --- | --- | --- |
+| **Text index** (Lucene-based) | Apache Lucene | Full Lucene query syntax: phrase queries, fuzzy, regex, wildcard, proximity |
+| **Native text index** | Pinot built-in | Simple keyword/phrase search with lower memory and faster ingestion |
+
+This playbook covers both. Start with the native text index for simpler use cases, and switch to Lucene-based if you need advanced query syntax.
+
+## Schema
+
+```json
+{
+  "schemaName": "support_tickets",
+  "dimensionFieldSpecs": [
+    { "name": "ticketId",    "dataType": "STRING" },
+    { "name": "customerId",  "dataType": "STRING" },
+    { "name": "severity",    "dataType": "STRING" },
+    { "name": "service",     "dataType": "STRING" },
+    { "name": "assignee",    "dataType": "STRING" },
+    { "name": "subject",     "dataType": "STRING" },
+    { "name": "body",        "dataType": "STRING" }
+  ],
+  "metricFieldSpecs": [
+    { "name": "responseTimeMs", "dataType": "LONG" }
+  ],
+  "dateTimeFieldSpecs": [
+    {
+      "name": "createdAt",
+      "dataType": "TIMESTAMP",
+      "format": "1:MILLISECONDS:EPOCH",
+      "granularity": "1:MILLISECONDS"
+    }
+  ]
+}
+```
+
+The `subject` and `body` columns will carry the text index. They must be declared as `STRING` type and should **not** have dictionary encoding (they go in the `noDictionaryColumns` list).
+
+## Table configuration with Lucene-based text index
+
+```json
+{
+  "tableName": "support_tickets",
+  "tableType": "REALTIME",
+  "segmentsConfig": {
+    "timeColumnName": "createdAt",
+    "retentionTimeUnit": "DAYS",
+    "retentionTimeValue": "180",
+    "replication": "2"
+  },
+  "tableIndexConfig": {
+    "loadMode": "MMAP",
+    "invertedIndexColumns": ["severity", "service", "assignee"],
+    "rangeIndexColumns": ["createdAt"],
+    "noDictionaryColumns": ["ticketId", "customerId", "subject", "body"],
+    "bloomFilterColumns": ["ticketId"],
+    "fieldConfigList": [
+      {
+        "name": "subject",
+        "encodingType": "RAW",
+        "indexTypes": ["TEXT"],
+        "properties": {
+          "fstType": "NATIVE"
+        }
+      },
+      {
+        "name": "body",
+        "encodingType": "RAW",
+        "indexTypes": ["TEXT"],
+        "properties": {
+          "fstType": "NATIVE"
+        }
+      }
+    ],
+    "streamConfigs": {
+      "streamType": "kafka",
+      "stream.kafka.topic.name": "support-tickets",
+      "stream.kafka.broker.list": "kafka:9092",
+      "stream.kafka.consumer.type": "lowlevel",
+      "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory",
+      "stream.kafka.decoder.class.name": "org.apache.pinot.plugin.stream.kafka.KafkaJSONMessageDecoder",
+      "realtime.segment.flush.threshold.rows": "250000",
+      "realtime.segment.flush.threshold.time": "4h"
+    }
+  },
+  "tenants": {
+    "broker": "DefaultTenant",
+    "server": "DefaultTenant"
+  },
+  "metadata": {}
+}
+```
+
+### Configuration highlights
+
+| Setting | Why |
+| --- | --- |
+| `fieldConfigList` with `indexTypes: ["TEXT"]` | Creates a Lucene-based text index on `subject` and `body` |
+| `encodingType: RAW` | Text-indexed columns must use raw encoding, not dictionary |
+| `noDictionaryColumns` includes text columns | Disables dictionary encoding, which is inefficient for long text |
+| `invertedIndexColumns` on structured columns | Standard inverted indexes for the non-text filters (severity, service) |
+
+## Alternative: native text index
+
+For simpler search needs (keyword match, phrase match) with lower resource overhead:
+
+```json
+"fieldConfigList": [
+  {
+    "name": "body",
+    "encodingType": "RAW",
+    "indexTypes": ["NATIVE_TEXT"]
+  }
+]
+```
+
+The native text index does not use Lucene and has lower memory overhead, but does not support fuzzy matching, regex, proximity queries, or boosting. See [Native Text Index](../build-with-pinot/indexing/native-text-index.md) for a comparison.
+
+## Query patterns
+
+### TEXT_MATCH: keyword search with aggregation
+
+Find tickets mentioning "timeout" and aggregate by service:
+
+```sql
+SELECT
+  service,
+  severity,
+  COUNT(*) AS ticket_count,
+  AVG(responseTimeMs) AS avg_response_time
+FROM support_tickets
+WHERE TEXT_MATCH(body, 'timeout')
+  AND createdAt > ago('P7D')
+GROUP BY service, severity
+ORDER BY ticket_count DESC
+LIMIT 50
+```
+
+### Phrase search
+
+Find tickets with the exact phrase "connection refused":
+
+```sql
+SELECT ticketId, subject, createdAt
+FROM support_tickets
+WHERE TEXT_MATCH(body, '"connection refused"')
+  AND severity = 'P1'
+ORDER BY createdAt DESC
+LIMIT 20
+```
+
+### Boolean text queries
+
+Combine text predicates with AND, OR, NOT:
+
+```sql
+SELECT ticketId, subject, service
+FROM support_tickets
+WHERE TEXT_MATCH(body, '(timeout OR "connection refused") AND NOT retry')
+  AND createdAt > ago('P30D')
+LIMIT 100
+```
+
+### Wildcard and fuzzy search (Lucene index only)
+
+```sql
+-- Wildcard: matches "authenticate", "authentication", "authenticator"
+SELECT ticketId, subject
+FROM support_tickets
+WHERE TEXT_MATCH(body, 'authenticat*')
+LIMIT 50
+
+-- Fuzzy: matches "recieve", "receive", "receieve" (edit distance 2)
+SELECT ticketId, subject
+FROM support_tickets
+WHERE TEXT_MATCH(body, 'receive~2')
+LIMIT 50
+```
+
+### Combining text search with OLAP aggregations
+
+The power of this pattern is running text filters as part of a larger analytical query:
+
+```sql
+SELECT
+  DATETRUNC('day', createdAt, 'MILLISECONDS') AS day,
+  COUNT(*) AS error_tickets,
+  PERCENTILEEST(responseTimeMs, 95) AS p95_response
+FROM support_tickets
+WHERE TEXT_MATCH(body, '"database error" OR "query timeout"')
+  AND severity IN ('P1', 'P2')
+  AND createdAt > ago('P14D')
+GROUP BY day
+ORDER BY day
+LIMIT 100
+```
+
+{% hint style="info" %}
+`TEXT_MATCH` is a predicate, not a scoring function. Pinot does not return relevance scores. If you need ranked search results, keep an external search engine for ranking and use Pinot for the analytical aggregation layer.
+{% endhint %}
+
+## Log analytics variant
+
+For log analytics (e.g., Apache access logs, application logs), the schema typically has a `logMessage` text column and structured columns extracted at ingestion time:
+
+```json
+{
+  "schemaName": "app_logs",
+  "dimensionFieldSpecs": [
+    { "name": "service",    "dataType": "STRING" },
+    { "name": "level",      "dataType": "STRING" },
+    { "name": "host",       "dataType": "STRING" },
+    { "name": "logMessage", "dataType": "STRING" }
+  ],
+  "dateTimeFieldSpecs": [
+    {
+      "name": "logTimestamp",
+      "dataType": "TIMESTAMP",
+      "format": "1:MILLISECONDS:EPOCH",
+      "granularity": "1:MILLISECONDS"
+    }
+  ]
+}
+```
+
+Use [ingestion transformations](../build-with-pinot/ingestion/ingestion-level-transformations.md) to extract structured fields from log lines during ingestion, and apply a text index on the raw `logMessage` for ad-hoc search.
+
+For high-cardinality log data, consider [Stream Ingestion with CLP](../build-with-pinot/ingestion/stream-ingestion/clp.md) which provides compressed log storage with efficient search.
+
+## Operational checklist
+
+### Before go-live
+
+- [ ] Confirm text-indexed columns are in `noDictionaryColumns` and use `encodingType: RAW` in `fieldConfigList`. Dictionary encoding on text columns wastes memory and breaks text indexing.
+- [ ] Size your servers with extra heap for Lucene indexes. Each Lucene text index maintains in-memory data structures per segment. Budget 20-30% more heap than a comparable table without text indexes.
+- [ ] Test query latency with realistic text queries. `TEXT_MATCH` on short keywords is fast; wildcard queries on large text columns can be slow.
+- [ ] Set `realtime.segment.flush.threshold.rows` lower than usual (e.g., 250K) because text-heavy segments are larger in bytes per row.
+
+### Monitoring
+
+- **Lucene index size on disk**: Text indexes can be 1-3x the size of the raw text data. Monitor disk usage per server.
+- **Query latency for TEXT_MATCH queries**: Lucene query execution time is included in the server-side query metrics. If P99 spikes, check for expensive wildcard or regex patterns.
+- **Segment flush time**: Building text indexes during segment flush takes longer than standard indexes. If flush times grow, reduce `flush.threshold.rows`.
+
+### Common pitfalls
+
+| Pitfall | Fix |
+| --- | --- |
+| `TEXT_MATCH` returns no results | Verify the column has a text index configured (not just inverted index). Check `fieldConfigList` |
+| High memory usage on servers | Lucene indexes are memory-intensive. Use the native text index if you only need keyword/phrase search |
+| Slow wildcard queries with leading wildcards | Leading wildcards (`*error`) require scanning the entire term dictionary. Avoid them, or use an FST index for prefix queries |
+| Text index on a low-cardinality column | Use a standard inverted index instead — text indexes are overkill for columns with few unique values |
+| Search relevance ranking needed | Pinot's `TEXT_MATCH` is a filter, not a scorer. Use Elasticsearch or similar for relevance-ranked search and Pinot for the aggregation layer |
+
+## Further reading
+
+- [Text Search Support](../build-with-pinot/indexing/text-search-support.md)
+- [Native Text Index](../build-with-pinot/indexing/native-text-index.md)
+- [FST Index](../build-with-pinot/indexing/fst-index.md)
+- [Stream Ingestion with CLP](../build-with-pinot/ingestion/stream-ingestion/clp.md)
+- [Choosing Indexes](../build-with-pinot/indexing/choosing-indexes.md)


### PR DESCRIPTION
## Summary
- Add a new **Workload Playbooks** section with 5 end-to-end guides for common Pinot use cases
- Playbooks include: Real-Time Product Analytics, CDC/Upsert Pipeline, Hybrid Real-Time + Offline, Multi-Tenant Analytics, and Text Search Analytics
- Each playbook provides complete schema, table config, ingestion config, and query examples

## Test plan
- [ ] Verify all playbook pages render correctly in GitBook
- [ ] Confirm SUMMARY.md links resolve to the correct files
- [ ] Review each playbook for accuracy of Pinot configurations

🤖 Generated with [Claude Code](https://claude.com/claude-code)