### PR TITLE
docs: refresh partition pruning function coverage

### DIFF
--- a/operate-pinot/tuning/routing.md
+++ b/operate-pinot/tuning/routing.md
@@ -55,7 +55,7 @@ Data cannot always be partitioned by a dimension column or even when it is, not 
 
 ![](../../.gitbook/assets/partition-on-member-id.png)
 
-Apache Pinot currently supports `Modulo`, `Murmur`, `ByteArray` and `HashCode` hash functions and partitioning can be enabled by setting the following configuration in the table config.
+Apache Pinot currently supports `Modulo`, `Murmur`, `Murmur3`, `FNV`, `ByteArray`, and `HashCode` partition functions. Partitioning can be enabled by setting the following configuration in the table config. For function-specific options such as `useRawBytes`, `seed`, `variant`, and `negativePartitionHandling`, see [`segmentPartitionConfig`](../../reference/configuration-reference/table.md#segments-config) in the table configuration reference.
 
 ```
 // Table config

--- a/operate-pinot/tuning/segment-pruning.md
+++ b/operate-pinot/tuning/segment-pruning.md
@@ -70,7 +70,9 @@ First, define the partition scheme in the table's index config:
 }
 ```
 
-**Supported partition functions:** `Modulo`, `Murmur`, `ByteArray`, `HashCode`
+**Supported partition functions:** `Modulo`, `Murmur`, `Murmur3`, `FNV`, `ByteArray`, `HashCode`
+
+For function-specific options such as `useRawBytes`, `seed`, `variant`, and `negativePartitionHandling`, see [`segmentPartitionConfig`](../../reference/configuration-reference/table.md#segments-config) in the table configuration reference.
 
 **Supported filter operators:** `=` (equality), `IN`
 


### PR DESCRIPTION
## Summary
- update partition-pruning docs to list the current supported partition functions
- add links back to the canonical `segmentPartitionConfig` reference for function-specific options

## Why
The tuning pages still listed an older subset of partition functions (`Modulo`, `Murmur`, `ByteArray`, `HashCode`) and omitted newer supported functions such as `Murmur3` and `FNV`.

The canonical table config reference is already correct; this PR brings the tuning guidance back in sync.

## Evidence
- `PartitionFunctionFactory` supports `Modulo`, `Murmur`, `Murmur2`, `Murmur3`, `Fnv`, `ByteArray`, and `HashCode`
- the canonical config reference already documents `Murmur3` and `FNV` options under `segmentPartitionConfig`

## Validation
- `python3 scripts/validate-docs.py --changed-only=<(printf '%s\n' operate-pinot/tuning/routing.md operate-pinot/tuning/segment-pruning.md)`
- `git diff --check`
