### PR TITLE
docs: refresh upsert snapshot and preload config docs

### DIFF
--- a/build-with-pinot/ingestion/upsert-and-dedup/dedup.md
+++ b/build-with-pinot/ingestion/upsert-and-dedup/dedup.md
@@ -90,7 +90,7 @@ Server stores the existing primary keys in dedup metadata map kept on JVM heap. 
 
 ## Enable preload for faster server restarts
 
-When ingesting new records, the server has to read the metadata map to check for duplicates. But when server restarts, the documents in existing segments are all unique as ensured by the dedup logic during real-time ingestion. So we can do write-only to bootstrap the metadata map faster.&#x20;
+When ingesting new records, the server has to read the metadata map to check for duplicates. But when server restarts, the documents in existing segments are all unique as ensured by the dedup logic during real-time ingestion. So we can do write-only to bootstrap the metadata map faster. Set `preload` to `ENABLE` to turn this on.&#x20;
 
 ```json
 { 
@@ -100,7 +100,7 @@ When ingesting new records, the server has to read the metadata map to check for
         "hashFunction": "NONE",
         "dedupTimeColumn": "mtime",
         "metadataTTL": 30000,
-        "enablePreload": true
+        "preload": "ENABLE"
    }, 
  ...
 }

--- a/build-with-pinot/ingestion/upsert-and-dedup/segment-compaction-on-upserts.md
+++ b/build-with-pinot/ingestion/upsert-and-dedup/segment-compaction-on-upserts.md
@@ -37,7 +37,7 @@ To compact segments on upserts, complete the following steps:
 * `invalidRecordsThresholdCount` (Optional) Limits the older records allowed in the completed segment by record count. In the example above, if the segment contains more than 100K records, it may be selected for compaction.
 * `tableMaxNumTasks` (Optional) Limits the number of tasks allowed to be scheduled.
 * `validDocIdsType` (Optional) Specifies the source of validDocIds to fetch when running the data compaction. The valid types are `SNAPSHOT`, `IN_MEMORY`, `IN_MEMORY_WITH_DELETE`
-  * `SNAPSHOT`: Default validDocIds type. This indicates that the validDocIds bitmap is loaded from the snapshot from the Pinot segment. UpsertConfig's `enableSnapshot` must be enabled for this type.
+  * `SNAPSHOT`: Default validDocIds type. This indicates that the validDocIds bitmap is loaded from the snapshot from the Pinot segment. `upsertConfig.snapshot` must not be `DISABLE` for this type.
   * `IN_MEMORY`: This indicates that the validDocIds bitmap is loaded from the real-time server's in-memory.&#x20;
   * `IN_MEMORY_WITH_DELETE`: This indicates that the validDocIds bitmap is read from the real-time server's in-memory. The valid document ids here does take account into the deleted records. UpsertConfig's `deleteRecordColumn` must be provided for this type.
 

--- a/build-with-pinot/ingestion/upsert-and-dedup/upsert.md
+++ b/build-with-pinot/ingestion/upsert-and-dedup/upsert.md
@@ -579,7 +579,7 @@ Under the hood, it uses the validDocIds snapshots to identify the valid docs and
 The feature also requires you to specify `pinot.server.instance.max.segment.preload.threads: N` in the server config where N should be replaced with the number of threads that should be used for preload. It's 0 by default to disable the preloading feature.
 
 {% hint style="warning" %}
-A bug was introduced in v1.2.0 that when enablePreload and enableSnapshot flags are set to true but max.segment.preload.threads is left as 0, the preloading mechanism is still enabled but segments fail to get loaded as there is no threads for preloading. This was fixed in newer versions, but for v1.2.0, if enablePreload and enableSnapshot are set to true, remember to set max.segment.preload.threads to a positive value as well. Server restart is needed to get max.segment.preload.threads config change into effect.
+A bug was introduced in v1.2.0 that when snapshot and preload recovery are enabled but `max.segment.preload.threads` is left as `0`, the preloading mechanism is still enabled but segments fail to load because there are no threads for preloading. This was fixed in newer versions, but for v1.2.0, remember to set `max.segment.preload.threads` to a positive value as well. Server restart is needed for the config change to take effect.
 {% endhint %}
 
 #### Enable commit time compaction for storage optimization

--- a/operate-pinot/upsert-compact-merge-task.md
+++ b/operate-pinot/upsert-compact-merge-task.md
@@ -73,7 +73,7 @@ The task uses a safe two-phase approach for segment management:
 1. **Phase 1**: Upload new merged segments without immediately deleting the original segments
 2. **Phase 2**: Post one segment commit cycle when validDocIDSnapshot is updated, identify original segments with `validDocIDCount = 0` and delete them
 
-This approach leverages ZooKeeper metadata and `enableSnapshot` runs to safely clean up old segments while avoiding data inconsistencies.
+This approach leverages ZooKeeper metadata and snapshot-enabled commit cycles to safely clean up old segments while avoiding data inconsistencies.
 
 #### Implementation details
 
@@ -87,7 +87,7 @@ This approach leverages ZooKeeper metadata and `enableSnapshot` runs to safely c
 
 **Partition constraints**: All segments selected for merging must belong to the same partition. The task validates this constraint before proceeding with the merge operation.
 
-**validDocIds snapshot requirement**: The task requires validDocIds to be available from the servers hosting the segments. This depends on the `enableSnapshot` configuration being active.
+**validDocIds snapshot requirement**: The task requires validDocIds to be available from the servers hosting the segments. This depends on `upsertConfig.snapshot` not being set to `DISABLE`.
 
 ### Configuration
 
@@ -112,12 +112,12 @@ This approach leverages ZooKeeper metadata and `enableSnapshot` runs to safely c
 }
 ```
 
-3. Ensure your upsert table has snapshot enabled:
+3. Ensure your upsert table has snapshot recovery enabled:
 
 ```json
 "upsertConfig": {
     "mode": "FULL", // or "PARTIAL"
-    "enableSnapshot": true
+    "snapshot": "ENABLE"
 }
 ```
 
@@ -143,7 +143,7 @@ controller.task.frequencyPeriod=1h
 ### Prerequisites
 
 * **Pinot version**: Requires Pinot version 1.3.0 or later
-* **Upsert enabled**: Table must have upsert configuration with `enableSnapshot: true`
+* **Upsert enabled**: Table must have upsert configuration with snapshot recovery enabled. Set `snapshot` to `ENABLE`, or leave it at `DEFAULT` only if the instance-level default enables snapshots.
 * **Completed segments**: Task only operates on completed (non-consuming) segments with validDocIds available
 * **Same partition**: All segments being merged must belong to the same partition to maintain upsert consistency
 * **Minion cluster**: At least one Pinot Minion must be running and accessible to the controller
@@ -198,14 +198,14 @@ Monitor task execution through the following methods:
 
 **Task not generating**:
 
-* Verify `enableSnapshot: true` in upsert config
+* Verify `snapshot` is not set to `DISABLE` in upsert config
 * Check that segments meet the selection criteria (small enough and old enough based on `bufferTimePeriod`)
 * Ensure completed segments exist for the table with validDocIds available
 * Verify table configuration passes validation (upsert enabled, correct table type)
 
 **Segments not being cleaned up**:
 
-* Verify `enableSnapshot` is running between task executions
+* Verify snapshot recovery remains enabled between task executions
 * Check ZooKeeper metadata for merge timestamps
 * Original segments should be cleaned up in subsequent task runs when validDocIDCount = 0
 * Ensure the two-phase cleanup process is completing properly
@@ -234,7 +234,7 @@ Monitor task execution through the following methods:
 ### Limitations
 
 * Only supports upsert-enabled REALTIME tables
-* Requires `enableSnapshot: true` in upsert configuration
+* Requires `upsertConfig.snapshot` not to be `DISABLE`
 * Cannot merge segments across different partitions
 * Original segments are not immediately deleted (cleaned up in subsequent runs)
 * Resource-intensive operation that should be scheduled appropriately

--- a/operate-pinot/upsert-merge-compact-task.md
+++ b/operate-pinot/upsert-merge-compact-task.md
@@ -63,7 +63,7 @@ The task uses a safe two-phase approach for segment management:
 1. **Phase 1**: Upload new merged segments without immediately deleting the original segments
 2. **Phase 2**: Post one segment commit cycle when validDocIDSnapshot is updated, identify original segments with `validDocIDCount = 0` and delete them
 
-This approach leverages ZooKeeper metadata and `enableSnapshot` runs to safely clean up old segments while avoiding data inconsistencies.
+This approach leverages ZooKeeper metadata and snapshot-enabled commit cycles to safely clean up old segments while avoiding data inconsistencies.
 
 ### Implementation details
 
@@ -77,7 +77,7 @@ This approach leverages ZooKeeper metadata and `enableSnapshot` runs to safely c
 
 **Partition constraints**: All segments selected for merging must belong to the same partition. The task validates this constraint before proceeding with the merge operation.
 
-**validDocIds snapshot requirement**: The task requires validDocIds to be available from the servers hosting the segments. This depends on the `enableSnapshot` configuration being active.
+**validDocIds snapshot requirement**: The task requires validDocIds to be available from the servers hosting the segments. This depends on `upsertConfig.snapshot` not being set to `DISABLE`.
 
 ## Configuration
 
@@ -103,12 +103,12 @@ This approach leverages ZooKeeper metadata and `enableSnapshot` runs to safely c
 }
 ```
 
-3. Ensure your upsert table has snapshot enabled:
+3. Ensure your upsert table has snapshot recovery enabled:
 
 ```json
 "upsertConfig": {
     "mode": "FULL", // or "PARTIAL"
-    "enableSnapshot": true
+    "snapshot": "ENABLE"
 }
 ```
 
@@ -134,7 +134,7 @@ controller.task.frequencyPeriod=1h
 ## Prerequisites
 
 - **Pinot version**: Requires Pinot version 1.3.0 or later
-- **Upsert enabled**: Table must have upsert configuration with `enableSnapshot: true`
+- **Upsert enabled**: Table must have upsert configuration with snapshot recovery enabled. Set `snapshot` to `ENABLE`, or leave it at `DEFAULT` only if the instance-level default enables snapshots.
 - **Completed segments**: Task only operates on completed (non-consuming) segments with validDocIds available
 - **Same partition**: All segments being merged must belong to the same partition to maintain upsert consistency
 - **Minion cluster**: At least one Pinot Minion must be running and accessible to the controller
@@ -183,13 +183,13 @@ Monitor task execution through the following methods:
 ### Common Issues
 
 **Task not generating**:
-- Verify `enableSnapshot: true` in upsert config
+- Verify `snapshot` is not set to `DISABLE` in upsert config
 - Check that segments meet the selection criteria (small enough and old enough based on `bufferTimePeriod`)
 - Ensure completed segments exist for the table with validDocIds available
 - Verify table configuration passes validation (upsert enabled, correct table type)
 
 **Segments not being cleaned up**:
-- Verify `enableSnapshot` is running between task executions
+- Verify snapshot recovery remains enabled between task executions
 - Check ZooKeeper metadata for merge timestamps
 - Original segments should be cleaned up in subsequent task runs when validDocIDCount = 0
 - Ensure the two-phase cleanup process is completing properly
@@ -215,7 +215,7 @@ Monitor task execution through the following methods:
 ## Limitations
 
 - Only supports upsert-enabled REALTIME tables
-- Requires `enableSnapshot: true` in upsert configuration
+- Requires `upsertConfig.snapshot` not to be `DISABLE`
 - Cannot merge segments across different partitions
 - Original segments are not immediately deleted (cleaned up in subsequent runs)
 - Resource-intensive operation that should be scheduled appropriately


### PR DESCRIPTION
## Summary
- replace stale `enableSnapshot` and `enablePreload` usage in the upsert, dedup, and upsert compact-merge docs
- align the task docs with the `Enablement`-based `snapshot` / `preload` config surface introduced by `apache/pinot#15528`

## Source
- closes the docs gap for `apache/pinot#15528`

## Validation
- `python3 scripts/validate-docs.py --changed-only=<(printf '%s\n' build-with-pinot/ingestion/upsert-and-dedup/dedup.md build-with-pinot/ingestion/upsert-and-dedup/upsert.md build-with-pinot/ingestion/upsert-and-dedup/segment-compaction-on-upserts.md operate-pinot/upsert-compact-merge-task.md operate-pinot/upsert-merge-compact-task.md)`
- `git diff --check`
