### PR TITLE
docs: add pause-consumption batch controls

### DIFF
--- a/build-with-pinot/ingestion/stream-ingestion/README.md
+++ b/build-with-pinot/ingestion/stream-ingestion/README.md
@@ -412,6 +412,14 @@ $ curl -X POST {controllerHost}/tables/{tableName}/pauseConsumption
 $ curl -X POST {controllerHost}/tables/{tableName}/resumeConsumption
 ```
 
+For tables with many consuming segments, you can batch the pause request so the controller commits fewer segments at a time:
+
+```bash
+$ curl -X POST "{controllerHost}/tables/{tableName}/pauseConsumption?batchSize=50&batchStatusCheckIntervalSec=5&batchStatusCheckTimeoutSec=180"
+```
+
+`batchSize` limits how many consuming segments Pinot commits in one batch. `batchStatusCheckIntervalSec` and `batchStatusCheckTimeoutSec` control how often and how long the controller waits for each batch to finish before moving on or failing the pause request.
+
 When a `Pause` request is issued, the controller instructs the real-time servers hosting your table to commit their consuming segments immediately. However, the commit process may take some time to complete. Note that `Pause` and `Resume` requests are async. An `OK` response means that instructions for pausing or resuming has been successfully sent to the real-time server. If you want to know if the consumption has actually stopped or resumed, issue a pause status request.
 
 ```bash

--- a/reference/api-reference/controller-api.md
+++ b/reference/api-reference/controller-api.md
@@ -943,10 +943,26 @@ curl -X POST "http://localhost:9000/tables/myTable/rebalance?type=OFFLINE&dryRun
 
 Pause real-time consumption for a table.
 
+| Query parameter | Type | Meaning |
+| --- | --- | --- |
+| `comment` | string | Optional comment stored with the administrative pause state. |
+| `batchSize` | integer | Maximum number of consuming segments Pinot commits at once while pausing. Defaults to queueing all consuming segments in one batch. |
+| `batchStatusCheckIntervalSec` | integer | How often, in seconds, the controller checks whether the current pause batch has finished committing. Default: `5`. |
+| `batchStatusCheckTimeoutSec` | integer | How long, in seconds, the controller waits for a pause batch to finish before failing the request. Default: `180`. |
+
+For realtime tables with many partitions, use the batch parameters to spread the commit work across smaller pause batches instead of asking every consuming segment to commit at once. Pinot returns `400 Bad Request` if any batch parameter is non-positive.
+
 **Request**
 
 ```
 curl -X POST "http://localhost:9000/tables/myTable/pauseConsumption" -H "accept: application/json"
+```
+
+Example with batching:
+
+```bash
+curl -X POST "http://localhost:9000/tables/myTable/pauseConsumption?comment=maintenance&batchSize=50&batchStatusCheckIntervalSec=5&batchStatusCheckTimeoutSec=180" \
+  -H "accept: application/json"
 ```
 
 ### POST /tables/\<tableName>/resumeConsumption


### PR DESCRIPTION
## Summary
- document the batch query parameters for `POST /tables/{tableName}/pauseConsumption`
- add an example for pausing realtime ingestion in smaller commit batches
- note the validation behavior for non-positive batch parameters

## Source
- closes the docs gap from apache/pinot#17194

## Validation
- `python3 scripts/validate-docs.py --changed-only=<(printf '%s\n' reference/api-reference/controller-api.md build-with-pinot/ingestion/stream-ingestion/README.md)`
- `git diff --check`
