### PR TITLE
docs: cover audited ingestion and resource-utilization gaps

### DIFF
--- a/build-with-pinot/ingestion/stream-ingestion/README.md
+++ b/build-with-pinot/ingestion/stream-ingestion/README.md
@@ -136,9 +136,9 @@ For our sample data and schema, the table config will look like this:
 }
 ```
 
-### Example `ingestionConfig` for multi-topics ingestion
+### Example `ingestionConfig` with multiple stream configs
 
-From [this PR](https://github.com/apache/pinot/pull/13790), Pinot starts to support ingesting data from multiple stream partitions. (It is currently in Beta mode, and only supports multiple Kafka topics. Other stream types would be supported in the near future.) For our sample data and schema, assume that we duplicate it to 2 topics, `transcript-topic1` and `transcript-topic2`. If we want to ingest from both topics, then the table config will look like this:
+Pinot allows `streamConfigMaps` to contain more than one stream config. For the example below, assume the sample data is duplicated to two Kafka topics, `transcript-topic1` and `transcript-topic2`, and the table should ingest from both topics:
 
 ```json
 {
@@ -200,14 +200,28 @@ From [this PR](https://github.com/apache/pinot/pull/13790), Pinot starts to supp
 }
 ```
 
-With multi-topics ingestion: (details please refer to the [design doc](https://docs.google.com/document/d/1Er2Tmtl5Pgwdapn5iOJ5qlCDU_2P67YMdpdsmL36MCk/edit?usp=sharing))
+When `streamConfigMaps` contains multiple entries, Pinot validates the combined configuration before allowing the table to be created or updated:
 
-* All transform functions would apply to both topics' ingestions.
-* Existing instance assignment strategy would all work as usual.
-* [Partition changes](../../../build-with-pinot/ingestion/stream-ingestion#handle-partition-changes-in-streams) would still be handled in the same way.
-* Underlying ingestion still works as `LOWLEVEL` mode, where
-  * `transcript-topic1` segments would be named like transcript\_\_0\_\_0\_\_20250101T0000Z
-  * `transcript-topic2` segments would be named like transcript\_\_10000\_\_0\_\_20250101T0000Z
+* Each entry must still be a valid stream config on its own.
+* All entries must use the same `streamType`.
+* Segment flush settings must match across all entries:
+  * `realtime.segment.flush.threshold.rows`
+  * `realtime.segment.flush.threshold.time`
+  * `realtime.segment.flush.threshold.variance.fraction`
+  * `realtime.segment.flush.threshold.segment.size`
+  * `realtime.segment.flush.threshold.segment.rows`
+* Topic names must be unique across the entries.
+* Multiple stream configs are not supported together with `pauselessConsumptionEnabled=true`.
+* Multiple stream configs are not supported for upsert tables.
+
+Once validated, Pinot applies the rest of the ingestion config normally:
+
+* Transform functions apply to records from every configured stream.
+* Existing instance-assignment strategies continue to work as usual.
+* [Partition changes](../../../build-with-pinot/ingestion/stream-ingestion#handle-partition-changes-in-streams) are handled the same way as for a single stream config.
+* Underlying ingestion still works in `LOWLEVEL` mode, where:
+  * `transcript-topic1` segments are named like `transcript__0__0__20250101T0000Z`
+  * `transcript-topic2` segments are named like `transcript__10000__0__20250101T0000Z`
 
 ## Upload schema and table config
 
@@ -451,9 +465,9 @@ $ curl -X POST {controllerHost}/tables/{tableName}/resumeConsumption?resumeFrom=
 
 ## Handle partition changes in streams
 
-If a Pinot table is configured to consume using a [Low Level](../../../build-with-pinot/ingestion/stream-ingestion#create-table-configuration) (partition-based) stream type, then it is possible that the partitions of the table change over time. In Kafka, for example, the number of partitions may increase. In Kinesis, the number of partitions may increase _or_ decrease -- some partitions could be merged to create a new one, or existing partitions split to create new ones.
+If a Pinot table is configured to consume using a [Low Level](../../../build-with-pinot/ingestion/stream-ingestion/README.md#create-table-configuration-with-ingestion-configuration) (partition-based) stream type, then it is possible that the partitions of the table change over time. In Kafka, for example, the number of partitions may increase. In Kinesis, the number of partitions may increase _or_ decrease -- some partitions could be merged to create a new one, or existing partitions split to create new ones.
 
-Pinot runs a periodic task called `RealtimeSegmentValidationManager` that monitors such changes and starts consumption on new partitions (or stops consumptions from old ones) as necessary. Since this is a [periodic task](../../../basics/components/cluster/controller.md#controller-periodic-tasks) that is run on the controller, it may take some time for Pinot to recognize new partitions and start consuming from them. This may delay the data in new partitions appearing in the results that pinot returns.
+Pinot runs a periodic task called `RealtimeSegmentValidationManager` that monitors such changes and starts consumption on new partitions (or stops consumptions from old ones) as necessary. Since this is a controller [periodic task](../../../basics/components/cluster/controller.md#running-the-periodic-task-manually), it may take some time for Pinot to recognize new partitions and start consuming from them. This may delay the data in new partitions appearing in the results that pinot returns.
 
 If you want to recognize the new partitions sooner, then [manually trigger](../../../basics/components/cluster/controller.md#running-the-periodic-task-manually) the periodic task so as to recognize such data immediately.
 

--- a/operate-pinot/pause-ingestion-based-on-resource-utilization.md
+++ b/operate-pinot/pause-ingestion-based-on-resource-utilization.md
@@ -1,43 +1,59 @@
 ---
-description: Pause and Un-pause Ingestion based on Resource Utilization
+description: Pause and resume ingestion based on resource utilization.
 ---
 
 # Pause ingestion based on resource utilization
 
-A new capability has been added to Pinot to pause and un-pause ingestion based on resource utilization. This feature is designed to help users manage their Pinot clusters more effectively by pausing ingestion when resource utilization exceeds a specified threshold. Ingestion is un-paused when resource utilization falls below the threshold.
+Pinot can pause real-time ingestion when disk utilization exceeds a configured threshold, and resume it when utilization returns within limits. The same resource-utilization status is also used to skip minion task generation for affected tables.
 
 ## How It Works
 
-The periodic task `ResourceUtilizationChecker` runs periodically and computes the disk usage info of the Pinot server instances. The periodic task `RealTimeSegmentValidationManager` utilizes the disk usage info captured by the `ResourceUtilizationChecker` task and pauses consumption on REALTIME tables if disk utilization is above the threshold. The `RealTimeSegmentValidationManager` task would un-pause ingestion when disk utilization falls below the threshold. The periodic task `PinotTaskManager` utilizes the disk usage info and prevents minion based task generation if disk utilization is above threshold. The `PinotTaskManager` task would allow minion based task generation when disk utilization falls below the threshold.
+The periodic task `ResourceUtilizationChecker` fetches disk-usage information from each Pinot server and stores it in the controller-side resource-utilization cache. Pinot then uses that cached status in two places:
+
+* `RealtimeSegmentValidationManager` pauses REALTIME tables when disk utilization is above the configured threshold.
+* `PinotTaskManager` skips minion task generation for tables whose servers are above the configured threshold.
+
+When the cached status returns to `PASS`, Pinot clears the resource-utilization pause state and allows ingestion to resume. If the status is `UNDETERMINED` and the table is already paused because of resource utilization, Pinot leaves it paused until fresh disk-usage data is available.
+
+## How disk usage is collected
+
+The controller calls the server endpoint `GET /instance/diskUtilization` on each server instance.
+
+In the current implementation, that endpoint always computes disk usage for the server's `instanceDataDir`. The controller still sends the configured `controller.disk.utilization.path` header, but the server endpoint ignores that header today.
 
 ## Configuration
 
-The following configurations are available to control this feature:
+The following controller configurations control this feature:
 
 | Config | Default Value | Description |
 | --- | --- | --- |
-| controller.resource.utilization.checker.frequency | 300 | Value is in seconds. The disk utilization is computed for all Pinot servers in this frequency. Setting the value to -1 would disable the disk usage computation. |
-| controller.disk.utilization.path | /home/pinot/data | Disk utilization is calculated for this path. |
-| controller.disk.utilization.threshold | 0.95 | Value should be between 0 and 1. |
-| controller.enable.resource.utilization.check | false | The feature is off by default. |
+| controller.enable.resource.utilization.check | false | Master switch for enforcing resource-utilization checks during real-time ingestion validation and minion task generation. |
+| controller.enable.all.resource.utilization.checkers | true | Registers all resource-utilization checkers for backward compatibility. |
+| controller.enable.disk.utilization.checker | false | Registers the disk-utilization checker when `controller.enable.all.resource.utilization.checkers` is `false`. |
+| controller.resource.utilization.checker.frequency | 300 | Checker frequency in seconds. Setting this value to `-1` disables the periodic checker task. |
+| controller.resource.utilization.checker.initial.delay | 300 | Initial delay in seconds before the checker runs. If `controller.resource.utilization.checker.collect.usage.at.startup=true`, Pinot forces this value to `0`. |
+| controller.resource.utilization.checker.collect.usage.at.startup | false | When enabled, the controller waits for the checker cache to be populated before reporting itself healthy. If the startup collection times out, the controller still becomes healthy (fail-open). |
+| controller.disk.utilization.threshold | 0.95 | Disk-usage threshold, expressed as a fraction between 0 and 1. |
+| controller.disk.utilization.check.timeoutMs | 30000 | Timeout in milliseconds for collecting disk-usage responses from servers. |
+| controller.disk.utilization.path | /home/pinot/data | Compatibility config sent by the controller when requesting disk usage. The current server endpoint ignores this value and always measures `instanceDataDir`. |
 
 ## Metrics
 
-The metric `pinot_controller_resourceUtilizationLimitExceeded_Value` would be set to `1` when disk utilization is above the threshold. The metric would be set to `0` when disk utilization is below the threshold.
+The gauge `pinot_controller_resourceUtilizationLimitExceeded_Value` is set to `1` when resource utilization is above the threshold for a table, and reset to `0` when the table is back within limits.
 
 ## FAQs
 
 ### Is controller restart required after changing any of the configuration properties?
 
-Yes, update the property to the desired value and restart the controller(s).
+Yes. Update the property to the desired value and restart the controller(s).
 
 ### Does ResourceUtilizationChecker run only on the lead controller?
 
-The periodic task `ResourceUtilizationChecker` runs on all controllers. The controller periodic tasks `RealtimeSegmentValidationManager` and `PinotTaskManager` runs only on the lead controller.
+The periodic task `ResourceUtilizationChecker` runs on all controllers. The controller periodic tasks `RealtimeSegmentValidationManager` and `PinotTaskManager` run only on the lead controller.
 
 ### How to identify the Pinot servers that are low on disk capacity?
 
-Grep for the keyword `Disk utilization for server` on any Pinot controller log to find the relevant servers.
+Search the controller logs for the message prefix `Disk utilization for server` to find the relevant instances.
 
 ## References
 

--- a/reference/configuration-reference/controller.md
+++ b/reference/configuration-reference/controller.md
@@ -211,11 +211,16 @@ This task periodically emits metrics about minion tasks, including task counts b
 
 ### ResourceUtilizationChecker
 
-The periodic task ResourceUtilizationChecker runs periodically and computes the disk usage info of the Pinot server instances.
+The periodic task `ResourceUtilizationChecker` runs periodically and fetches disk-usage information from Pinot server instances via `GET /instance/diskUtilization`.
 
 | Config | Default Value | Description |
 | --- | --- | --- |
-| controller.resource.utilization.checker.frequency | 300 | Value is in seconds. Setting the value to -1 would disable the task. |
-| controller.disk.utilization.path | /home/pinot/data | Disk utilization is calculated for this path. |
-| controller.resource.utilization.checker.initial.delay | 0 (when collect.usage.at.startup is true) | Initial delay for the resource utilization checker in seconds. Automatically set to 0 when controller.resource.utilization.checker.collect.usage.at.startup is enabled. |
+| controller.enable.resource.utilization.check | false | Master switch for enforcing resource-utilization checks during real-time ingestion validation and minion task generation. |
+| controller.enable.all.resource.utilization.checkers | true | Registers all resource-utilization checkers for backward compatibility. |
+| controller.enable.disk.utilization.checker | false | Registers the disk-utilization checker when `controller.enable.all.resource.utilization.checkers` is `false`. |
+| controller.resource.utilization.checker.frequency | 300 | Value is in seconds. Setting the value to `-1` disables the periodic checker task. |
+| controller.resource.utilization.checker.initial.delay | 300 (or 0 when collect.usage.at.startup is true) | Initial delay for the resource-utilization checker in seconds. Automatically set to 0 when `controller.resource.utilization.checker.collect.usage.at.startup` is enabled. |
 | controller.resource.utilization.checker.collect.usage.at.startup | false | When set to `true`, the controller waits for the resource utilization checker (disk usage cache) to be populated before marking itself as healthy. This prevents segment push requests from being accepted when disk usage is already high (e.g., 90%) immediately after a restart. When enabled, `controller.resource.utilization.checker.initial.delay` is automatically set to 0 so the checker runs immediately. If the checker times out, the controller still becomes healthy (fail-open). |
+| controller.disk.utilization.threshold | 0.95 | Disk-usage threshold expressed as a fraction between 0 and 1. |
+| controller.disk.utilization.check.timeoutMs | 30000 | Timeout in milliseconds for collecting disk-usage responses from servers. |
+| controller.disk.utilization.path | /home/pinot/data | Compatibility config sent by the controller when requesting disk usage. The current server endpoint ignores this value and always measures the server `instanceDataDir`. |

--- a/reference/configuration-reference/ingestion.md
+++ b/reference/configuration-reference/ingestion.md
@@ -46,7 +46,7 @@ Take the above example, if you set `realtime.segment.flush.threshold.segment.row
 {% endhint %}
 
 {% hint style="info" %}
-Since [this PR](https://github.com/apache/pinot/pull/13790), `streamConfigMaps` could contain multiple maps pointing to multiple Kafka topics. This would allow creating one single Pinot table with data from multiple stream topics.
+`streamConfigMaps` can contain more than one config map. When you configure multiple entries, Pinot requires all of them to use the same `streamType`, requires the segment-flush parameters to match across all entries, requires topic names to be unique, and rejects the configuration for upsert tables or when `pauselessConsumptionEnabled=true`.
 {% endhint %}
 
 ## `streamIngestionConfig`


### PR DESCRIPTION
## Summary
This is batch 3 of the Pinot documentation audit follow-up after #622 and #623.

It closes the remaining two high-confidence, user-facing doc gaps from the current audited backlog:
- `#13790` multiple stream-config constraints for real-time ingestion
- `#15008` pause/resume ingestion behavior based on resource utilization

## What changed
- Clarified the multi-stream ingestion guide and ingestion config reference to document the validator-enforced rules for multiple `streamConfigMaps` entries:
  - same `streamType`
  - consistent segment flush settings
  - unique topic names
  - not supported with `pauselessConsumptionEnabled=true`
  - not supported for upsert tables
- Updated the resource-utilization operations guide to reflect the actual controller/server flow:
  - disk usage is fetched from `GET /instance/diskUtilization`
  - the server currently measures `instanceDataDir`
  - the controller still sends `controller.disk.utilization.path`, but the server ignores that header today
  - ingestion resumes only after the cached status returns to `PASS`
  - if status is `UNDETERMINED` and the table is already paused for resource utilization, Pinot leaves it paused
- Expanded the controller config reference with the missing resource-utilization knobs and corrected defaults/behavior notes.

## Validation
Ran:

```bash
python3 scripts/validate-docs.py --changed-only=/tmp/pinot-docs-batch3-changed.txt
git diff --check
```

Both passed.
