### PR TITLE
docs: upgrade Kafka quickstart examples to 4.0 with KRaft mode

### DIFF
--- a/basics/components/table/README.md
+++ b/basics/components/table/README.md
@@ -222,10 +222,16 @@ Check out the table config in the [Rest API](http://localhost:9000/help#!/Table/
 ```
 docker run \
     --network pinot-demo --name=kafka \
-    -e KAFKA_ZOOKEEPER_CONNECT=pinot-zookeeper:2181/kafka \
-    -e KAFKA_BROKER_ID=0 \
-    -e KAFKA_ADVERTISED_HOST_NAME=kafka \
-    -d wurstmeister/kafka:latest
+    -e KAFKA_NODE_ID=1 \
+    -e KAFKA_PROCESS_ROLES=broker,controller \
+    -e KAFKA_LISTENERS=PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093 \
+    -e KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092 \
+    -e KAFKA_CONTROLLER_LISTENER_NAMES=CONTROLLER \
+    -e KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT \
+    -e KAFKA_CONTROLLER_QUORUM_VOTERS=1@kafka:9093 \
+    -e KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1 \
+    -e CLUSTER_ID=MkU3OEVBNTcwNTJENDM2Qk \
+    -d apache/kafka:4.0.0
 ```
 
 **Create a Kafka topic**
@@ -234,7 +240,7 @@ docker run \
 docker exec \
   -t kafka \
   /opt/kafka/bin/kafka-topics.sh \
-  --zookeeper pinot-zookeeper:2181/kafka \
+  --bootstrap-server kafka:9092 \
   --partitions=1 --replication-factor=1 \
   --create --topic flights-realtime
 ```

--- a/basics/getting-started/first-stream-ingest.md
+++ b/basics/getting-started/first-stream-ingest.md
@@ -36,18 +36,22 @@ bin/pinot-admin.sh StartKafka -zkAddress=localhost:2123/kafka -port 9876
 {% endtab %}
 
 {% tab title="Docker" %}
+Kafka 4.0 runs in KRaft mode and does not require ZooKeeper:
+
 ```bash
 docker run \
     --network pinot-demo --name=kafka \
-    -e KAFKA_ZOOKEEPER_CONNECT=pinot-zookeeper:2181/kafka \
-    -e KAFKA_BROKER_ID=0 \
-    -e KAFKA_ADVERTISED_HOST_NAME=kafka \
-    -d bitnami/kafka:3.6
+    -e KAFKA_NODE_ID=1 \
+    -e KAFKA_PROCESS_ROLES=broker,controller \
+    -e KAFKA_LISTENERS=PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093 \
+    -e KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092 \
+    -e KAFKA_CONTROLLER_LISTENER_NAMES=CONTROLLER \
+    -e KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT \
+    -e KAFKA_CONTROLLER_QUORUM_VOTERS=1@kafka:9093 \
+    -e KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1 \
+    -e CLUSTER_ID=MkU3OEVBNTcwNTJENDM2Qk \
+    -d apache/kafka:4.0.0
 ```
-
-{% hint style="info" %}
-Replace `pinot-zookeeper` with the actual container name of your ZooKeeper instance if you used a different name during setup.
-{% endhint %}
 {% endtab %}
 {% endtabs %}
 
@@ -68,7 +72,7 @@ bin/kafka-topics.sh --create --bootstrap-server localhost:9876 \
 docker exec \
   -t kafka \
   /opt/kafka/bin/kafka-topics.sh \
-  --zookeeper pinot-zookeeper:2181/kafka \
+  --bootstrap-server kafka:9092 \
   --partitions=1 --replication-factor=1 \
   --create --topic transcript-topic
 ```

--- a/basics/getting-started/first-stream-ingest.md
+++ b/basics/getting-started/first-stream-ingest.md
@@ -220,7 +220,7 @@ Create the file `/tmp/pinot-quick-start/rawdata/transcript.json`:
 {% tab title="Local" %}
 ```bash
 bin/kafka-console-producer.sh \
-    --broker-list localhost:9876 \
+    --bootstrap-server localhost:9876 \
     --topic transcript-topic < /tmp/pinot-quick-start/rawdata/transcript.json
 ```
 {% endtab %}
@@ -228,7 +228,7 @@ bin/kafka-console-producer.sh \
 {% tab title="Docker" %}
 ```bash
 docker exec -t kafka /opt/kafka/bin/kafka-console-producer.sh \
-    --broker-list localhost:9092 \
+    --bootstrap-server localhost:9092 \
     --topic transcript-topic < /tmp/pinot-quick-start/rawdata/transcript.json
 ```
 {% endtab %}

--- a/basics/getting-started/install/docker.md
+++ b/basics/getting-started/install/docker.md
@@ -25,7 +25,7 @@ Start a multi-component Pinot cluster using Docker, suitable for local evaluatio
 export PINOT_VERSION=1.4.0
 export PINOT_IMAGE=apachepinot/pinot:${PINOT_VERSION}
 export ZK_IMAGE=zookeeper:3.9.5
-export KAFKA_IMAGE=bitnami/kafka:3.6
+export KAFKA_IMAGE=apache/kafka:4.0.0
 ```
 
 See the [Version reference](../pinot-versions.md) page for the current stable release.
@@ -143,22 +143,25 @@ services:
       - pinot-demo
 
   pinot-kafka:
-    image: ${KAFKA_IMAGE:-bitnami/kafka:3.6}
+    image: ${KAFKA_IMAGE:-apache/kafka:4.0.0}
     container_name: "kafka"
     restart: unless-stopped
     ports:
       - "9092:9092"
     environment:
-      KAFKA_ZOOKEEPER_CONNECT: pinot-zookeeper:2181/kafka
-      KAFKA_BROKER_ID: 0
-      KAFKA_ADVERTISED_HOST_NAME: kafka
-    depends_on:
-      pinot-zookeeper:
-        condition: service_healthy
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka:9093
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      CLUSTER_ID: MkU3OEVBNTcwNTJENDM2Qk
     networks:
       - pinot-demo
     healthcheck:
-      test: ["CMD-SHELL", "kafka-broker-api-versions.sh -bootstrap-server kafka:9092"]
+      test: ["CMD-SHELL", "/opt/kafka/bin/kafka-broker-api-versions.sh --bootstrap-server kafka:9092"]
       interval: 30s
       timeout: 10s
       retries: 5
@@ -254,12 +257,20 @@ docker run --rm -ti \
 
 **Start Kafka (optional)**
 
+Kafka 4.0 runs in KRaft mode and does not require ZooKeeper:
+
 ```bash
 docker run --rm -ti \
     --network pinot-demo --name=kafka \
-    -e KAFKA_ZOOKEEPER_CONNECT=pinot-zookeeper:2181/kafka \
-    -e KAFKA_BROKER_ID=0 \
-    -e KAFKA_ADVERTISED_HOST_NAME=kafka \
+    -e KAFKA_NODE_ID=1 \
+    -e KAFKA_PROCESS_ROLES=broker,controller \
+    -e KAFKA_LISTENERS=PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093 \
+    -e KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092 \
+    -e KAFKA_CONTROLLER_LISTENER_NAMES=CONTROLLER \
+    -e KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT \
+    -e KAFKA_CONTROLLER_QUORUM_VOTERS=1@kafka:9093 \
+    -e KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1 \
+    -e CLUSTER_ID=MkU3OEVBNTcwNTJENDM2Qk \
     -p 9092:9092 \
     -d ${KAFKA_IMAGE}
 ```

--- a/basics/getting-started/kubernetes/stream-ingestion.md
+++ b/basics/getting-started/kubernetes/stream-ingestion.md
@@ -10,17 +10,14 @@ This guide walks you through loading streaming data into a Pinot cluster running
 
 ### **Bring up a Kafka cluster for real-time data ingestion**
 
-{% hint style="warning" %}
-Bitnami's Kafka Helm chart now defaults to **KRaft mode**, which does not deploy ZooKeeper. Because the Pinot Helm chart already runs its own ZooKeeper quorum, you must configure Kafka to use **ZooKeeper mode** so that it registers with the existing ZooKeeper ensemble. Add the flags below to disable KRaft and enable ZooKeeper.
+{% hint style="info" %}
+Kafka 4.0 uses **KRaft mode** by default and does not require ZooKeeper. The Bitnami Helm chart deploys Kafka with its own built-in controller quorum, so no separate ZooKeeper is needed for Kafka.
 {% endhint %}
 
 ```bash
 helm repo add kafka https://charts.bitnami.com/bitnami
 helm install -n pinot-quickstart kafka kafka/kafka \
     --set replicas=1 \
-    --set kraft.enabled=false \
-    --set zookeeper.enabled=true \
-    --set zookeeper.replicaCount=3 \
     --set listeners.client.protocol=PLAINTEXT
 ```
 

--- a/basics/getting-started/kubernetes/stream-ingestion.md
+++ b/basics/getting-started/kubernetes/stream-ingestion.md
@@ -11,7 +11,7 @@ This guide walks you through loading streaming data into a Pinot cluster running
 ### **Bring up a Kafka cluster for real-time data ingestion**
 
 {% hint style="info" %}
-Kafka 4.0 uses **KRaft mode** by default and does not require ZooKeeper. The Bitnami Helm chart deploys Kafka with its own built-in controller quorum, so no separate ZooKeeper is needed for Kafka.
+The Bitnami Kafka Helm chart deploys Kafka in **KRaft mode** (with a built-in controller quorum) by default, so a separate ZooKeeper deployment is not required for Kafka.
 {% endhint %}
 
 ```bash

--- a/build-with-pinot/ingestion/stream-ingestion/import-from-apache-kafka.md
+++ b/build-with-pinot/ingestion/stream-ingestion/import-from-apache-kafka.md
@@ -21,7 +21,7 @@ Let's start by downloading Kafka to our local machine.
 To pull down the latest Docker image, run the following command:
 
 ```bash
-docker pull wurstmeister/kafka:latest
+docker pull apache/kafka:4.0.0
 ```
 {% endtab %}
 
@@ -29,37 +29,41 @@ docker pull wurstmeister/kafka:latest
 Download Kafka from [kafka.apache.org/quickstart#quickstart\_download](https://kafka.apache.org/quickstart#quickstart\_download) and then extract it:
 
 ```bash
-tar -xzf kafka_2.13-3.7.0.tgz
-cd kafka_2.13-3.7.0
+tar -xzf kafka_2.13-4.0.0.tgz
+cd kafka_2.13-4.0.0
 ```
 {% endtab %}
 {% endtabs %}
 
-Next we'll spin up a Kafka broker:
+Next we'll spin up a Kafka broker. Kafka 4.0 uses KRaft mode by default and does not require ZooKeeper:
 
 {% tabs %}
 {% tab title="Docker" %}
 ```bash
-docker run --network pinot-demo --name=kafka -e KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181/kafka -e KAFKA_BROKER_ID=0 -e KAFKA_ADVERTISED_HOST_NAME=kafka wurstmeister/kafka:latest
+docker run --network pinot-demo --name=kafka \
+    -e KAFKA_NODE_ID=1 \
+    -e KAFKA_PROCESS_ROLES=broker,controller \
+    -e KAFKA_LISTENERS=PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093 \
+    -e KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092 \
+    -e KAFKA_CONTROLLER_LISTENER_NAMES=CONTROLLER \
+    -e KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT \
+    -e KAFKA_CONTROLLER_QUORUM_VOTERS=1@kafka:9093 \
+    -e KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1 \
+    -e CLUSTER_ID=MkU3OEVBNTcwNTJENDM2Qk \
+    apache/kafka:4.0.0
 ```
 
 Note: The --network pinot-demo flag is optional and assumes that you have a Docker network named pinot-demo that you want to connect the Kafka container to.
 {% endtab %}
 
 {% tab title="Launcher Scripts" %}
-On one terminal window run this command:
+Kafka 4.0 uses KRaft mode by default. Generate a cluster ID and format the storage directory, then start the broker:
 
-**Start Zookeeper**
-
-```bash
-bin/zookeeper-server-start.sh config/zookeeper.properties
-```
-
-And on another window, run this command:
-
-**Start Kafka Broker**
+**Start Kafka Broker (KRaft mode)**
 
 ```bash
+KAFKA_CLUSTER_ID="$(bin/kafka-storage.sh random-uuid)"
+bin/kafka-storage.sh format --standalone -t $KAFKA_CLUSTER_ID -c config/server.properties
 bin/kafka-server-start.sh config/server.properties
 ```
 {% endtab %}

--- a/build-with-pinot/ingestion/stream-ingestion/import-from-apache-kafka.md
+++ b/build-with-pinot/ingestion/stream-ingestion/import-from-apache-kafka.md
@@ -122,13 +122,13 @@ We can check how many messages have been ingested by running the following comma
 {% tabs %}
 {% tab title="Docker" %}
 ```bash
-docker exec -i kafka kafka-run-class.sh kafka.tools.GetOffsetShell --broker-list localhost:9092 --topic events
+docker exec -i kafka /opt/kafka/bin/kafka-get-offsets.sh --bootstrap-server localhost:9092 --topic events
 ```
 {% endtab %}
 
 {% tab title="Launcher Scripts" %}
 ```bash
-kafka-run-class.sh kafka.tools.GetOffsetShell --broker-list localhost:9092 --topic events
+bin/kafka-get-offsets.sh --bootstrap-server localhost:9092 --topic events
 ```
 {% endtab %}
 {% endtabs %}

--- a/operate-pinot/advanced-pinot-setup.md
+++ b/operate-pinot/advanced-pinot-setup.md
@@ -348,10 +348,16 @@ See [Streaming Tables](advanced-pinot-setup.md) for table configuration details 
 ```
 docker run \
     --network pinot-demo --name=kafka \
-    -e KAFKA_ZOOKEEPER_CONNECT=pinot-zookeeper:2181/kafka \
-    -e KAFKA_BROKER_ID=0 \
-    -e KAFKA_ADVERTISED_HOST_NAME=kafka \
-    -d wurstmeister/kafka:latest
+    -e KAFKA_NODE_ID=1 \
+    -e KAFKA_PROCESS_ROLES=broker,controller \
+    -e KAFKA_LISTENERS=PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093 \
+    -e KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092 \
+    -e KAFKA_CONTROLLER_LISTENER_NAMES=CONTROLLER \
+    -e KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT \
+    -e KAFKA_CONTROLLER_QUORUM_VOTERS=1@kafka:9093 \
+    -e KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1 \
+    -e CLUSTER_ID=MkU3OEVBNTcwNTJENDM2Qk \
+    -d apache/kafka:4.0.0
 ```
 
 **Create a Kafka Topic**
@@ -360,7 +366,7 @@ docker run \
 docker exec \
   -t kafka \
   /opt/kafka/bin/kafka-topics.sh \
-  --zookeeper pinot-zookeeper:2181/kafka \
+  --bootstrap-server kafka:9092 \
   --partitions=1 --replication-factor=1 \
   --create --topic flights-realtime
 ```

--- a/operate-pinot/advanced-pinot-setup.md
+++ b/operate-pinot/advanced-pinot-setup.md
@@ -395,6 +395,11 @@ Sending request: http://pinot-controller:9000/schemas to controller: 8fbe601012f
 {% endtab %}
 
 {% tab title="Using launcher scripts" %}
+
+{% hint style="info" %}
+Pinot's built-in `StartKafka` launcher starts an embedded Kafka instance that uses ZooKeeper for coordination. This is separate from standalone Kafka 4.0 (KRaft mode) shown in the Docker tab.
+{% endhint %}
+
 **Start Kafka-Zookeeper**
 
 ```

--- a/tutorials/getting-started/dash.md
+++ b/tutorials/getting-started/dash.md
@@ -221,7 +221,7 @@ We'll see the following (truncated) output:
 Now we're going to import each of the events into Apache Kafka. First let's create a Kafka topic called `wiki_events` with 5 partitions:
 
 ```bash
-docker exec -it kafka-wiki kafka-topics.sh \
+docker exec -it kafka-wiki /opt/kafka/bin/kafka-topics.sh \
   --bootstrap-server localhost:9092 \
   --create \
   --topic wiki_events \
@@ -339,7 +339,7 @@ wiki_events:4:58
 Looks good. We can also stream all the messages in this topic by running the following command:
 
 ```bash
-docker exec -it kafka-wiki kafka-console-consumer.sh \
+docker exec -it kafka-wiki /opt/kafka/bin/kafka-console-consumer.sh \
   --bootstrap-server localhost:9092 \
   --topic wiki_events \
   --from-beginning

--- a/tutorials/getting-started/dash.md
+++ b/tutorials/getting-started/dash.md
@@ -28,22 +28,23 @@ services:
       ZOOKEEPER_CLIENT_PORT: 2181
       ZOOKEEPER_TICK_TIME: 2000
   kafka:
-    image: wurstmeister/kafka:latest
+    image: apache/kafka:4.0.0
     restart: unless-stopped
     container_name: "kafka-wiki"
     ports:
       - "9092:9092"
     expose:
       - "9093"
-    depends_on:
-      - zookeeper
     environment:
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper-wiki:2181/kafka
-      KAFKA_BROKER_ID: 0
-      KAFKA_ADVERTISED_HOST_NAME: kafka-wiki
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9093,OUTSIDE://0.0.0.0:9092,CONTROLLER://0.0.0.0:29093
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka-wiki:9093,OUTSIDE://localhost:9092
-      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9093,OUTSIDE://0.0.0.0:9092
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,OUTSIDE:PLAINTEXT
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,OUTSIDE:PLAINTEXT
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka-wiki:29093
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      CLUSTER_ID: MkU3OEVBNTcwNTJENDM2Qk
   pinot-controller:
     image: apachepinot/pinot:latest
     command: "StartController -zkAddress zookeeper-wiki:2181 -dataDir /data"

--- a/tutorials/getting-started/dash.md
+++ b/tutorials/getting-started/dash.md
@@ -321,8 +321,8 @@ Let's check that the data has made its way into Kafka.
 The following command returns the message offset for each partition in the `wiki_events` topic:
 
 ```bash
-docker exec -it kafka-wiki kafka-run-class.sh kafka.tools.GetOffsetShell \
-  --broker-list localhost:9092 \
+docker exec -it kafka-wiki /opt/kafka/bin/kafka-get-offsets.sh \
+  --bootstrap-server localhost:9092 \
   --topic wiki_events
 ```
 

--- a/tutorials/getting-started/github-events-stream.md
+++ b/tutorials/getting-started/github-events-stream.md
@@ -60,7 +60,7 @@ Create a Kafka topic called `pullRequestMergedEvents` for the demo.
 ```bash
 docker exec \
   -it kafka \
-  /opt/bitnami/kafka/bin/kafka-topics.sh \
+  /opt/kafka/bin/kafka-topics.sh \
   --bootstrap-server kafka:9092 --partitions=1 \
   --replication-factor=1 --create \
   --topic pullRequestMergedEvents

--- a/tutorials/getting-started/streamlit.md
+++ b/tutorials/getting-started/streamlit.md
@@ -221,7 +221,7 @@ We'll see the following (truncated) output:
 Now we're going to import each of the events into Apache Kafka. First let's create a Kafka topic called `wiki_events` with 5 partitions:
 
 ```bash
-docker exec -it kafka-wiki kafka-topics.sh \
+docker exec -it kafka-wiki /opt/kafka/bin/kafka-topics.sh \
   --bootstrap-server localhost:9092 \
   --create \
   --topic wiki_events \
@@ -339,7 +339,7 @@ wiki_events:4:58
 Looks good. We can also stream all the messages in this topic by running the following command:
 
 ```bash
-docker exec -it kafka-wiki kafka-console-consumer.sh \
+docker exec -it kafka-wiki /opt/kafka/bin/kafka-console-consumer.sh \
   --bootstrap-server localhost:9092 \
   --topic wiki_events \
   --from-beginning

--- a/tutorials/getting-started/streamlit.md
+++ b/tutorials/getting-started/streamlit.md
@@ -28,22 +28,23 @@ services:
       ZOOKEEPER_CLIENT_PORT: 2181
       ZOOKEEPER_TICK_TIME: 2000
   kafka:
-    image: wurstmeister/kafka:latest
+    image: apache/kafka:4.0.0
     restart: unless-stopped
     container_name: "kafka-wiki"
     ports:
       - "9092:9092"
     expose:
       - "9093"
-    depends_on:
-      - zookeeper
     environment:
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper-wiki:2181/kafka
-      KAFKA_BROKER_ID: 0
-      KAFKA_ADVERTISED_HOST_NAME: kafka-wiki
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9093,OUTSIDE://0.0.0.0:9092,CONTROLLER://0.0.0.0:29093
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka-wiki:9093,OUTSIDE://localhost:9092
-      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9093,OUTSIDE://0.0.0.0:9092
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,OUTSIDE:PLAINTEXT
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,OUTSIDE:PLAINTEXT
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka-wiki:29093
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      CLUSTER_ID: MkU3OEVBNTcwNTJENDM2Qk
   pinot-controller:
     image: apachepinot/pinot:latest
     command: "StartController -zkAddress zookeeper-wiki:2181 -dataDir /data"

--- a/tutorials/getting-started/streamlit.md
+++ b/tutorials/getting-started/streamlit.md
@@ -321,8 +321,8 @@ Let's check that the data has made its way into Kafka.
 The following command returns the message offset for each partition in the `wiki_events` topic:
 
 ```bash
-docker exec -it kafka-wiki kafka-run-class.sh kafka.tools.GetOffsetShell \
-  --broker-list localhost:9092 \
+docker exec -it kafka-wiki /opt/kafka/bin/kafka-get-offsets.sh \
+  --bootstrap-server localhost:9092 \
   --topic wiki_events
 ```
 


### PR DESCRIPTION
## Summary
- Replace all quickstart/tutorial Kafka Docker setups with `apache/kafka:4.0.0` using KRaft mode, removing the ZooKeeper dependency for Kafka
- Update docker images (`wurstmeister/kafka`, `bitnami/kafka:3.6` → `apache/kafka:4.0.0`), environment variables, `kafka-topics.sh` commands (`--zookeeper` → `--bootstrap-server`), and Kubernetes Helm chart flags
- Fix `bitnami/kafka` binary path (`/opt/bitnami/kafka/bin/` → `/opt/kafka/bin/`) in github-events-stream tutorial

### Files changed (9)
- `basics/getting-started/install/docker.md` — env var, docker-compose, docker run
- `basics/getting-started/first-stream-ingest.md` — docker run, kafka-topics.sh
- `build-with-pinot/ingestion/stream-ingestion/import-from-apache-kafka.md` — docker pull, docker run, launcher scripts
- `tutorials/getting-started/dash.md` — docker-compose Kafka service
- `tutorials/getting-started/streamlit.md` — docker-compose Kafka service
- `basics/components/table/README.md` — docker run, kafka-topics.sh
- `operate-pinot/advanced-pinot-setup.md` — docker run, kafka-topics.sh
- `basics/getting-started/kubernetes/stream-ingestion.md` — helm install (KRaft mode, removed ZK flags)
- `tutorials/getting-started/github-events-stream.md` — fixed bitnami bin path

## Test plan
- [ ] Verify `docker compose up` with the updated `docker.md` compose file starts Kafka in KRaft mode
- [ ] Verify `docker run` commands start Kafka 4.0 without ZooKeeper
- [ ] Verify `kafka-topics.sh --bootstrap-server` commands create topics successfully
- [ ] Verify Kubernetes helm install deploys Kafka in KRaft mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)