### PR TITLE
docs: document segment reload controller APIs

### DIFF
--- a/operate-pinot/segment-lifecycle-and-repair.md
+++ b/operate-pinot/segment-lifecycle-and-repair.md
@@ -50,15 +50,20 @@ Reset does **not** re-download or rebuild the segment. If the underlying segment
 **API.**
 
 ```
-# Reload all segments
-POST /segments/{tableName}/reload
+# Reload all segments on an offline table
+POST /segments/{tableName}/reload?type=OFFLINE
 
 # Reload a single segment
 POST /segments/{tableName}/{segmentName}/reload
 
-# Force re-download from deep store before reloading
-POST /segments/{tableName}/reload?forceDownload=true
+# Force re-download immutable segments from deep store before reloading
+POST /segments/{tableName}/reload?type=OFFLINE&forceDownload=true
+
+# Poll job status
+GET /segments/segmentReloadStatus/{jobId}
 ```
+
+`targetInstance` is available on both reload endpoints when you want to reload only one server's copy. `instanceToSegmentsMap` is also available on the table-level endpoint when you need to reload a specific set of segments on specific servers.
 
 **UI.** The Cluster Manager offers **Reload All Segments** at the table level and **Reload Segment** at the individual segment level.
 
@@ -184,7 +189,7 @@ Both tasks are configured in the table's `taskTypeConfigsMap` and run automatica
 
 1. Update the table config to include the new index column.
 2. Run `POST /segments/{tableName}/reload` to rebuild indexes in-place on every server.
-3. Monitor reload job status via `GET /segments/{tableName}/reload/status/{jobId}`.
+3. Monitor reload job status via `GET /segments/segmentReloadStatus/{jobId}`.
 
 If the table has RefreshSegmentTask enabled, the task will also detect the config change and rebuild stale segments on its next run.
 

--- a/operate-pinot/segment-reload.md
+++ b/operate-pinot/segment-reload.md
@@ -12,23 +12,136 @@ If a **new column is added to your table or schema configuration during ingestio
 
 ## Use the Pinot Controller API to reload segments
 
-To reload all segments from a table, use:
+Pinot exposes three reload-related controller endpoints:
+
+```
+POST /segments/{tableName}/reload
+POST /segments/{tableName}/{segmentName}/reload
+GET /segments/segmentReloadStatus/{jobId}
+```
+
+The reload requests are asynchronous. Pinot returns a reload job ID, and you can poll that job ID until the reload finishes.
+
+### Reload all segments in a table
+
+To reload all segments for a table, use:
 
 ```
 POST /segments/{tableName}/reload
 ```
 
-To reload a specific segment from a table, use:
+`tableName` can be either a typed table name such as `myTable_OFFLINE`, or a raw table name such as `myTable`.
+
+Supported query parameters:
+
+| Parameter | Description |
+| --- | --- |
+| `type` | Optional table type filter when the path uses a raw table name. Supported values are `OFFLINE` and `REALTIME`. |
+| `forceDownload` | Re-download immutable segments from deep store before reloading. Defaults to `false`. |
+| `targetInstance` | Send reload messages only to the specified server instance. |
+| `instanceToSegmentsMap` | JSON map of server instance to segment list. When present, Pinot reloads only the listed segments on the listed servers. |
+
+Example:
+
+```bash
+curl -X POST "http://localhost:9000/segments/baseballStats/reload?type=OFFLINE&forceDownload=true" \
+  -H "accept: application/json"
+```
+
+When `forceDownload=true` and you pass a raw table name without a type, Pinot automatically limits the request to the `OFFLINE` table because forced deep-store download is only supported for immutable segments.
+
+If you use `instanceToSegmentsMap`, URL-encode the JSON map and send it as a query parameter.
+
+Typical response:
+
+```json
+{
+  "status": "{\"baseballStats_OFFLINE\":{\"numMessagesSent\":\"24\",\"reloadJobId\":\"6b2f9d35-0d3f-4ef5-91db-f77cb6fdd1c0\",\"reloadJobMetaZKStorageStatus\":\"SUCCESS\"}}"
+}
+```
+
+The `status` field is a JSON string keyed by table name. Each table entry includes the submitted `reloadJobId`, the number of reload messages sent to servers, and whether Pinot successfully persisted job metadata in ZooKeeper.
+
+### Reload one segment
+
+To reload a single segment from a table, use:
 
 ```
 POST /segments/{tableName}/{segmentName}/reload
 ```
 
-A successful API call returns the following response:
+Supported query parameters:
+
+| Parameter | Description |
+| --- | --- |
+| `forceDownload` | Re-download the segment from deep store before reloading. Defaults to `false`. |
+| `targetInstance` | Reload the segment only on the specified server instance. |
+
+Example:
+
+```bash
+curl -X POST "http://localhost:9000/segments/baseballStats_OFFLINE/baseballStats_2026-04-01_0/reload?targetInstance=Server_localhost_8098" \
+  -H "accept: application/json"
+```
+
+Typical response:
 
 ```json
 {
-    "status": "200"
+  "status": "Submitted reload job id: 4f947c6f-8f51-4dbf-b4e7-a8f4f446ce88, sent 1 reload messages. Job meta ZK storage status: SUCCESS"
+}
+```
+
+If the table path omits the type suffix, Pinot derives the table type from the segment name.
+
+### Check reload job status
+
+To check the progress of a submitted reload job, use the `reloadJobId` returned by either reload endpoint:
+
+```bash
+curl -X GET "http://localhost:9000/segments/segmentReloadStatus/6b2f9d35-0d3f-4ef5-91db-f77cb6fdd1c0" \
+  -H "accept: application/json"
+```
+
+Typical response:
+
+```json
+{
+  "status": "IN_PROGRESS",
+  "timeElapsedInMinutes": 0.6,
+  "estimatedTimeRemainingInMinutes": 1.4,
+  "totalSegmentCount": 24,
+  "successCount": 10,
+  "totalServersQueried": 6,
+  "totalServerCallsFailed": 0,
+  "failureCount": 0,
+  "metadata": {
+    "jobId": "6b2f9d35-0d3f-4ef5-91db-f77cb6fdd1c0"
+  },
+  "segmentReloadFailures": []
+}
+```
+
+### Check whether a table needs reload
+
+Before reloading, you can ask Pinot whether any servers think the table needs reload:
+
+```bash
+curl -X GET "http://localhost:9000/segments/baseballStats_OFFLINE/needReload?verbose=true" \
+  -H "accept: application/json"
+```
+
+This endpoint requires a typed table name. With `verbose=true`, Pinot includes per-server decisions:
+
+```json
+{
+  "needReload": true,
+  "serverToSegmentsCheckReloadList": {
+    "instance123": {
+      "needReload": true,
+      "instanceId": "instance123"
+    }
+  }
 }
 ```
 

--- a/reference/api-reference/controller-api.md
+++ b/reference/api-reference/controller-api.md
@@ -16,7 +16,7 @@ The controller exposes the administrative API surface for cluster, schema, table
 | Schema | `GET /schemas`, `GET /schemas/{schemaName}`, `POST /schemas`, `PUT /schemas/{schemaName}`, `DELETE /schemas/{schemaName}` |
 | Table | `GET /tables`, `POST /tables`, `PUT /tables/{tableName}`, `DELETE /tables/{tableName}`, `POST /tableConfigs/validate` |
 | Logical tables | `GET /logicalTables`, `POST /logicalTables`, `PUT /logicalTables/{tableName}`, `DELETE /logicalTables/{tableName}` |
-| Segments | `GET /segments/{tableName}`, `POST /segments`, `POST /segments/{tableName}/{segmentName}/reload`, `DELETE /segments/{tableName}` |
+| Segments | `GET /segments/{tableName}/invalidPartitionMetadata`, `POST /segments/{tableName}/reload`, `GET /segments/segmentReloadStatus/{jobId}`, `GET /segments/{tableNameWithType}/needReload` |
 | Tenant and instance management | `GET /tenants`, `GET /tenants/{tenantName}`, `GET /instances`, `POST /instances` |
 
 ## Swagger UI
@@ -504,6 +504,131 @@ curl -X GET "http://localhost:9000/segments/myTable/invalidPartitionMetadata?typ
   "seg3": "not-valid-json"
 }
 ```
+
+### POST /segments/\{tableName\}/reload
+
+Submit an asynchronous reload job for every segment in a table. The controller accepts either a table name with a type suffix such as `myTable_OFFLINE`, or a raw table name such as `myTable`.
+
+Use the optional query parameters to scope the request:
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `type` | string | Optional table type filter when the path uses a raw table name. Supported values are `OFFLINE` and `REALTIME`. |
+| `forceDownload` | boolean | Re-download immutable segments from deep store before reloading. Defaults to `false`. |
+| `targetInstance` | string | Send reload messages only to a specific server instance. |
+| `instanceToSegmentsMap` | string | JSON map of server instance to segment list. When present, this overrides `targetInstance` and reloads only the listed segments on the listed servers. |
+
+When `forceDownload=true` and the path uses a raw table name without a type, Pinot restricts the reload to the `OFFLINE` table because forced deep-store download is only supported for immutable segments.
+
+**Request**
+
+```bash
+curl -X POST "http://localhost:9000/segments/myTable/reload?type=OFFLINE&forceDownload=true" \
+  -H "accept: application/json"
+```
+
+If you use `instanceToSegmentsMap`, URL-encode the JSON map and send it as a query parameter.
+
+**Response**
+
+```json
+{
+  "status": "{\"myTable_OFFLINE\":{\"numMessagesSent\":\"24\",\"reloadJobId\":\"6b2f9d35-0d3f-4ef5-91db-f77cb6fdd1c0\",\"reloadJobMetaZKStorageStatus\":\"SUCCESS\"}}"
+}
+```
+
+The `status` string is itself a JSON object keyed by table name. Each entry includes the submitted `reloadJobId`, the number of server reload messages sent, and whether Pinot persisted job metadata in ZooKeeper for later status checks.
+
+### POST /segments/\{tableName\}/\{segmentName\}/reload
+
+Submit an asynchronous reload job for a single segment. If the table path omits the type suffix, Pinot derives the table type from the segment name.
+
+**Query parameters**
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `forceDownload` | boolean | Re-download the segment from deep store before reloading. Defaults to `false`. |
+| `targetInstance` | string | Reload the segment only on a specific server instance. |
+
+**Request**
+
+```bash
+curl -X POST "http://localhost:9000/segments/myTable_OFFLINE/myTable_0/reload?targetInstance=Server_localhost_8098" \
+  -H "accept: application/json"
+```
+
+**Response**
+
+```json
+{
+  "status": "Submitted reload job id: 4f947c6f-8f51-4dbf-b4e7-a8f4f446ce88, sent 1 reload messages. Job meta ZK storage status: SUCCESS"
+}
+```
+
+### GET /segments/segmentReloadStatus/\{jobId\}
+
+Fetch the current status for a previously submitted reload job.
+
+**Request**
+
+```bash
+curl -X GET "http://localhost:9000/segments/segmentReloadStatus/6b2f9d35-0d3f-4ef5-91db-f77cb6fdd1c0" \
+  -H "accept: application/json"
+```
+
+**Response**
+
+```json
+{
+  "status": "IN_PROGRESS",
+  "timeElapsedInMinutes": 0.6,
+  "estimatedTimeRemainingInMinutes": 1.4,
+  "totalSegmentCount": 24,
+  "successCount": 10,
+  "totalServersQueried": 6,
+  "totalServerCallsFailed": 0,
+  "failureCount": 0,
+  "metadata": {
+    "jobId": "6b2f9d35-0d3f-4ef5-91db-f77cb6fdd1c0"
+  },
+  "segmentReloadFailures": []
+}
+```
+
+The typed response tracks overall progress, estimated completion time, job metadata, and any per-segment failures Pinot has collected so far.
+
+### GET /segments/\{tableNameWithType\}/needReload
+
+Ask every server hosting a typed table whether any of its segments need a reload. This endpoint requires a table name with type suffix such as `myTable_OFFLINE` or `myTable_REALTIME`.
+
+**Query parameters**
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `verbose` | boolean | Include per-server reload decisions in the response. Defaults to `false`. |
+
+**Request**
+
+```bash
+curl -X GET "http://localhost:9000/segments/myTable_OFFLINE/needReload?verbose=true" \
+  -H "accept: application/json"
+```
+
+**Response**
+
+```json
+{
+  "needReload": true,
+  "serverToSegmentsCheckReloadList": {
+    "instance123": {
+      "needReload": true,
+      "instanceId": "instance123"
+    }
+  }
+}
+```
+
+Without `verbose=true`, Pinot still returns the top-level `needReload` flag but leaves `serverToSegmentsCheckReloadList` empty.
 
 
 ### DELETE /tables/\<tableName>


### PR DESCRIPTION
## Summary
- document the current controller reload endpoints, query parameters, and response payloads
- add reload status and needReload coverage to the controller API reference
- fix the operator workflow page to use the current segment reload status endpoint

## Validation
- python3 scripts/validate-docs.py --changed-only=/tmp/pinot-docs-batch14-changed.txt
- git diff --check