### PR TITLE
docs: document guarded upsert and dedup config updates

### DIFF
--- a/build-with-pinot/ingestion/upsert-and-dedup/upsert.md
+++ b/build-with-pinot/ingestion/upsert-and-dedup/upsert.md
@@ -1023,6 +1023,10 @@ Not recommended. Existing segments contain validDocId snapshots computed using t
 
 **Avoid changing:** primary key columns, comparison columns, partial upsert strategies, upsert mode, and hashFunction.
 
+Pinot now enforces this guard on the controller update APIs. By default, `PUT /tables/{tableName}` and `PUT /tableConfigs/{tableName}` reject backward-incompatible upsert or dedup config changes with `400 Bad Request`. For upsert tables, this includes comparison columns, hash function, mode, out-of-order settings, partial-upsert strategies, and the table time column when Pinot is using it as the default comparison column. For dedup tables, this includes the dedup hash function, dedup time column, and the table time column when Pinot is using it as the default dedup time column.
+
+You can still bypass the guard with `force=true` on `PUT /tables/{tableName}` or `forceTableSchemaUpdate=true` on `PUT /tableConfigs/{tableName}`, but Pinot recommends using that only for controlled recovery or migration workflows.
+
 If changes are unavoidable:
 
 **Best option:** Create a new table and reingest all data.

--- a/reference/api-reference/controller-api.md
+++ b/reference/api-reference/controller-api.md
@@ -656,6 +656,65 @@ curl -X GET "http://localhost:9000/segments/myTable_OFFLINE/needReload?verbose=t
 
 Without `verbose=true`, Pinot still returns the top-level `needReload` flag but leaves `serverToSegmentsCheckReloadList` empty.
 
+### PUT /tables/\<tableName>
+
+Update the config for an existing typed table.
+
+**Query parameters**
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `validationTypesToSkip` | string | Comma-separated validation types to skip during table-config validation. |
+| `force` | boolean | Defaults to `false`. When `true`, Pinot still applies backward-incompatible upsert or dedup config changes that it would otherwise reject. Use only for controlled migrations. |
+
+By default, Pinot returns `400 Bad Request` for backward-incompatible changes on existing upsert or dedup tables. The protected fields include upsert comparison columns, hash function, mode, out-of-order settings, partial-upsert strategies, dedup hash function, dedup time column, and the table time column when Pinot is using it as the default comparison or dedup time column. The safest path for those changes is still to create a new table and reingest the data.
+
+**Request**
+
+```bash
+curl -X PUT "http://localhost:9000/tables/myTable_REALTIME?force=true" \
+  -H "Content-Type: application/json" \
+  -d @table-config.json
+```
+
+**Response**
+
+```json
+{
+  "status": "Table config updated for myTable_REALTIME"
+}
+```
+
+### PUT /tableConfigs/\<tableName>
+
+Update a combined `TableConfigs` payload for the raw table name. Pinot uses this endpoint when you want to update schema-linked offline and realtime table configs together.
+
+**Query parameters**
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `validationTypesToSkip` | string | Comma-separated validation types to skip during validation. |
+| `reload` | boolean | Defaults to `false`. When `true`, Pinot reloads the table if the schema update is backward compatible. |
+| `forceTableSchemaUpdate` | boolean | Defaults to `false`. When `true`, Pinot forces both the schema update and the included table-config updates even when they would normally be rejected as backward incompatible. This is intended for exceptional cases and should be used with caution. |
+
+The same upsert and dedup compatibility checks described above apply to the realtime or offline configs inside the `TableConfigs` payload. Without `forceTableSchemaUpdate=true`, Pinot rejects those backward-incompatible changes with `400 Bad Request`.
+
+**Request**
+
+```bash
+curl -X PUT "http://localhost:9000/tableConfigs/myTable?forceTableSchemaUpdate=true" \
+  -H "Content-Type: application/json" \
+  -d @table-configs.json
+```
+
+**Response**
+
+```json
+{
+  "status": "TableConfigs updated for myTable"
+}
+```
+
 
 ### DELETE /tables/\<tableName>
 


### PR DESCRIPTION
## Summary
- document the `PUT /tables/{tableName}` and `PUT /tableConfigs/{tableName}` compatibility guards in the controller API reference
- explain the `force` and `forceTableSchemaUpdate` escape hatches for controlled migrations
- tighten the upsert-and-dedup FAQ so it reflects the controller's current rejection behavior for backward-incompatible updates

## Source
- closes the docs gap from apache/pinot#17645

## Validation
- `python3 scripts/validate-docs.py --changed-only=<(printf '%s\n' reference/api-reference/controller-api.md build-with-pinot/ingestion/upsert-and-dedup/upsert.md)`
- `git diff --check`
