### PR TITLE
docs: close user-facing gaps from Pinot PR audit

### DIFF
--- a/build-with-pinot/indexing/forward-index.md
+++ b/build-with-pinot/indexing/forward-index.md
@@ -167,6 +167,18 @@ There are additional special-purpose compression codecs available for specific u
 
 `targetMaxChunkSize` changes the target max chunk size. For `rawIndexWriterVersion` versions 2 and 3, this can only be used with deriveNumDocsPerChunk. For `rawIndexWriterVersion` version 4, this sets the upper bound for a dynamically calculated chunk size. Documents larger than the `targetMaxChunkSize` will be given their own 'huge' chunk, therefore, it is recommended to size this such that huge chunks are avoided.
 
+#### Cluster and instance defaults
+
+If you want operator-managed defaults for raw forward indexes, Pinot can read the following properties from local instance config or ZK cluster config:
+
+| Property | Applies to |
+| --- | --- |
+| `pinot.forward.index.default.raw.index.writer.version` | `rawIndexWriterVersion` |
+| `pinot.forward.index.default.target.max.chunk.size` | `targetMaxChunkSize` |
+| `pinot.forward.index.default.target.docs.per.chunk` | `targetDocsPerChunk` |
+
+These defaults are only used when the corresponding property is not explicitly set in the table config.
+
 #### Raw forward index configuration
 
 The recommended way to configure the forward index using raw format is by including the parameters explained above in the `indexes.forward` object. For example:

--- a/build-with-pinot/indexing/json-index.md
+++ b/build-with-pinot/indexing/json-index.md
@@ -68,7 +68,10 @@ To enable the JSON index, you can configure the following options in the table c
 | **excludeFields** | Exclude the given fields, e.g. "*b*", "*c*", even if it is under the included paths. | Set<String> | null (include all fields) |
 | **indexPaths** | Index the given paths, e.g. `*.*`, `a.**`. Paths matches the indexed paths will be indexed, e.g. `a.**` will index everything whose first layer is "a", `*.*` will index everything with maxLevels=2. This config could work together with other configs, e.g. includePaths, excludePaths, maxLevels but usually does not have to because it should be flexible enough to catch any scenarios. | Set<String> | null that is equivalent to `**` (include all fields) |
 | **maxValueLength** | If the value of a json node (not the whole document) is longer than given value then replace it with `$SKIPPED$` before indexing. | int | 0 (disabled) |
+| **maxBytesSize** | Approximate on-heap byte budget for the mutable JSON index used during real-time ingestion. Pinot stops growing the mutable JSON index once the tracked size reaches this limit. This excludes posting lists, so use it as a practical guardrail rather than an exact cap. | long | null (no limit) |
 | **skipInvalidJson** | If set, while adding json to index, instead of throwing exception, replace ill-formed json with empty key/path and $SKIPPED$ value . | boolean | false (disabled) |
+
+`maxBytesSize` is most useful for real-time tables that ingest large or highly variable JSON documents. It helps bound heap growth in the mutable JSON index and can reduce the risk of building unexpectedly large segments.
 
 ### Recommended way to configure
 
@@ -85,6 +88,7 @@ The recommended way to configure a JSON index is in the `fieldConfigList.indexes
           "maxLevels": 2,
           "excludeArray": false,
           "disableCrossArrayUnnest": true,
+          "maxBytesSize": 134217728,
           "includePaths": null,
           "excludePaths": null,
           "excludeFields": null,

--- a/build-with-pinot/ingestion/stream-ingestion/clp.md
+++ b/build-with-pinot/ingestion/stream-ingestion/clp.md
@@ -70,7 +70,8 @@ Assuming the user wants to encode `message` and `logPath` as in the example, the
   "tableIndexConfig": {
     "streamConfigs": {
       "stream.kafka.decoder.class.name": "org.apache.pinot.plugin.inputformat.clplog.CLPLogMessageDecoder",
-      "stream.kafka.decoder.prop.fieldsForClpEncoding": "message,logPath"
+      "stream.kafka.decoder.prop.fieldsForClpEncoding": "message,logPath",
+      "stream.kafka.decoder.prop.removeProcessedFields": "true"
     },
     "varLengthDictionaryColumns": [
       "message_logtype",
@@ -83,6 +84,7 @@ Assuming the user wants to encode `message` and `logPath` as in the example, the
 ```
 
 * `stream.kafka.decoder.prop.fieldsForClpEncoding` is a comma-separated list of names for fields that should be encoded with CLP.
+* `stream.kafka.decoder.prop.removeProcessedFields` is optional. When set to `true`, Pinot removes the original input field after writing the derived CLP columns (`<field>_logtype`, `<field>_dictionaryVars`, `<field>_encodedVars`). The default is `false`, which keeps the original field alongside the derived columns.
 * We use [variable-length dictionaries](../../../reference/configuration-reference/table.md#table-index-config) for the logtype and dictionary variables since their length can vary significantly.
 
 ### Schema

--- a/reference/api-reference/controller-api.md
+++ b/reference/api-reference/controller-api.md
@@ -422,6 +422,42 @@ curl -X POST "http://localhost:9000/applicationQuotas/myApp" \
   -H "accept: application/json"
 ```
 
+## Segments
+
+### GET /segments/\{tableName\}/invalidPartitionMetadata
+
+Return a map of segment name to raw partition metadata JSON for segments whose partition metadata is invalid.
+
+Use this endpoint when you need to find segments whose stored partition metadata cannot be trusted for partition-based routing or validation.
+
+**Request**
+
+```bash
+curl -X GET "http://localhost:9000/segments/myTable/invalidPartitionMetadata?type=OFFLINE" \
+  -H "accept: application/json"
+```
+
+You can optionally scope the validation to a single partition column:
+
+```bash
+curl -X GET "http://localhost:9000/segments/myTable/invalidPartitionMetadata?type=OFFLINE&partitionColumn=memberId" \
+  -H "accept: application/json"
+```
+
+**Behavior**
+
+* Without `partitionColumn`, Pinot treats `null` partition metadata as valid and returns segments whose metadata is malformed or where any column maps to more than one partition.
+* With `partitionColumn`, Pinot validates only that column and treats `null` metadata, malformed metadata, missing column metadata, or multiple partitions for the column as invalid.
+
+**Response**
+
+```json
+{
+  "seg2": "{\"columnPartitionMap\":{\"memberId\":{\"functionName\":\"Modulo\",\"numPartitions\":4,\"partitions\":[0,1]}}}",
+  "seg3": "not-valid-json"
+}
+```
+
 
 ### DELETE /tables/\<tableName>
 


### PR DESCRIPTION
## Summary

This PR closes a small set of high-confidence documentation gaps found while auditing merged PRs in `apache/pinot` over the last two years.

Included fixes:
- document `stream.kafka.decoder.prop.removeProcessedFields` for CLP stream ingestion
- document `maxBytesSize` for the JSON index
- document operator-managed raw forward-index defaults
- document `GET /segments/{tableName}/invalidPartitionMetadata` in the controller API reference

## Audit methodology

Time window audited: `2024-04-04` through `2026-04-04`

What I did:
- enumerated every merged PR in `apache/pinot` in that window month-by-month via GitHub GraphQL to avoid search truncation
- expanded changed-file inventories for all `3673` merged PRs
- coarsely classified the inventory across SQL/query, config, ingestion, API/admin, plugin, ops, refactor, test, CI/build, and dependency-only buckets
- reduced to a `125` PR high-confidence review set using release-note and explicit feature signals
- only included items where code/tests showed a clear user-facing surface and the docs tree had missing or release-note-only coverage

## Files updated

- `build-with-pinot/ingestion/stream-ingestion/clp.md`
- `build-with-pinot/indexing/json-index.md`
- `build-with-pinot/indexing/forward-index.md`
- `reference/api-reference/controller-api.md`

## Follow-up / exclusions

Not included in this PR:
- internal-only refactors, test scaffolding, CI/build changes, and dependency bumps
- items already documented in the main docs tree under different terminology
- ambiguous changes where the user-facing contract was not stable enough to document without speculation
- release-note items that did not justify broader user documentation after source and docs review
