### PR TITLE
docs: add controller disaster recovery mode refs

### DIFF
--- a/operate-pinot/pauseless-consumption.md
+++ b/operate-pinot/pauseless-consumption.md
@@ -142,6 +142,8 @@ For tables with dedup or upsert enabled, reingestion may conflict with data cons
 When using `ALWAYS` mode with dedup tables, dedup metadata may be temporarily inconsistent until a full metadata rebuild is performed after recovery.
 {% endhint %}
 
+For a cluster-wide default, set `controller.segment.disaster.recovery.mode` to `DEFAULT` or `ALWAYS`. This applies the same policy through the controller's periodic realtime validation task without requiring every table config to repeat the setting. Table-level `disasterRecoveryMode` remains available when you want to opt an individual table into `ALWAYS` while the cluster default stays at `DEFAULT`.
+
 ## Observability
 
 ### Metrics

--- a/reference/configuration-reference/controller.md
+++ b/reference/configuration-reference/controller.md
@@ -142,8 +142,11 @@ This task does not fix consumption stalled due to
 | controller.realtime.segment.deepStoreUploadRetry.timeoutMs | -1 |
 | controller.realtime.segment.deepStoreUploadRetry.parallelism | 1 |
 | controller.realtime.segment.partialOfflineReplicaRepairEnabled | false |
+| controller.segment.disaster.recovery.mode | DEFAULT |
 
 When `controller.realtime.segment.partialOfflineReplicaRepairEnabled` is enabled, the controller's periodic validation task automatically resets OFFLINE replicas back to CONSUMING for IN_PROGRESS segments that have a mix of CONSUMING and OFFLINE replicas. This handles cases where a replica's startup fails (for example, due to Kafka consumer initialization errors) while other replicas continue normally. Enable only after verifying that OFFLINE replicas are caused by transient failures rather than persistent errors.
+
+`controller.segment.disaster.recovery.mode` sets the cluster-wide default disaster-recovery policy used by the controller's realtime segment validation task for pauseless ingestion. Supported values are `DEFAULT` and `ALWAYS`, matching the table-level `disasterRecoveryMode` setting in `streamIngestionConfig`. You can set this in `controller.conf`, or update the same key through cluster configs so the controller picks up the new mode without restart.
 
 ### RetentionManager
 


### PR DESCRIPTION
## Summary
- document `controller.segment.disaster.recovery.mode` in the controller config reference
- explain the cluster-wide disaster recovery default for pauseless ingestion
- connect the global controller setting back to the existing table-level `disasterRecoveryMode` docs

## Source
- closes the docs gap from apache/pinot#17243

## Validation
- `python3 scripts/validate-docs.py --changed-only=<(printf '%s\n' reference/configuration-reference/controller.md operate-pinot/pauseless-consumption.md)`
- `git diff --check`
