### PR TITLE
docs: add WITHIN GROUP clause to LISTAGG documentation

### DIFF
--- a/functions/aggregation/listagg.md
+++ b/functions/aggregation/listagg.md
@@ -14,9 +14,25 @@ Aggregates string values from rows into a single delimited string. An optional d
 >
 > LISTAGG(DISTINCT colName, delimiter)
 
+### WITHIN GROUP clause
+
+Use the `WITHIN GROUP (ORDER BY ...)` clause to control the order of values in the concatenated result. Without this clause the order of values is undefined.
+
+> LISTAGG(colName, delimiter) WITHIN GROUP (ORDER BY sortCol)
+>
+> LISTAGG(DISTINCT colName, delimiter) WITHIN GROUP (ORDER BY sortCol)
+
+{% hint style="info" %}
+The `WITHIN GROUP` clause requires the **multi-stage query engine** (v2). It was introduced in Apache Pinot 1.2.0 ([#13146](https://github.com/apache/pinot/pull/13146)).
+
+Only a single `WITHIN GROUP` clause is supported per query.
+{% endhint %}
+
 ## Usage Examples
 
 These examples are based on the [Batch Quick Start](../../basics/getting-started/quick-start.md#batch).
+
+**Basic aggregation**
 
 ```sql
 select LISTAGG(league, '/') AS value
@@ -28,6 +44,8 @@ WHERE playerName = 'Barry Bonds'
 | ----------------------------------- |
 | NL/NL/NL/NL/NL/NL/NL/NL/NL/NL/... |
 
+**Distinct values**
+
 ```sql
 select LISTAGG(DISTINCT league, ', ') AS value
 from baseballStats
@@ -37,3 +55,32 @@ WHERE playerName = 'Barry Bonds'
 | value  |
 | ------ |
 | NL, AL |
+
+**Ordered aggregation with WITHIN GROUP**
+
+Concatenate carriers in alphabetical order for each origin–destination pair:
+
+```sql
+SELECT Origin, Dest,
+  LISTAGG(DISTINCT Carrier, ', ') WITHIN GROUP (ORDER BY Carrier) AS carriers
+FROM airlineStats
+GROUP BY Origin, Dest
+```
+
+| Origin | Dest | carriers      |
+| ------ | ---- | ------------- |
+| SFO    | LAX  | AA, DL, UA, … |
+| JFK    | BOS  | B6, DL, …     |
+
+**Ordered aggregation with GROUP BY**
+
+```sql
+SELECT teamID,
+  LISTAGG(playerName, ' | ') WITHIN GROUP (ORDER BY playerName) AS players
+FROM baseballStats
+GROUP BY teamID
+```
+
+| teamID | players                              |
+| ------ | ------------------------------------ |
+| PIT    | Barry Bonds \| Bobby Bonilla \| …    |


### PR DESCRIPTION
## Summary
- Expand the LISTAGG function reference to cover the `WITHIN GROUP (ORDER BY ...)` clause introduced in Pinot 1.2.0 ([apache/pinot#13146](https://github.com/apache/pinot/pull/13146))
- Add syntax signatures for ordered aggregation (with and without `DISTINCT`)
- Add info hint noting multi-stage engine (v2) requirement and single-clause-per-query limitation
- Add two new usage examples demonstrating `WITHIN GROUP` with `GROUP BY`

## Cross-checked against `apache/pinot` source
- `ListAggFunction` / `ListAggDistinctFunction` in pinot-core
- `PinotAggregateExchangeNodeInsertRule` (single collation TODO comment)
- `AggregationFunctionFactory` LISTAGG case (2-3 arg signatures)
- Integration tests in `ArrayTest` confirming ordering behavior

## Validation
- `git diff --check` clean
- Internal links resolve (Batch Quick Start link, PR link)
- Navigation unchanged — page already linked from aggregation README

## Test plan
- [ ] Verify page renders correctly on GitBook preview
- [ ] Confirm internal links resolve