### PR TITLE
docs: add Netty and gRPC memory metrics

### DIFF
--- a/operate-pinot/metrics-and-monitoring.md
+++ b/operate-pinot/metrics-and-monitoring.md
@@ -39,6 +39,8 @@ The broker receives queries, compiles them, routes them to servers, and merges r
 | `JVM_HEAP_USED_BYTES` | Gauge | Current JVM heap usage on the broker. | > 85% of max heap |
 | `QUERY_QUOTA_CAPACITY_UTILIZATION_RATE` | Gauge | Percentage of configured rate limit in use. | > 80% |
 
+For broker transport memory pressure, also monitor `GRPC_TOTAL_USED_DIRECT_MEMORY` and compare it with `GRPC_TOTAL_MAX_DIRECT_MEMORY`. These gauges cover the shaded Netty runtime used by the broker gRPC listener and MSE mailbox traffic.
+
 ### Broker Query Latency Breakdown
 
 These timers help identify which phase of query execution is slow:
@@ -95,6 +97,8 @@ Servers store segments and execute queries. Monitoring servers helps detect inge
 | `JVM_HEAP_USED_BYTES` | Gauge | Current JVM heap usage on the server. | > 85% of max heap |
 | `HEAP_CRITICAL_LEVEL_EXCEEDED` | Meter | Times heap usage exceeded the critical threshold, triggering query killing. | > 0 |
 | `REALTIME_OFFHEAP_MEMORY_USED` | Gauge | Off-heap memory used by real-time segments. | Approaching configured `MaxDirectMemorySize` |
+
+For server transport memory pressure, also monitor `NETTY_TOTAL_USED_DIRECT_MEMORY` and `GRPC_TOTAL_USED_DIRECT_MEMORY`, and compare them with the corresponding `*_MAX_DIRECT_MEMORY` gauges. `NETTY_*` covers the server Netty query service, while `GRPC_*` covers the server gRPC query service and MSE mailbox traffic.
 
 ### Server Query Latency Breakdown
 

--- a/reference/configuration-reference/monitoring-metrics.md
+++ b/reference/configuration-reference/monitoring-metrics.md
@@ -49,6 +49,10 @@ Pinot provides metrics out of the box so that you can monitor every aspect of pe
 | NETTY_CONNECTION_RESPONSES_SENT | total responses sent by the server |  |
 | FRESHNESS_LAG_MS | time period between when the data was last updated in the table and the current time |  |
 | NETTY_CONNECTION_SEND_RESPONSE_LATENCY | time spent in sending response to brokers after the results are available |  |
+| NETTY_TOTAL_MAX_DIRECT_MEMORY | Maximum direct memory available to the server's Netty query service |  |
+| NETTY_TOTAL_USED_DIRECT_MEMORY | Current direct memory allocated by the server's Netty query service |  |
+| GRPC_TOTAL_MAX_DIRECT_MEMORY | Maximum direct memory available to the shaded Netty runtime used by the server gRPC query service and MSE mailbox traffic |  |
+| GRPC_TOTAL_USED_DIRECT_MEMORY | Current direct memory allocated by the shaded Netty runtime used by the server gRPC query service and MSE mailbox traffic |  |
 | EXECUTION_THREAD_CPU_TIME_NS | time spent by all threads processing query and results (doesn't includes time spent in system activities) |  |
 | SYSTEM_ACTIVITIES_CPU_TIME_NS | time spent in nanoseconds processing query on the servers (only counts system acitivities such as GC, OS paging etc.) |  |
 | RESPONSE_SER_CPU_TIME_NS | time spent in nanoseconds serializing query response on servers |  |
@@ -119,6 +123,8 @@ Pinot provides metrics out of the box so that you can monitor every aspect of pe
 | REALTIME_RESPONSE_SER_CPU_TIME_NS | aggregated response serialization cpu time in nanoseconds for query processing from real-time servers |  |
 | OFFLINE_TOTAL_CPU_TIME_NS | aggregated total cpu time(thread + system activities + response serialization) in nanoseconds for query processing from offline servers |  |
 | REALTIME_TOTAL_CPU_TIME_NS | time(thread + system activities + response serialization) in nanoseconds for query processing from real-time servers |  |
+| GRPC_TOTAL_MAX_DIRECT_MEMORY | Maximum direct memory available to the shaded Netty runtime used by broker gRPC services and MSE mailbox traffic |  |
+| GRPC_TOTAL_USED_DIRECT_MEMORY | Current direct memory allocated by the shaded Netty runtime used by broker gRPC services and MSE mailbox traffic |  |
 
 #### Tracking time spent in various phases of Query execution in milliseconds
 


### PR DESCRIPTION
## Summary
- add the missing direct-memory metric names to the broker and server monitoring reference tables
- call out the broker `GRPC_*` gauges in the monitoring guide
- call out the server `NETTY_*` and `GRPC_*` gauges in the monitoring guide

## Source
- closes the docs gap from apache/pinot#16939

## Validation
- `python3 scripts/validate-docs.py --changed-only=<(printf '%s\n' reference/configuration-reference/monitoring-metrics.md operate-pinot/metrics-and-monitoring.md)`
- `git diff --check`
