### PR TITLE
docs: correct RLS configuration examples

### DIFF
--- a/operate-pinot/access-control.md
+++ b/operate-pinot/access-control.md
@@ -40,22 +40,22 @@ pinot.broker.access.control.principals.admin.password=verysecret
 # Alice can only access the sales_table and user_table
 pinot.broker.access.control.principals.alice.password=alice123
 pinot.broker.access.control.principals.alice.tables=sales_table,user_table
-pinot.broker.access.control.principals.alice.rls.sales_table=department='marketing'
-pinot.broker.access.control.principals.alice.rls.user_table=user_id='alice'
+pinot.broker.access.control.principals.alice.sales_table.rls=department='marketing'
+pinot.broker.access.control.principals.alice.user_table.rls=user_id='alice'
 
 # Bob can access sales_table but only for a different department
 pinot.broker.access.control.principals.bob.password=bob456
 pinot.broker.access.control.principals.bob.tables=sales_table
-pinot.broker.access.control.principals.bob.rls.sales_table=department='engineering'
+pinot.broker.access.control.principals.bob.sales_table.rls=department='engineering'
 ```
 
 The configuration key format is:
 
 ```
-pinot.broker.access.control.principals.<user>.rls.<tableName>=<filter_predicate>
+pinot.broker.access.control.principals.<user>.<tableName>.rls=<filter_predicate>
 ```
 
-Where `<filter_predicate>` is any valid SQL predicate expression such as `department='marketing'` or `region IN ('US', 'EU')`.
+The value is parsed as a comma-separated list of filter predicates for that table. Pinot trims each predicate and combines them with `AND`.
 
 ### Query rewriting example
 
@@ -75,7 +75,7 @@ The additional filter is combined with the original WHERE clause using AND. If m
 
 ### Custom access control implementations
 
-If you use a custom `AccessControlFactory`, you can support RLS by implementing the `getRowColFilters()` method on your `AccessControl` class. This method receives the `RequesterIdentity` and table name, and returns a `TableRowColAuthResult` containing the RLS filter predicates to apply.
+If you use a custom `AccessControlFactory`, you can support RLS by implementing the `getRowColFilters()` method on your `AccessControl` class. This method receives the `RequesterIdentity` and table name, and returns a `TableRowColAccessResult` containing the RLS filter predicates to apply.
 
 ### Performance considerations
 

--- a/operate-pinot/security-hardening.md
+++ b/operate-pinot/security-hardening.md
@@ -73,7 +73,7 @@ pinot.broker.access.control.principals.analyst.tables=orders_table
 pinot.broker.access.control.principals.analyst.permissions=READ
 
 # Example: RLS filter — analyst sees only their own region
-pinot.broker.access.control.principals.analyst.rls.orders_table=region='us-west'
+pinot.broker.access.control.principals.analyst.orders_table.rls=region='us-west'
 ```
 
 For full details see [Access Control](access-control.md).

--- a/playbooks/multi-tenant-analytics.md
+++ b/playbooks/multi-tenant-analytics.md
@@ -182,11 +182,20 @@ See [Query Quotas](../build-with-pinot/querying-and-sql/query-execution-controls
 
 ## Data isolation (row-level security)
 
-Pinot does not have built-in row-level security. The standard approach is to enforce tenant filtering in the **application layer** that sits between the user and the Pinot broker.
+Pinot has built-in row-level security (RLS) at the broker. You can configure per-principal, per-table filter predicates so Pinot rewrites incoming SQL queries before execution. This is the preferred enforcement point when the tenant policy maps cleanly to broker-authenticated principals.
 
 ### Implementation pattern
 
-Your application backend should:
+For Pinot-managed enforcement, define tenant-scoped RLS filters in broker access-control config:
+
+```properties
+pinot.broker.access.control.principals=tenant_app
+pinot.broker.access.control.principals.tenant_app.password=verysecret
+pinot.broker.access.control.principals.tenant_app.tables=events
+pinot.broker.access.control.principals.tenant_app.events.rls=tenantId='tenant_123'
+```
+
+If your application needs to derive filters dynamically at request time, you can still enforce tenant filtering in the application layer that sits between the user and the Pinot broker. In that model, your application backend should:
 
 1. Authenticate the user and determine their `tenantId`.
 2. Inject `AND tenantId = '<tenantId>'` into every SQL query before sending it to the Pinot broker.


### PR DESCRIPTION
## Summary
- correct the broker Basic Auth RLS key format for apache/pinot#16043
- fix the matching example in security-hardening
- update the multi-tenant analytics playbook to reflect built-in broker-side RLS support

## Validation
- python3 scripts/validate-docs.py --changed-only=<(printf '%s\\n' operate-pinot/access-control.md operate-pinot/security-hardening.md playbooks/multi-tenant-analytics.md)\n- git diff --check