### PR TITLE
docs: correct logical table API and UI coverage

### DIFF
--- a/basics/components/table/logical-table.md
+++ b/basics/components/table/logical-table.md
@@ -284,7 +284,7 @@ Storage quota (`quota.storage`) is not supported for logical tables since they d
 
 ## Managing Logical Tables via the Controller UI
 
-The Pinot Controller UI provides full CRUD management for logical tables, accessible directly from the main Tables page.
+The Pinot Controller UI provides browsing and in-place management for logical tables, accessible directly from the main Tables page.
 
 ### Accessing Logical Tables
 
@@ -305,7 +305,7 @@ The Pinot Controller UI provides full CRUD management for logical tables, access
 | **Delete** | Remove a logical table from the cluster |
 
 {% hint style="tip" %}
-All operations are also available via the REST API at `/logicalTables/{tableName}` using GET, PUT, and DELETE.
+Create logical tables with `POST /logicalTables`. Get, update, and delete are available at `/logicalTables/{tableName}` using GET, PUT, and DELETE.
 {% endhint %}
 
 ## Quick Start Example

--- a/reference/api-reference/controller-api.md
+++ b/reference/api-reference/controller-api.md
@@ -651,7 +651,7 @@ curl -X GET "http://localhost:9000/logicalTables" -H "accept: application/json"
 
 ### GET /logicalTables/\<tableName>
 
-Get the configuration of a specific logical table.
+Get the configuration of a specific logical table. The response body is the logical table config JSON.
 
 **Request**
 
@@ -664,19 +664,18 @@ curl -X GET "http://localhost:9000/logicalTables/logicalEvents" -H "accept: appl
 ```
 {
   "tableName": "logicalEvents",
-  "physicalTableNames": [
-    "events_REALTIME",
-    "events_2024_OFFLINE",
-    "events_2023_OFFLINE"
-  ],
+  "physicalTableConfigMap": {
+    "events_2024_OFFLINE": {},
+    "events_2023_OFFLINE": {}
+  },
   "brokerTenant": "DefaultTenant",
-  "logicalTableConfig": { ... }
+  "refOfflineTableName": "events_2024_OFFLINE"
 }
 ```
 
 ### POST /logicalTables
 
-Create a new logical table. The physical tables referenced must already exist. All physical tables must share a compatible schema.
+Create a new logical table. The request body is a logical table config. The physical tables referenced must already exist, and all physical tables must share a compatible schema.
 
 **Request**
 
@@ -685,11 +684,19 @@ curl -X POST "http://localhost:9000/logicalTables" \
   -H "Content-Type: application/json" \
   -d '{
     "tableName": "logicalEvents",
-    "physicalTableNames": [
-      "events_REALTIME",
-      "events_2024_OFFLINE"
-    ],
-    "brokerTenant": "DefaultTenant"
+    "physicalTableConfigMap": {
+      "events_REALTIME": {},
+      "events_2024_OFFLINE": {}
+    },
+    "brokerTenant": "DefaultTenant",
+    "refOfflineTableName": "events_2024_OFFLINE",
+    "refRealtimeTableName": "events_REALTIME",
+    "timeBoundaryConfig": {
+      "boundaryStrategy": "min",
+      "parameters": {
+        "includedTables": ["events_2024_OFFLINE"]
+      }
+    }
   }'
 ```
 
@@ -703,7 +710,7 @@ curl -X POST "http://localhost:9000/logicalTables" \
 
 ### PUT /logicalTables/\<tableName>
 
-Update an existing logical table, for example to add or remove physical tables.
+Update an existing logical table by sending the full logical table config, for example to add or remove physical tables.
 
 **Request**
 
@@ -712,12 +719,20 @@ curl -X PUT "http://localhost:9000/logicalTables/logicalEvents" \
   -H "Content-Type: application/json" \
   -d '{
     "tableName": "logicalEvents",
-    "physicalTableNames": [
-      "events_REALTIME",
-      "events_2024_OFFLINE",
-      "events_2023_OFFLINE"
-    ],
-    "brokerTenant": "DefaultTenant"
+    "physicalTableConfigMap": {
+      "events_REALTIME": {},
+      "events_2024_OFFLINE": {},
+      "events_2023_OFFLINE": {}
+    },
+    "brokerTenant": "DefaultTenant",
+    "refOfflineTableName": "events_2024_OFFLINE",
+    "refRealtimeTableName": "events_REALTIME",
+    "timeBoundaryConfig": {
+      "boundaryStrategy": "min",
+      "parameters": {
+        "includedTables": ["events_2024_OFFLINE"]
+      }
+    }
   }'
 ```
 


### PR DESCRIPTION
## Summary
- fix the logical table Controller API examples to use the actual `LogicalTableConfig` request/response shape
- correct the Controller UI docs so they match the current UI surface: list/view/update/delete in the UI, create via `POST /logicalTables`

## Why
This batch closes the next high-confidence, low-noise documentation gap from the Pinot audit:
- `reference/api-reference/controller-api.md` still documented `physicalTableNames` request bodies and a wrapped GET response, but the endpoint now accepts and returns the full logical table config
- `basics/components/table/logical-table.md` claimed full CRUD support in the Controller UI even though the UI currently exposes list/view/update/delete only

## Verification
- `python3 scripts/validate-docs.py --changed-only=/tmp/pinot-docs-batch8-changed.txt`
- `git diff --check`
