### PR TITLE
docs: update Avro logical type defaults

### DIFF
--- a/build-with-pinot/ingestion/pinot-input-formats.md
+++ b/build-with-pinot/ingestion/pinot-input-formats.md
@@ -67,6 +67,8 @@ Your CSV file may have raw text fields that cannot be reliably delimited using a
 
 ### Avro
 
+To keep the defaults explicit, the example below shows `enableLogicalTypes: true`, but Pinot enables Avro logical-type conversion by default.
+
 ```
 dataFormat: 'avro'
 className: 'org.apache.pinot.plugin.inputformat.avro.AvroRecordReader'
@@ -74,7 +76,7 @@ configs:
     enableLogicalTypes: true
 ```
 
-The Avro record reader converts the data in file to a `GenericRecord`. A Java class or `.avro` file is not required. By default, the Avro record reader only supports primitive types. To enable support for rest of the Avro data types, set `enableLogicalTypes` to `true` .
+The Avro record reader converts the data in file to a `GenericRecord`. A Java class or `.avro` file is not required. By default, Pinot applies Avro logical-type conversions during extraction. If you need the older primitive-only behavior, set `enableLogicalTypes` to `false`.
 
 We use the following conversion table to translate between Avro and Pinot data types. The conversions are done using the offical Avro methods present in `org.apache.avro.Conversions`.
 


### PR DESCRIPTION
## Summary
- update the Avro input-format docs for apache/pinot#15654
- document that logical-type conversion is now enabled by default
- show `enableLogicalTypes: false` as the opt-out path for primitive-only behavior

## Validation
- python3 scripts/validate-docs.py --changed-only=<(printf '%s\\n' build-with-pinot/ingestion/pinot-input-formats.md)\n- git diff --check