### PR TITLE
docs: add JSON field-spec default overrides

### DIFF
--- a/reference/configuration-reference/cluster.md
+++ b/reference/configuration-reference/cluster.md
@@ -25,6 +25,8 @@ These settings control baseline cluster behavior and compatibility semantics.
 | enable.case.insensitive | true | Pinot queries are case insensitive by default, including table and column names. If you set this to `false`, Pinot uses the exact case defined in the schema. This property is applicable to brokers and is read only when the broker starts, so changing it requires a broker restart. |
 | default.hyperloglog.log2m | 8 | Default `log2m` value for HyperLogLog-based approximate distinct-count functions. |
 | max.segment.completion.time.millis | 300000 (5 minutes) | Cluster config for the maximum time allowed for LLC real-time segment completion after `segmentCommitStart`. Increase this when large segments, deep-store upload time, or retries can push real-time segment completion beyond 5 minutes. Removing the cluster config reverts Pinot to the default. |
+| pinot.field.spec.default.json.max.length | 512 | Default `maxLength` Pinot applies to `JSON` columns when the field spec does not set one explicitly. Set this as a cluster config for a cluster-wide default, or in local instance config for a node-local override. |
+| pinot.field.spec.default.json.max.length.exceed.strategy | NO_ACTION | Default `maxLengthExceedStrategy` Pinot applies to `JSON` columns when the field spec does not set one explicitly. Supported values are `TRIM_LENGTH`, `SUBSTITUTE_DEFAULT_VALUE`, `NO_ACTION`, and `ERROR`. Set this as a cluster config for a cluster-wide default, or in local instance config for a node-local override. |
 
 ## Query Safety
 

--- a/reference/configuration-reference/schema.md
+++ b/reference/configuration-reference/schema.md
@@ -318,6 +318,8 @@ These advanced properties are available across field specs:
 | `allowTrailingZeros` | Whether `BIG_DECIMAL` should preserve trailing zeros. Defaults to `false`, which strips them. |
 | `virtualColumnProvider` | Provider used to populate a virtual column value. |
 
+For `JSON` columns, Pinot also supports cluster-wide or node-local fallback defaults when the field spec omits `maxLength` or `maxLengthExceedStrategy`. By default, Pinot uses `512` and `NO_ACTION`. You can override those defaults with `pinot.field.spec.default.json.max.length` and `pinot.field.spec.default.json.max.length.exceed.strategy`. Explicit field-spec values still take precedence.
+
 ## Related Pages
 
 - [Configuration Reference](README.md)


### PR DESCRIPTION
## Summary
- document cluster and schema refs for the JSON field-spec fallback defaults added in apache/pinot#16149
- cover `pinot.field.spec.default.json.max.length` and `pinot.field.spec.default.json.max.length.exceed.strategy`
- clarify that explicit field-spec values still take precedence

## Validation
- python3 scripts/validate-docs.py --changed-only=<(printf '%s\\n' reference/configuration-reference/cluster.md reference/configuration-reference/schema.md)\n- git diff --check