### PR TITLE
docs: document broker gRPC client transport options

### DIFF
--- a/build-with-pinot/connectors-clients-apis/clients/java.md
+++ b/build-with-pinot/connectors-clients-apis/clients/java.md
@@ -93,6 +93,49 @@ Connection connection = ConnectionFactory.fromHostList
   ("broker-1:1234", "broker-2:1234", ...);
 ```
 
+## gRPC Connections
+
+The Java client also exposes gRPC broker connections via `ConnectionFactory.fromControllerGrpc(...)`, `fromZookeeperGrpc(...)`, and `fromHostListGrpc(...)`.
+
+```java
+Properties properties = new Properties();
+properties.setProperty("usePlainText", "false");
+properties.setProperty("maxInboundMessageSizeBytes", "134217728");
+properties.setProperty("channelKeepAliveTimeSeconds", "60");
+properties.setProperty("channelKeepAliveTimeoutSeconds", "20");
+properties.setProperty("channelKeepAliveWithoutCalls", "true");
+properties.setProperty("channelShutdownTimeoutSeconds", "10");
+properties.setProperty("tls.truststore.path", "/path/to/grpc-truststore.jks");
+properties.setProperty("tls.truststore.password", "changeit");
+
+GrpcConnection connection = ConnectionFactory.fromControllerGrpc(properties, "localhost:9000");
+ResultSetGroup resultSetGroup = connection.execute(
+    "SELECT COUNT(*) FROM myTable",
+    Map.of("blockRowSize", "10000", "encoding", "JSON", "compression", "ZSTD"));
+```
+
+The gRPC transport properties below are read directly from the connection `Properties` through `GrpcConfig`. TLS settings use the `tls.*` namespace, not `pinot.*.tls.*`.
+
+| Property | Default | Notes |
+| --- | --- | --- |
+| `usePlainText` | `true` | Use plaintext gRPC transport. Set to `false` to enable TLS. |
+| `maxInboundMessageSizeBytes` | `134217728` (128 MB) | Maximum inbound gRPC message size accepted by the client. |
+| `channelKeepAliveTimeSeconds` | `-1` (disabled) | Keepalive ping interval. Set a positive value to enable keepalive. |
+| `channelKeepAliveTimeoutSeconds` | `20` | Timeout waiting for keepalive acknowledgements. |
+| `channelKeepAliveWithoutCalls` | `true` | Allows keepalive pings even without active RPCs. |
+| `channelShutdownTimeoutSeconds` | `10` | How long the client waits for the gRPC channel to terminate on close. |
+| `tls.keystore.type` | JVM default keystore type (`KeyStore.getDefaultType()`) | Client keystore type for mutual TLS. |
+| `tls.keystore.path` | None | Client keystore path for mutual TLS. |
+| `tls.keystore.password` | None | Client keystore password. |
+| `tls.truststore.type` | JVM default keystore type (`KeyStore.getDefaultType()`) | Truststore type used to validate the broker certificate. |
+| `tls.truststore.path` | None | Truststore path used to validate the broker certificate. |
+| `tls.truststore.password` | None | Truststore password. |
+| `tls.ssl.provider` | `JDK` | SSL provider used when building the gRPC client SSL context. |
+| `tls.insecure` | `false` | Skip broker certificate verification. Only appropriate for non-production testing. |
+| `tls.protocols` | JVM TLS defaults | Comma-separated TLS protocol allowlist such as `TLSv1.2,TLSv1.3`. |
+
+For default metadata such as auth headers, use the `headers.<name>` property prefix. Query-specific gRPC metadata such as `blockRowSize`, `compression`, and `encoding` should be passed in the metadata map for `execute(..., metadataMap)` or `executeGrpc(..., metadataMap)`.
+
 ## Query Methods
 
 You can run the query in both blocking as well as async manner. Use

--- a/build-with-pinot/connectors-clients-apis/clients/jdbc.md
+++ b/build-with-pinot/connectors-clients-apis/clients/jdbc.md
@@ -67,6 +67,43 @@ while(rs.next()){
 conn.close();
 ```
 
+## gRPC Connections
+
+To use the broker gRPC transport from JDBC, switch the scheme from `jdbc:pinot://` to `jdbc:pinotgrpc://`.
+
+```java
+Properties connectionProperties = new Properties();
+connectionProperties.setProperty("usePlainText", "false");
+connectionProperties.setProperty("tls.truststore.path", "/path/to/grpc-truststore.jks");
+connectionProperties.setProperty("tls.truststore.password", "changeit");
+
+Connection conn = DriverManager.getConnection(
+    "jdbc:pinotgrpc://localhost:9000?blockRowSize=10000&encoding=JSON&compression=ZSTD",
+    connectionProperties);
+```
+
+The `pinotgrpc` driver accepts the following gRPC transport properties through either the JDBC URL query string or the `Properties` object passed to `DriverManager.getConnection(...)`. TLS settings use the `tls.*` namespace, not broker-side keys such as `pinot.broker.tls.*`.
+
+| Property | Default | Notes |
+| --- | --- | --- |
+| `usePlainText` | `true` | Use plaintext gRPC transport. Set to `false` to enable TLS. |
+| `maxInboundMessageSizeBytes` | `134217728` (128 MB) | Maximum inbound gRPC message size accepted by the client. |
+| `channelKeepAliveTimeSeconds` | `-1` (disabled) | Keepalive ping interval. Set a positive value to enable keepalive. |
+| `channelKeepAliveTimeoutSeconds` | `20` | Timeout waiting for keepalive acknowledgements. |
+| `channelKeepAliveWithoutCalls` | `true` | Allows keepalive pings even without active RPCs. |
+| `channelShutdownTimeoutSeconds` | `10` | How long the client waits for the gRPC channel to terminate on close. |
+| `tls.keystore.type` | JVM default keystore type (`KeyStore.getDefaultType()`) | Client keystore type for mutual TLS. |
+| `tls.keystore.path` | None | Client keystore path for mutual TLS. |
+| `tls.keystore.password` | None | Client keystore password. |
+| `tls.truststore.type` | JVM default keystore type (`KeyStore.getDefaultType()`) | Truststore type used to validate the broker certificate. |
+| `tls.truststore.path` | None | Truststore path used to validate the broker certificate. |
+| `tls.truststore.password` | None | Truststore password. |
+| `tls.ssl.provider` | `JDK` | SSL provider used when building the gRPC client SSL context. |
+| `tls.insecure` | `false` | Skip broker certificate verification. Only appropriate for non-production testing. |
+| `tls.protocols` | JVM TLS defaults | Comma-separated TLS protocol allowlist such as `TLSv1.2,TLSv1.3`. |
+
+The JDBC gRPC path also accepts request metadata options such as `blockRowSize`, `encoding`, `compression`, and `headers.<name>` through URL parameters or connection properties and forwards them to each gRPC request.
+
 ## Authentication
 
 Pinot supports [basic HTTP authorization](../../../operate-pinot/authentication/basic-auth-access-control.md), which can be enabled for your cluster using configuration. To support basic HTTP authorization in your client-side JDBC applications, make sure you are using Pinot JDBC 0.10.0 or later. The following code snippet shows you how to connect to and query a Pinot cluster that has basic HTTP authorization enabled when using the JDBC client.

--- a/reference/api-reference/broker-grpc-api.md
+++ b/reference/api-reference/broker-grpc-api.md
@@ -18,23 +18,62 @@ If you expose the secure broker gRPC listener, the current broker startup path r
 
 ## Client Options
 
+The Java gRPC client and the JDBC `pinotgrpc` driver both use `GrpcConfig` for connection transport settings. That means the same transport property names work in Java `Properties` and JDBC URL query parameters.
+
+### Request Metadata Options
+
 | Option | Default | Notes |
 | --- | --- | --- |
 | `blockRowSize` | `10000` | Rows per response block |
 | `compression` | `ZSTD` | Wire compression choice |
 | `encoding` | `JSON` | Result transport encoding; `ARROW` is also supported |
+| `headers.<name>` | None | Adds request metadata headers such as `headers.Authorization` |
+
+### Transport Properties
+
+| Property | Default | Notes |
+| --- | --- | --- |
+| `usePlainText` | `true` | Use plaintext gRPC transport. Set to `false` to enable TLS. |
+| `maxInboundMessageSizeBytes` | `134217728` (128 MB) | Maximum inbound gRPC message size accepted by the client. |
+| `channelKeepAliveTimeSeconds` | `-1` (disabled) | Keepalive ping interval. Set a positive value to enable keepalive. |
+| `channelKeepAliveTimeoutSeconds` | `20` | Timeout waiting for keepalive acknowledgements. |
+| `channelKeepAliveWithoutCalls` | `true` | Allows keepalive pings even when no RPC is active. |
+| `channelShutdownTimeoutSeconds` | `10` | How long the client waits for the gRPC channel to terminate on close. |
+| `tls.keystore.type` | JVM default keystore type (`KeyStore.getDefaultType()`) | Client keystore type for mutual TLS. |
+| `tls.keystore.path` | None | Client keystore path for mutual TLS. |
+| `tls.keystore.password` | None | Client keystore password. |
+| `tls.truststore.type` | JVM default keystore type (`KeyStore.getDefaultType()`) | Truststore type used to validate the broker certificate. |
+| `tls.truststore.path` | None | Truststore path used to validate the broker certificate. |
+| `tls.truststore.password` | None | Truststore password. |
+| `tls.ssl.provider` | `JDK` | SSL provider used when building the gRPC client SSL context. |
+| `tls.insecure` | `false` | Skip broker certificate verification. Only appropriate for non-production testing. |
+| `tls.protocols` | JVM TLS defaults | Comma-separated TLS protocol allowlist such as `TLSv1.2,TLSv1.3`. |
 
 ## Client Examples
 
 The gRPC Java and JDBC clients use the `pinotgrpc` scheme.
 
 ```java
+Properties properties = new Properties();
+properties.setProperty("usePlainText", "false");
+properties.setProperty("tls.truststore.path", "/path/to/grpc-truststore.jks");
+properties.setProperty("tls.truststore.password", "changeit");
+
 GrpcConnection grpcConnection = ConnectionFactory.fromControllerGrpc(properties, "localhost:9000");
-ResultSetGroup resultSetGroup = grpcConnection.execute("SELECT * FROM airlineStats limit 1000");
+ResultSetGroup resultSetGroup = grpcConnection.execute(
+    "SELECT * FROM airlineStats LIMIT 1000",
+    Map.of("blockRowSize", "10000", "encoding", "JSON", "compression", "ZSTD"));
 ```
 
 ```java
-try (Connection connection = DriverManager.getConnection("jdbc:pinotgrpc://localhost:9000?blockRowSize=10000&encoding=JSON&compression=ZSTD")) {
+Properties properties = new Properties();
+properties.setProperty("usePlainText", "false");
+properties.setProperty("tls.truststore.path", "/path/to/grpc-truststore.jks");
+properties.setProperty("tls.truststore.password", "changeit");
+
+try (Connection connection = DriverManager.getConnection(
+    "jdbc:pinotgrpc://localhost:9000?blockRowSize=10000&encoding=JSON&compression=ZSTD",
+    properties)) {
   // execute queries
 }
 ```
@@ -43,8 +82,10 @@ try (Connection connection = DriverManager.getConnection("jdbc:pinotgrpc://local
 
 - Use the same `--add-opens` JVM flag when running Arrow-based clients.
 - Connection establishment performs a lightweight validation query.
-- Request headers can be attached with the `headers.` prefix.
-- If the broker also uses `pinot.broker.request.handler.type=grpc` for broker-to-server communication, the outbound gRPC channels can be tuned with `channelKeepAliveTimeSeconds`, `channelKeepAliveTimeoutSeconds`, `channelKeepAliveWithoutCalls`, and `channelShutdownTimeoutSeconds` in `broker.conf`.
+- Client TLS properties are namespaced under `tls.*`, not broker-side keys such as `pinot.broker.tls.*`.
+- The Java gRPC client takes `blockRowSize`, `compression`, and `encoding` per request via the metadata map passed to `execute(..., metadataMap)` or `executeGrpc(..., metadataMap)`.
+- The JDBC gRPC driver also accepts `blockRowSize`, `compression`, and `encoding` as URL parameters or connection properties and forwards them as request metadata.
+- If the broker also uses `pinot.broker.request.handler.type=grpc` for broker-to-server communication, the similarly named top-level `broker.conf` keepalive and shutdown settings apply to the broker's outbound channels, not to Java/JDBC client connections.
 
 ## What this page covered
 


### PR DESCRIPTION
## Summary
This is batch 13 of the Pinot merged-PR documentation audit.

It closes the next compact, high-confidence docs gap in the broker gRPC client path:
- document the shared Java/JDBC gRPC transport properties actually consumed by `GrpcConfig`
- document that client TLS settings use the `tls.*` prefix
- clarify how Java vs JDBC pass request metadata such as `blockRowSize`, `compression`, and `encoding`

## Audit basis
Time window: merged PRs in `apache/pinot` from 2024-04-04 through 2026-04-04.

Included source PRs and evidence:
- `#13546` added keepalive and shutdown timeout tuning for `GrpcQueryClient`
- `#16170` added auth support for broker gRPC connections
- `#18029` unified `headers.*` handling across the HTTP and gRPC JDBC drivers
- current `GrpcConfig`, `GrpcConnection`, `PinotGrpcConnection`, and `PinotDriver` were re-checked before writing docs so the property names, defaults, and metadata behavior match present behavior

## Changes made
- expanded the broker gRPC API reference with transport properties such as `usePlainText`, `maxInboundMessageSizeBytes`, the keepalive/shutdown knobs, and the `tls.*` client namespace
- added Java client documentation for gRPC connection factory usage and the exact transport property keys
- added JDBC documentation for the `jdbc:pinotgrpc://` path and clarified that URL parameters or connection properties can supply both transport settings and request metadata
- clarified that Java takes `blockRowSize`, `compression`, and `encoding` per request via the metadata map, while JDBC also maps them from connection properties / URL parameters

## Validation
- `python3 scripts/validate-docs.py --changed-only=/tmp/pinot-docs-batch13-changed.txt`
- `git diff --check`
