### PR TITLE
docs: document duplicate key detection in config files (apache/pinot#15648)

### DIFF
--- a/basics/components/cluster/minion.md
+++ b/basics/components/cluster/minion.md
@@ -52,6 +52,18 @@ bin/pinot-admin.sh StartMinion \
 The Pinot task generator interface defines the APIs for the controller to generate tasks for minions to execute.
 
 ```java
+
+{% hint style="warning" %}
+**Duplicate Keys in Configuration File**
+
+Starting from Apache Pinot 1.3.0, duplicate keys in the minion configuration file will cause a `ConfigurationException` to be thrown during startup. Previously, duplicate keys would be silently merged into a list. If you encounter this error, ensure that each configuration property appears only once in your configuration file. The exception will include the exact file path, duplicate key name, and the line numbers where the duplicates were found.
+
+Example error:
+```
+ConfigurationException: Duplicate key found in /path/to/minion.conf at line 10 and line 15: pinot.minion.task.allow.download.from.server
+```
+{% endhint %}
+
 public interface PinotTaskGenerator {
 
   /**

--- a/reference/configuration-reference/broker.md
+++ b/reference/configuration-reference/broker.md
@@ -6,6 +6,18 @@ You can set broker properties in a configuration file. The file can be provided 
 bin/pinot-admin.sh StartBroker -configFileName /path/to/broker.conf
 ```
 
+
+{% hint style="warning" %}
+**Duplicate Keys in Configuration File**
+
+Starting from Apache Pinot 1.3.0, duplicate keys in the configuration file will cause a `ConfigurationException` to be thrown during startup. Previously, duplicate keys would be silently merged into a list. If you encounter this error, ensure that each configuration property appears only once in your configuration file. The exception will include the exact file path, duplicate key name, and the line numbers where the duplicates were found.
+
+Example error:
+```
+ConfigurationException: Duplicate key found in /path/to/broker.conf at line 10 and line 15: pinot.broker.timeoutMs
+```
+{% endhint %}
+
 `broker.conf` can have the following properties. All properties are defined in this class.
 
 | Property                                                        | Default                                                               | Description                                                                                                                                                                                                                                                                                            |

--- a/reference/configuration-reference/controller.md
+++ b/reference/configuration-reference/controller.md
@@ -8,6 +8,18 @@ bin/pinot-admin.sh StartController -configFileName /path/to/controller.conf
 
 `Controller.conf` can have the following properties.
 
+{% hint style="warning" %}
+**Duplicate Keys in Configuration File**
+
+Starting from Apache Pinot 1.3.0, duplicate keys in the configuration file will cause a `ConfigurationException` to be thrown during startup. Previously, duplicate keys would be silently merged into a list. If you encounter this error, ensure that each configuration property appears only once in your configuration file. The exception will include the exact file path, duplicate key name, and the line numbers where the duplicates were found.
+
+Example error:
+```
+ConfigurationException: Duplicate key found in /path/to/controller.conf at line 10 and line 15: controller.port
+```
+{% endhint %}
+
+
 ## Primary configuration
 
 | Property                                                     | Default                                                                  | Description                                                                                                                                                                                                                                                 |

--- a/reference/configuration-reference/server.md
+++ b/reference/configuration-reference/server.md
@@ -6,6 +6,18 @@ Server configuration can be provided as part of the server startup parameters.
 bin/pinot-admin.sh StartServer -configFileName /path/to/server.conf
 ```
 
+
+{% hint style="warning" %}
+**Duplicate Keys in Configuration File**
+
+Starting from Apache Pinot 1.3.0, duplicate keys in the configuration file will cause a `ConfigurationException` to be thrown during startup. Previously, duplicate keys would be silently merged into a list. If you encounter this error, ensure that each configuration property appears only once in your configuration file. The exception will include the exact file path, duplicate key name, and the line numbers where the duplicates were found.
+
+Example error:
+```
+ConfigurationException: Duplicate key found in /path/to/server.conf at line 10 and line 15: pinot.server.netty.port
+```
+{% endhint %}
+
 `server.conf` can have the following properties
 
 | Property                                                                  | Default                                                                                                                              | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |


### PR DESCRIPTION
Documents the new duplicate key detection behavior in config files from apache/pinot#15648.

## Summary
Added warning notes to the configuration reference documentation for controller, broker, server, and minion components.

When duplicate keys are found in configuration files, a `ConfigurationException` is now thrown during startup, instead of silently merging them into a list. The exception includes the exact file path, duplicate key name, and the line numbers where the duplicates were found.

## Files Changed
- `reference/configuration-reference/controller.md`: Added duplicate key detection warning
- `reference/configuration-reference/broker.md`: Added duplicate key detection warning  
- `reference/configuration-reference/server.md`: Added duplicate key detection warning
- `basics/components/cluster/minion.md`: Added duplicate key detection warning