### PR TITLE
docs: document pauseless segment deletion API (#15299)

### DIFF
--- a/operate-pinot/pauseless-consumption.md
+++ b/operate-pinot/pauseless-consumption.md
@@ -198,7 +198,7 @@ If a segment remains in `COMMITTING` state for an extended period, the server ma
 Segments in `ERROR` state with no completed replica on any server indicate a non-recoverable failure. If `disasterRecoveryMode` is set to `DEFAULT` for a dedup or upsert table, these segments will not be automatically recovered. Options include:
 
 1. Set `disasterRecoveryMode` to `ALWAYS` to enable automatic reingestion (with the caveat of temporary metadata inconsistency for dedup/upsert tables).
-2. Manually delete the affected segments and allow Pinot to re-create them.
+2. Pause ingestion for the table and use `DELETE /deleteSegmentsFromSequenceNum/{tableNameWithType}` to remove the affected segment and every later segment in the same partition. Start with `dryRun=true` to inspect the deletion plan, then rerun with `dryRun=false` after you confirm the target segments. Pinot recreates the deleted range from the stream when consumption resumes.
 
 ### Slow replicas and segment download
 

--- a/reference/api-reference/controller-api.md
+++ b/reference/api-reference/controller-api.md
@@ -16,7 +16,7 @@ The controller exposes the administrative API surface for cluster, schema, table
 | Schema | `GET /schemas`, `GET /schemas/{schemaName}`, `POST /schemas`, `PUT /schemas/{schemaName}`, `DELETE /schemas/{schemaName}` |
 | Table | `GET /tables`, `POST /tables`, `PUT /tables/{tableName}`, `DELETE /tables/{tableName}`, `POST /tableConfigs/validate` |
 | Logical tables | `GET /logicalTables`, `POST /logicalTables`, `PUT /logicalTables/{tableName}`, `DELETE /logicalTables/{tableName}` |
-| Segments | `GET /segments/{tableName}/invalidPartitionMetadata`, `POST /segments/{tableName}/reload`, `POST /segments/{tableNameWithType}/uploadFromServerToDeepstore`, `GET /segments/segmentReloadStatus/{jobId}`, `GET /segments/{tableNameWithType}/needReload` |
+| Segments | `GET /segments/{tableName}/invalidPartitionMetadata`, `POST /segments/{tableName}/reload`, `POST /segments/{tableNameWithType}/uploadFromServerToDeepstore`, `DELETE /deleteSegmentsFromSequenceNum/{tableNameWithType}`, `GET /segments/segmentReloadStatus/{jobId}`, `GET /segments/{tableNameWithType}/needReload` |
 | Tenant and instance management | `GET /tenants`, `GET /tenants/{tenantName}`, `GET /instances`, `POST /instances` |
 
 ## Swagger UI
@@ -590,6 +590,57 @@ curl -X POST "http://localhost:9000/segments/myTable_REALTIME/uploadFromServerTo
 ```
 
 If the table is not realtime, Pinot returns `400 Bad Request`. If named segments are missing from ZooKeeper metadata, Pinot skips them and only queues the segments it can resolve. When no segments remain after resolution, Pinot returns a success response saying there are no segments to upload.
+
+### DELETE /deleteSegmentsFromSequenceNum/\{tableNameWithType\}
+
+Delete a contiguous tail of LLC segments per partition for a pauseless realtime table. For each input segment, Pinot finds that segment's partition and deletes every segment in the same partition whose sequence number is greater than or equal to the oldest supplied segment for that partition.
+
+Use this endpoint during manual pauseless recovery when a failed segment build or upload left later segments inconsistent and you need Pinot to recreate them from the stream.
+
+| Query parameter | Type | Meaning |
+| --- | --- | --- |
+| `segments` | string list | Required LLC segment names. Pinot treats the oldest supplied segment in each partition as the deletion starting point. |
+| `dryRun` | boolean | When `true`, Pinot returns the per-partition deletion plan without deleting anything. When `false`, Pinot performs the deletion. |
+| `force` | boolean | When `false`, Pinot requires the table to be realtime, pauseless-enabled, and currently paused. When `true`, Pinot bypasses the pauseless-enabled and paused-state checks. |
+
+**Request**
+
+Preview the deletion plan first:
+
+```bash
+curl -X DELETE "http://localhost:9000/deleteSegmentsFromSequenceNum/myTable_REALTIME?segments=myTable__0__17__20250320T1530Z&dryRun=true" \
+  -H "accept: application/json"
+```
+
+Apply the deletion after you have paused ingestion and verified the target partitions:
+
+```bash
+curl -X DELETE "http://localhost:9000/deleteSegmentsFromSequenceNum/myTable_REALTIME?segments=myTable__0__17__20250320T1530Z&dryRun=false" \
+  -H "accept: application/json"
+```
+
+**Response**
+
+```json
+{
+  "tableName": "myTable_REALTIME",
+  "dryRun": true,
+  "partitions": {
+    "0": {
+      "segmentsToDelete": [
+        "myTable__0__17__20250320T1530Z",
+        "myTable__0__18__20250320T1540Z"
+      ],
+      "oldestSegment": "myTable__0__17__20250320T1530Z",
+      "latestSegment": "myTable__0__18__20250320T1540Z",
+      "segmentCount": 2
+    }
+  },
+  "message": "Dry run completed. Segments identified for deletion but not actually deleted."
+}
+```
+
+Pinot skips segment names that are no longer present in the ideal state. For operational safety, run the endpoint once with `dryRun=true` and only rerun with `dryRun=false` after you verify the per-partition segment list.
 
 ### GET /segments/segmentReloadStatus/\{jobId\}
 


### PR DESCRIPTION
## Summary
- document the controller endpoint that deletes pauseless realtime segments from a sequence boundary
- show the dry-run and execute flows in the controller API reference
- replace the vague manual-delete guidance in the pauseless runbook with the actual recovery API

## Evidence
- apache/pinot#15299 introduced the pauseless segment deletion endpoint
- current Pinot source exposes `DELETE /deleteSegmentsFromSequenceNum/{tableNameWithType}` and returns a per-partition deletion plan

## Validation
- python3 scripts/validate-docs.py --changed-only=<(printf "%s\n" reference/api-reference/controller-api.md operate-pinot/pauseless-consumption.md)
- git diff --check