### PR TITLE
docs: correct timeseries controller UI docs

### DIFF
--- a/basics/components/cluster/controller.md
+++ b/basics/components/cluster/controller.md
@@ -8,7 +8,7 @@ description: >-
 
 The Pinot controller schedules and reschedules resources in a Pinot cluster when metadata changes or a node fails. As an Apache Helix Controller, the Pinot controller schedules the resources that comprise the cluster and orchestrates connections between certain external processes and cluster components (for example, ingest of [real-time tables](../../../reference/configuration-reference/table.md#real-time-table-config) and [offline tables](../../../reference/configuration-reference/table.md#offline-table)). The Pinot controller can be deployed as a single process on its own server or as a group of redundant servers in an active/passive configuration.
 
-The controller exposes a [REST API endpoint](../../../reference/api-reference/controller-api.md) for cluster-wide administrative operations as well as a web-based query console to execute interactive SQL queries and perform simple administrative tasks.
+The controller exposes a [REST API endpoint](../../../reference/api-reference/controller-api.md) for cluster-wide administrative operations as well as a web-based query console for interactive SQL queries, time-series queries, and simple administrative tasks.
 
 The Pinot controller is responsible for the following:
 

--- a/basics/components/exploring-pinot.md
+++ b/basics/components/exploring-pinot.md
@@ -100,7 +100,7 @@ Pinot uses SQL for querying. For the complete syntax reference, see the [SQL Syn
 
 ### Time-series query execution
 
-The Query Console also supports time-series query execution ([#16305](https://github.com/apache/pinot/pull/16305)), introduced as part of the Time Series Engine beta. This feature provides a dedicated interface for running and visualizing time-series queries using languages such as PromQL. It connects to a Prometheus-compatible `/query_range` endpoint ([#16286](https://github.com/apache/pinot/pull/16286)) exposed by the Pinot controller, letting you explore time-series data and inspect query execution plans directly from the UI.
+The Query Console also supports time-series query execution ([#16305](https://github.com/apache/pinot/pull/16305)), introduced as part of the Time Series Engine beta. The current Controller UI adds a dedicated page for running M3QL queries against the controller's Prometheus-compatible `/query_range` endpoint ([#16286](https://github.com/apache/pinot/pull/16286)). It provides time-range controls and shows the raw JSON response directly in the UI.
 
 ## REST API
 

--- a/build-with-pinot/querying-and-sql/time-series-queries.md
+++ b/build-with-pinot/querying-and-sql/time-series-queries.md
@@ -38,13 +38,13 @@ pinot.timeseries.promql.series.builder.factory=com.example.promql.PromQLSeriesBu
 
 ### Controller UI
 
-Pinot includes a Time Series Query page in the Controller UI for easy querying and visualization at `http://localhost:9000`.
+Pinot includes a Time Series Query page in the Controller UI at `http://localhost:9000/query/timeseries`.
 
 ![](../../.gitbook/assets/timeseries-controller-ui.png)
 
-*Time Series Query UI showing the query editor, time controls, and visualization options*
+*Time Series Query UI showing the query editor and time controls*
 
-The UI includes a query editor with language selector (compatible with custom language plugins) and visualizes results as both an interactive time series chart and raw JSON. It also displays query statistics and supports explain plans and query options for enhanced control.
+The current Controller UI implementation is scoped to M3QL queries. It provides an editor, `start` and `end` Unix timestamp inputs, a `timeout` input, and a raw JSON result viewer. The UI sends requests through the Controller's `/timeseries/api/v1/query_range` proxy with a fixed `step` of `1m`. It does not currently expose plugin-specific language selection, chart visualization, explain plans, or generic query-option controls.
 
 ### Broker-Compatible API
 

--- a/reference/releases/1.4.0.md
+++ b/reference/releases/1.4.0.md
@@ -152,7 +152,7 @@ Logical tables are designed to simplify and unify a wide range of use cases by a
 Pinot 1.3.0  introduced a Generic Time Series Query Engine in Apache Pinot, enabling native support for various time-series query languages (e.g., PromQL, M3QL) through a pluggable framework. Multiple enhancements and bugfixes have been added in 1.4.0.
 
 ### Timeseries Query Execution UI in Pinot Controller [#16305](https://github.com/apache/pinot/pull/16305)
-Added a new UI in the Pinot Controller for visualizing timeseries query execution plans. This feature helps developers and operators better understand query breakdowns, execution stages, and time-series–specific optimizations, making troubleshooting and tuning more intuitive.
+Added a dedicated Time Series Query page to the Pinot Controller. The UI lets operators run M3QL queries against the controller's `/timeseries/api/v1/query_range` proxy, set the query time range and timeout, and inspect the raw JSON response directly in the controller.
 
 ### Adding controller endpoint to access timeseries API [#16286](https://github.com/apache/pinot/pull/16286)
 Introduces a Prometheus-compatible /query_range endpoint to support time series queries in Pinot. Refactors broker request handling to generalize support for both GET and POST methods, simplifies header extraction, and improves error handling and logging. Includes minor code cleanups and enhancements to maintainability.


### PR DESCRIPTION
## Summary
- align the Controller time-series UI docs with the behavior shipped in apache/pinot#16305
- document the current M3QL-only, raw-JSON-only UI scope
- remove incorrect claims about visualization, explain plans, and plugin-language selection from the affected pages

## Validation
- python3 scripts/validate-docs.py --changed-only=<(printf '%s\\n' build-with-pinot/querying-and-sql/time-series-queries.md basics/components/exploring-pinot.md basics/components/cluster/controller.md reference/releases/1.4.0.md)\n- git diff --check\n\n## Notes\n- `validate-docs.py` still reports the same pre-existing broken anchors in `basics/components/cluster/controller.md`