### PR TITLE
docs: remove Kafka 2.0 references, update default to Kafka 3.0

### DIFF
--- a/build-with-pinot/ingestion/stream-ingestion/kafka-connector-versions.md
+++ b/build-with-pinot/ingestion/stream-ingestion/kafka-connector-versions.md
@@ -48,14 +48,13 @@ The Kafka 4.0 connector uses the same configuration properties as the Kafka 3.0 
 }
 ```
 
-### Migration from Kafka 3.0
+### Migration from Kafka 2.0 or 3.0
 
-To migrate from the Kafka 3.0 connector to Kafka 4.0:
-
-1. Update the consumer factory class name in your table configuration:
+To migrate from an older Kafka connector to Kafka 3.0 or 4.0, update the consumer factory class name in your table configuration:
 
 | From | To |
 |---|---|
+| `org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory` | `org.apache.pinot.plugin.stream.kafka30.KafkaConsumerFactory` (Kafka 3.x) or `org.apache.pinot.plugin.stream.kafka40.KafkaConsumerFactory` (Kafka 4.x) |
 | `org.apache.pinot.plugin.stream.kafka30.KafkaConsumerFactory` | `org.apache.pinot.plugin.stream.kafka40.KafkaConsumerFactory` |
 
 2. Ensure the `pinot-kafka-4.0` plugin JAR is available in your Pinot plugin directory.

--- a/build-with-pinot/ingestion/stream-ingestion/kafka-connector-versions.md
+++ b/build-with-pinot/ingestion/stream-ingestion/kafka-connector-versions.md
@@ -15,7 +15,7 @@ Apache Pinot provides multiple Kafka connector versions to match different Kafka
 | `pinot-kafka-4.0` | 4.1.x | Recommended for Kafka 4.x clusters (KRaft mode). Pure Java — no Scala dependency. |
 
 {% hint style="warning" %}
-The `pinot-kafka-2.0` (kafka20) plugin is deprecated. If your table config references `org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory`, you should migrate to either `kafka30` or `kafka40`.
+The `pinot-kafka-2.0` (kafka20) plugin has been removed. If your table config references `org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory`, you must migrate to either `kafka30` or `kafka40`.
 {% endhint %}
 
 ## Kafka 4.0 Connector
@@ -48,15 +48,14 @@ The Kafka 4.0 connector uses the same configuration properties as the Kafka 3.0 
 }
 ```
 
-### Migration from Kafka 2.0/3.0
+### Migration from Kafka 3.0
 
-To migrate from an older Kafka connector to Kafka 4.0:
+To migrate from the Kafka 3.0 connector to Kafka 4.0:
 
 1. Update the consumer factory class name in your table configuration:
 
 | From | To |
 |---|---|
-| `org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory` | `org.apache.pinot.plugin.stream.kafka40.KafkaConsumerFactory` |
 | `org.apache.pinot.plugin.stream.kafka30.KafkaConsumerFactory` | `org.apache.pinot.plugin.stream.kafka40.KafkaConsumerFactory` |
 
 2. Ensure the `pinot-kafka-4.0` plugin JAR is available in your Pinot plugin directory.

--- a/develop-contribute/build-docker-images.md
+++ b/develop-contribute/build-docker-images.md
@@ -40,7 +40,7 @@ The docker image is tagged as `[Docker Tag]`.
 
 `Pinot Git URL`: The Pinot Git Repo to build, users can set it to their own fork. Note that the URL is `https://` based, not `git://`. Default is the Apache Repo: `https://github.com/apache/pinot.git`.
 
-`Kafka Version`: The Kafka Version to build pinot with. Default is `2.0`
+`Kafka Version`: The Kafka Version to build pinot with. Default is `3.0`. Supported values are `3.0` and `4.0`.
 
 `Java Version`: The Java Build and Runtime image version. Default is `21`
 


### PR DESCRIPTION
## Summary
- Update Docker build docs to reflect Kafka `3.0` as the default version (was `2.0`), with `3.0` and `4.0` as supported values
- Mark `pinot-kafka-2.0` as "removed" instead of "deprecated" in the Kafka connector versions page
- Clean up the Kafka 4.0 migration section to only reference migrating from Kafka 3.0 (removed stale kafka20 row)

## Test plan
- [ ] Verify the Docker build documentation correctly shows `3.0` as default
- [ ] Verify the Kafka connector versions page accurately reflects removal status
- [ ] Confirm no broken links or formatting issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)