### PR TITLE
docs: document Spark connector write options

### DIFF
--- a/build-with-pinot/connectors-clients-apis/spark-pinot-connector/spark-pinot-connector-write-model.md
+++ b/build-with-pinot/connectors-clients-apis/spark-pinot-connector/spark-pinot-connector-write-model.md
@@ -4,7 +4,7 @@
 Caution: This feature is experimental and the API may change in future releases.
 {% endhint %}
 
-Spark Connector also has experimental support for writing Pinot segments from Spark DataFrames. Currently, only append mode is supported and the schema of the DataFrame should match the schema of the Pinot table.
+Spark Connector also has experimental support for writing Pinot segments from Spark DataFrames. The current implementation writes OFFLINE segment tar files to the destination path supplied via `.save(path)` (or the equivalent `path` option), and the schema of the DataFrame should match the schema of the Pinot table. The examples below use `append` mode.
 
 ```
 // create sample data
@@ -22,13 +22,39 @@ val airports = spark.createDataFrame(data)
 airports.write.format("pinot")
   .mode("append")
   .option("table", "airlineStats")
-  .option("tableType", "OFFLINE")
-  .option("segmentNameFormat", "{table}_{partitionId:03}")
+  .option("segmentNameFormat", "{table}_{startTime}_{endTime}_{partitionId:03}")
   .option("invertedIndexColumns", "airport")
   .option("noDictionaryColumns", "airport,state")
   .option("bloomFilterColumns", "airport")
+  .option("rangeIndexColumns", "distance")
   .option("timeColumnName", "ts")
+  .option("timeFormat", "EPOCH|SECONDS")
+  .option("timeGranularity", "1:SECONDS")
   .save("myPath")
 ```
 
-For more details, refer to the implementation at `org.apache.pinot.connector.spark.v3.datasource.PinotDataWriter`.
+`.save("myPath")` provides the required `path` option automatically. The writer reads the options below and uses them to build Pinot segment metadata and indexes before pushing `tar.gz` segment files to the target filesystem.
+
+### Connector Write Parameters
+
+| Configuration | Description | Required | Default Value |
+| ------------- | ----------- | -------- | ------------- |
+| `table` | Pinot table name used for generated segment metadata and schema translation. | Yes | - |
+| `path` | Destination directory for generated segment tar files. Calling `.save("...")` sets this option automatically. The current implementation pushes to local filesystems and HDFS. | Yes | - |
+| `segmentNameFormat` | Segment name template. Supports `{table}`, `{partitionId}`, `{startTime}`, and `{endTime}` placeholders, plus zero-padding such as `{partitionId:03}`. `startTime` and `endTime` are populated from the minimum and maximum values of a numeric `timeColumnName`. | No | `<tableName>-{partitionId:03}` |
+| `invertedIndexColumns` | Comma-separated list of columns that should use Pinot inverted indexes in generated segments. | No | Empty |
+| `noDictionaryColumns` | Comma-separated list of columns that should disable dictionary encoding in generated segments. | No | Empty |
+| `bloomFilterColumns` | Comma-separated list of columns that should use Pinot bloom filters in generated segments. | No | Empty |
+| `rangeIndexColumns` | Comma-separated list of columns that should use Pinot range indexes in generated segments. | No | Empty |
+| `timeColumnName` | Pinot time column name to emit in the generated schema and segment metadata. When set, `timeFormat` and `timeGranularity` must also be set. | No | None |
+| `timeFormat` | Pinot date-time format for `timeColumnName`, for example `EPOCH|SECONDS`. | Conditionally required | None |
+| `timeGranularity` | Pinot granularity for `timeColumnName`, for example `1:SECONDS`. | Conditionally required | None |
+
+### Validation And Behavior Notes
+
+* `table` and `path` are required. The writer rejects requests that omit either option.
+* `segmentNameFormat` cannot be an empty string.
+* If `timeColumnName` is set, both `timeFormat` and `timeGranularity` must also be set.
+* `tableType` is not part of the current write option contract. The writer builds OFFLINE segments regardless of any `tableType` option passed to Spark.
+
+For more details, refer to the implementation at `org.apache.pinot.connector.spark.v3.datasource.PinotDataWriter` and `org.apache.pinot.connector.spark.common.PinotDataSourceWriteOptions`.


### PR DESCRIPTION
## Summary
This is batch 12 of the Pinot merged-PR documentation audit.

It closes the next compact, high-confidence docs gap in the Spark connector write path:
- document the actual Spark write option contract instead of leaving the page as a minimal example stub
- add the missing `path`, `rangeIndexColumns`, `timeFormat`, and `timeGranularity` coverage
- clarify current write behavior around `segmentNameFormat` and OFFLINE segment generation

## Audit basis
Time window: merged PRs in `apache/pinot` from 2024-04-04 through 2026-04-04.

Included source PRs and evidence:
- `#13748` added Spark connector write support for creating Pinot segments
- current `PinotDataSourceWriteOptions`, `PinotWrite`, and `PinotDataWriter` were re-checked before writing docs so the option list, defaults, and behavior notes match present behavior

## Changes made
- expanded the Spark write-model page from a single example into a parameter table with required/defaulted options
- documented `path`, `segmentNameFormat`, `rangeIndexColumns`, `timeColumnName`, `timeFormat`, and `timeGranularity`
- clarified that `.save(path)` satisfies the required `path` option
- clarified that the current writer builds OFFLINE segments and does not consume `tableType` as a write option

## Validation
- `python3 scripts/validate-docs.py --changed-only=/tmp/pinot-docs-batch12-changed.txt`
- `git diff --check`
