### PR TITLE
docs: add smart hllplus function refs

### DIFF
--- a/build-with-pinot/querying-and-sql/function-index.md
+++ b/build-with-pinot/querying-and-sql/function-index.md
@@ -22,6 +22,7 @@ For full details, see [Aggregation Functions](../../functions/aggregation/README
 | [`DISTINCTCOUNT`](../../functions/aggregation/distinctcount.md) | `DISTINCTCOUNT(col)` | INT | Returns the exact distinct count | Both |
 | [`DISTINCTCOUNTHLL`](../../functions/aggregation/distinctcounthll.md) | `DISTINCTCOUNTHLL(col [, log2m])` | LONG | Approximate distinct count using HyperLogLog | Both |
 | [`DISTINCTCOUNTHLLPLUS`](../../functions/sketch/distinctcounthllplus.md) | `DISTINCTCOUNTHLLPLUS(col [, p])` | LONG | Approximate distinct count using HyperLogLog++ | Both |
+| [`DISTINCTCOUNTSMARTHLLPLUS`](../../functions/sketch/distinctcounthllplus.md#distinctcountsmarthllplus) | `DISTINCTCOUNTSMARTHLLPLUS(col [, params])` | LONG | Exact-then-approximate distinct count that switches to HLL++ after a threshold | Both |
 | [`DISTINCTCOUNTBITMAP`](../../functions/aggregation/distinctcountbitmap.md) | `DISTINCTCOUNTBITMAP(col)` | INT | Distinct count using bitmap | Both |
 | [`DISTINCTCOUNTTHETASKETCH`](../../functions/aggregation/distinctcountthetasketch.md) | `DISTINCTCOUNTTHETASKETCH(col [, predicates...])` | LONG | Distinct count using Theta Sketch | Both |
 | [`DISTINCTCOUNTCPCSKETCH`](../../functions/sketch/distinctcountcpcsketch.md) | `DISTINCTCOUNTCPCSKETCH(col [, lgK])` | LONG | Distinct count using CPC Sketch | Both |

--- a/functions/sketch/README.md
+++ b/functions/sketch/README.md
@@ -26,6 +26,7 @@ HyperLogLogPlus (HLL++) provides approximate distinct counts with configurable p
 | Function | Description |
 | -------- | ----------- |
 | [DISTINCTCOUNTHLLPLUS](distinctcounthllplus.md) | Approximate distinct count using HLL++ |
+| [DISTINCTCOUNTSMARTHLLPLUS](distinctcounthllplus.md#distinctcountsmarthllplus) | Starts exact and converts to HLL++ after a threshold |
 | [DISTINCTCOUNTHLLPLUSMV](distinctcounthllplusmv.md) | HLL++ for multi-value columns |
 | [DISTINCTCOUNTRAWHLLPLUS](distinctcountrawhllplus.md) | Returns serialized HLL++ sketch |
 | [DISTINCTCOUNTRAWHLLPLUSMV](distinctcountrawhllplusmv.md) | Serialized HLL++ sketch for multi-value columns |

--- a/functions/sketch/distinctcounthllplus.md
+++ b/functions/sketch/distinctcounthllplus.md
@@ -37,3 +37,31 @@ from baseballStats
 | value |
 | ----- |
 | 149   |
+
+## DISTINCTCOUNTSMARTHLLPLUS
+
+`DISTINCTCOUNTSMARTHLLPLUS` starts with exact distinct counting in a set and switches to HyperLogLog++ when the number of distinct values exceeds a threshold. This is useful when some groups stay small enough for exact counting while larger groups still need bounded memory usage.
+
+### Signature
+
+> DISTINCTCOUNTSMARTHLLPLUS(colName)
+> DISTINCTCOUNTSMARTHLLPLUS(colName, 'threshold=<n>;p=<p>;sp=<sp>')
+
+### Parameters
+
+* `colName` (required): Column to aggregate.
+* `threshold` (optional): Number of distinct values Pinot keeps exactly before converting to HLL++. Default: `100000`. A non-positive value disables the conversion.
+* `p` (optional): HyperLogLog++ normal precision after conversion. Default: `14`.
+* `sp` (optional): HyperLogLog++ sparse precision after conversion. Default: `0`.
+
+### Usage Examples
+
+```sql
+SELECT DISTINCTCOUNTSMARTHLLPLUS(teamID) AS value
+FROM baseballStats
+```
+
+```sql
+SELECT DISTINCTCOUNTSMARTHLLPLUS(teamID, 'threshold=10000;p=12') AS value
+FROM baseballStats
+```


### PR DESCRIPTION
## Summary
- add `DISTINCTCOUNTSMARTHLLPLUS` to the central function index
- surface the smart HLL++ variant in the sketch README
- document the threshold, `p`, and `sp` parameters on the existing HLL++ reference page

## Source
- closes the docs gap from apache/pinot#17011

## Validation
- `python3 scripts/validate-docs.py --changed-only=<(printf '%s\n' build-with-pinot/querying-and-sql/function-index.md functions/sketch/README.md functions/sketch/distinctcounthllplus.md)`
- `git diff --check`

## Note
- `validate-docs.py` still reports one pre-existing broken anchor in `functions/sketch/distinctcounthllplus.md` pointing at `quick-start.md#batch`; this PR does not change that anchor.
