### PR TITLE
docs: cover funnel duration and event-eval functions

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -242,6 +242,7 @@
   * [DISTINCTCOUNTRAWHLL](functions/aggregation/distinctcountrawhll.md)
   * [DISTINCTCOUNTRAWTHETASKETCH](functions/aggregation/distinctcountrawthetasketch.md)
   * [DISTINCTCOUNTULL](functions/aggregation/distinctcountull.md)
+  * [FUNNELEVENTSFUNCTIONEVAL](functions/aggregation/funneleventsfunctioneval.md)
   * [FUNNELSTEPDURATIONSTATS](functions/aggregation/funnelstepdurationstats.md)
   * [maxString](functions/aggregation/maxstring.md)
   * [minmaxrange](functions/aggregation/minmaxrange.md)

--- a/build-with-pinot/querying-and-sql/function-index.md
+++ b/build-with-pinot/querying-and-sql/function-index.md
@@ -55,7 +55,8 @@ For full details, see [Aggregation Functions](../../functions/aggregation/README
 | [`FUNNELCOUNT`](../../functions/funnel/funnelcount.md) | `FUNNELCOUNT(stepCol, corCol, settings, step1, step2, ...)` | LONG[] | Funnel step counts | Both |
 | [`FUNNELMAXSTEP`](../../functions/funnel/funnelmaxstep.md) | `FUNNELMAXSTEP(stepCol, corCol, settings, step1, step2, ...)` | INT | Maximum funnel step reached | Both |
 | [`FUNNELCOMPLETECOUNT`](../../functions/funnel/funnelcompletecount.md) | `FUNNELCOMPLETECOUNT(stepCol, corCol, settings, step1, step2, ...)` | INT | Count of completed funnels | Both |
-| [`FUNNELSTEPDURATIONSTATS`](../../functions/aggregation/funnelstepdurationstats.md) | `FUNNELSTEPDURATIONSTATS(stepCol, corCol, tsCol, settings, step1, step2, ...)` | STRING | Step duration statistics | Both |
+| [`FUNNELSTEPDURATIONSTATS`](../../functions/aggregation/funnelstepdurationstats.md) | `FUNNELSTEPDURATIONSTATS(timestampExpression, windowSize, numberSteps, step1, ..., 'durationFunctions=...')` | DOUBLE[] | Step-to-step duration statistics for completed funnel runs | Both |
+| [`FUNNELEVENTSFUNCTIONEVAL`](../../functions/aggregation/funneleventsfunctioneval.md) | `FUNNELEVENTSFUNCTIONEVAL(timestampExpression, windowSize, numberSteps, step1, ..., extraFieldCount, extraField1, ...)` | STRING[] | Extra-field values from matched funnel events | Both |
 | [`DISTINCTSUM`](../../functions/aggregation/distinctsum.md) | `DISTINCTSUM(col)` | DOUBLE | Sum of distinct values | Both |
 | [`DISTINCTAVG`](../../functions/aggregation/distinctavg.md) | `DISTINCTAVG(col)` | DOUBLE | Average of distinct values | Both |
 | [`SUMPRECISION`](../../functions/aggregation/sumprecision.md) | `SUMPRECISION(col [, precision])` | STRING | High-precision sum using BigDecimal | Both |

--- a/functions/aggregation/README.md
+++ b/functions/aggregation/README.md
@@ -135,8 +135,9 @@ FROM MyTable WHERE COL3 > 50
 | --- | --- |
 | [DISTINCT_COUNT_OFF_HEAP](distinct_count_off_heap.md) | [DISTINCTCOUNTHLLPLUS](distinctcounthll-1.md) |
 | [DISTINCTCOUNTRAWHLL](distinctcountrawhll.md) | [DISTINCTCOUNTRAWTHETASKETCH](distinctcountrawthetasketch.md) |
-| [DISTINCTCOUNTULL](distinctcountull.md) | [FUNNELSTEPDURATIONSTATS](funnelstepdurationstats.md) |
-| [maxString](maxstring.md) | [minmaxrange](minmaxrange.md) |
-| [minString](minstring.md) | [percentilekllmv](percentilekllmv.md) |
-| [percentilerawkll](percentilerawkll.md) | [percentilerawkllmv](percentilerawkllmv.md) |
-| [SEGMENTPARTITIONEDDISTINCTCOUNT](segmentpartitioneddistinctcount.md) | [VALUEIN](valuein.md) |
+| [DISTINCTCOUNTULL](distinctcountull.md) | [FUNNELEVENTSFUNCTIONEVAL](funneleventsfunctioneval.md) |
+| [FUNNELSTEPDURATIONSTATS](funnelstepdurationstats.md) | [maxString](maxstring.md) |
+| [minmaxrange](minmaxrange.md) | [minString](minstring.md) |
+| [percentilekllmv](percentilekllmv.md) | [percentilerawkll](percentilerawkll.md) |
+| [percentilerawkllmv](percentilerawkllmv.md) | [SEGMENTPARTITIONEDDISTINCTCOUNT](segmentpartitioneddistinctcount.md) |
+| [VALUEIN](valuein.md) |  |

--- a/functions/aggregation/funneleventsfunctioneval.md
+++ b/functions/aggregation/funneleventsfunctioneval.md
@@ -1,0 +1,69 @@
+---
+description: This section contains reference documentation for the FUNNELEVENTSFUNCTIONEVAL function.
+---
+
+# FUNNELEVENTSFUNCTIONEVAL
+
+Evaluates completed window funnel runs and returns selected extra-field values for each matched step.
+
+## Signature
+
+> `FUNNELEVENTSFUNCTIONEVAL(timestampExpression, windowSize, numberSteps, stepExpression1, ..., stepExpressionN, extraFieldCount, extraFieldExpression1, ..., extraFieldExpressionM [, 'mode=...' | 'strict_order' | 'strict_deduplication' | 'strict_increase' | 'keep_all' | 'maxStepDuration=...'])`
+
+## Parameters
+
+| Parameter | Description |
+| --------- | ----------- |
+| `timestampExpression` | Expression that evaluates to the event timestamp. Pinot accepts `TIMESTAMP` or `LONG` values. |
+| `windowSize` | Positive time window literal. Funnel steps must complete within this window. |
+| `numberSteps` | Number of funnel steps. This must match the number of step expressions that follow. |
+| `stepExpression1 ... stepExpressionN` | Boolean expressions that define each funnel step in order. |
+| `extraFieldCount` | Number of extra-field expressions to capture for each matched step. This must match the number of extra-field expressions that follow. |
+| `extraFieldExpression1 ... extraFieldExpressionM` | Expressions whose values should be returned for each matched step. Pinot converts the returned values to strings. |
+| Optional trailing arguments | Optional funnel controls shared with the other window funnel functions, including `mode=...`, `strict_order`, `strict_deduplication`, `strict_increase`, `keep_all`, and `maxStepDuration=...`. |
+
+## Returns
+
+Returns a `STRING[]`.
+
+The first element is a header string:
+
+* the first number is the number of matched funnel runs
+* each following number is the count of flattened extra-field values emitted for that matched run
+
+The remaining array elements are the requested extra-field values flattened in matched step order for each completed funnel run.
+
+If Pinot finds no completed funnel run, the result contains only `0`.
+
+## Example
+
+```sql
+SELECT
+  userId,
+  funnelEventsFunctionEval(
+    timestampCol,
+    '1000',
+    4,
+    url = '/product/search',
+    url = '/cart/add',
+    url = '/checkout/start',
+    url = '/checkout/confirmation',
+    3,
+    timestampCol,
+    userId,
+    url
+  ) AS funnelEvents
+FROM events
+GROUP BY userId
+ORDER BY userId
+```
+
+For a single matched four-step funnel, Pinot's integration tests return a `STRING[]` shaped like:
+
+```text
+["1, 12", "1000", "user00", "/product/search", "1010", "user00", "/cart/add", ...]
+```
+
+Here `1, 12` means one matched funnel run and twelve flattened extra-field values after the header (`4 steps * 3 extra fields`).
+
+For more information on the related funnel functions, see [Funnel Analysis Functions](../funnel/README.md).

--- a/functions/aggregation/funnelstepdurationstats.md
+++ b/functions/aggregation/funnelstepdurationstats.md
@@ -4,39 +4,56 @@ description: This section contains reference documentation for the FUNNELSTEPDUR
 
 # FUNNELSTEPDURATIONSTATS
 
-Calculates duration statistics between funnel steps. Returns an array of computed statistics (such as average, median, min, max, count, or percentiles) for the time elapsed between consecutive funnel steps. This function is part of the funnel analysis family and requires a windowed funnel configuration.
+Computes step-to-step duration statistics for window funnel matches.
 
 ## Signature
 
-> FUNNELSTEPDURATIONSTATS(stepColumn, correlationColumn, timestampColumn, 'settings', step1, step2, ...)
+> `FUNNELSTEPDURATIONSTATS(timestampExpression, windowSize, numberSteps, stepExpression1, ..., stepExpressionN, 'durationFunctions=...' [, 'mode=...' | 'strict_order' | 'strict_deduplication' | 'strict_increase' | 'keep_all' | 'maxStepDuration=...'])`
 
-Parameters:
+## Parameters
 
 | Parameter | Description |
 | --------- | ----------- |
-| `stepColumn` | Column used to identify which step an event belongs to |
-| `correlationColumn` | Column used to correlate events from the same entity (e.g., user ID) |
-| `timestampColumn` | Column containing the event timestamp |
-| `settings` | Configuration string including `DURATIONFUNCTIONS` (comma-separated: AVG, MEDIAN, MIN, MAX, COUNT, PERCENTILEx) |
-| `step1, step2, ...` | Boolean expressions defining each funnel step |
+| `timestampExpression` | Expression that evaluates to the event timestamp. Pinot accepts `TIMESTAMP` or `LONG` values. |
+| `windowSize` | Positive time window literal. Funnel steps must complete within this window. |
+| `numberSteps` | Number of funnel steps. This must match the number of step expressions that follow. |
+| `stepExpression1 ... stepExpressionN` | Boolean expressions that define each funnel step in order. |
+| `'durationFunctions=...'` | Required config string listing the statistics to emit. Supported values are `COUNT`, `AVG`, `MIN`, `MEDIAN`, `MAX`, and `PERCENTILE<value>` such as `PERCENTILE95`. The output preserves the requested function order. |
+| Optional trailing arguments | Optional funnel controls shared with the other window funnel functions, including `mode=...`, `strict_order`, `strict_deduplication`, `strict_increase`, `keep_all`, and `maxStepDuration=...`. |
 
-## Usage Examples
+## Returns
+
+Returns a `DOUBLE[]` flattened in step order.
+
+For each step, Pinot emits the requested statistics in the same order they were listed in `durationFunctions`. If `COUNT` is requested, Pinot includes it for every step. Duration metrics on the final step use Pinot's double null placeholder because there is no next step to measure against.
+
+If `COUNT` is omitted and no funnel completes, Pinot returns an empty array.
+
+## Example
 
 ```sql
-select FUNNELSTEPDURATIONSTATS(
-  stepCol,
-  visitorId,
-  ts,
-  'DURATIONFUNCTIONS(AVG,MEDIAN,MAX)',
-  url = '/home',
-  url = '/product',
-  url = '/checkout'
-) AS durationStats
-from eventTable
+SELECT
+  userId,
+  funnelStepDurationStats(
+    timestampCol,
+    '1000',
+    4,
+    url = '/product/search',
+    url = '/cart/add',
+    url = '/checkout/start',
+    url = '/checkout/confirmation',
+    'durationFunctions=count,avg,min,median,percentile95,max'
+  ) AS statsArray
+FROM events
+GROUP BY userId
+HAVING arrayLength(statsArray) > 0
+ORDER BY userId
 ```
 
-| durationStats              |
-| -------------------------- |
-| [120.5, 100.0, 350.0, ...] |
+In Pinot's integration tests, a completed four-step funnel with 10-millisecond gaps between steps returns duration stats such as:
 
-For more information on funnel analysis, see [Funnel Functions](../funnel/).
+* step 0 -> step 1: `count=1`, `avg=10`, `min=10`, `median=10`, `percentile95=10`, `max=10`
+* step 1 -> step 2: the same six values
+* step 2 -> step 3: the same six values
+
+For more information on the related funnel functions, see [Funnel Analysis Functions](../funnel/README.md).

--- a/functions/funnel/README.md
+++ b/functions/funnel/README.md
@@ -43,3 +43,5 @@ This function evaluates funnel steps and returns the distinct correlated counts 
 ## Additional Reference Pages
 
 - [funnelmaxstep.md](funnelmaxstep.md)
+- [FUNNELSTEPDURATIONSTATS](../aggregation/funnelstepdurationstats.md)
+- [FUNNELEVENTSFUNCTIONEVAL](../aggregation/funneleventsfunctioneval.md)


### PR DESCRIPTION
## Summary
- correct the `FUNNELSTEPDURATIONSTATS` signature, return type, and output semantics
- add the missing `FUNNELEVENTSFUNCTIONEVAL` function reference
- wire both functions into the aggregation index, funnel references, and SUMMARY

## Source
- closes the docs gap for `apache/pinot#14941`

## Validation
- `python3 scripts/validate-docs.py --changed-only=<(printf '%s\n' functions/aggregation/funnelstepdurationstats.md functions/aggregation/funneleventsfunctioneval.md functions/aggregation/README.md functions/funnel/README.md build-with-pinot/querying-and-sql/function-index.md SUMMARY.md)`
- `git diff --check`
