### PR TITLE
docs: cover pauseless segment download timeout (#15316)

### DIFF
--- a/operate-pinot/pauseless-consumption.md
+++ b/operate-pinot/pauseless-consumption.md
@@ -100,6 +100,12 @@ Pauseless consumption supports the same segment flush thresholds as standard rea
 
 Pinot 1.4.0 also added support for a size-based flush threshold that works with pauseless consumption. When `realtime.segment.flush.threshold.segment.size` is configured, the `FlushThresholdUpdater` updates statistics from committing segments and computes the threshold for new consuming segments. This allows pauseless tables to automatically tune their flush thresholds based on actual segment sizes.
 
+### Segment download timeout
+
+Non-committing replicas wait for the committing segment to become downloadable from deep store or from a peer server. Use `realtime.segment.pauseless.download.timeoutSeconds` in the stream config map to control how long Pinot waits before timing out that download attempt. If you do not set the property, Pinot defaults to 600 seconds.
+
+Older table configs may still use `segmentDownloadTimeoutMinutes`. Pinot continues to read that key as a fallback, but new configs should use `realtime.segment.pauseless.download.timeoutSeconds`.
+
 ## Disaster recovery
 
 Pauseless consumption introduces new failure scenarios because segments can be marked `ONLINE` in the ideal state before they have been built and uploaded. If the committing server crashes during the build or upload phase, and no other replica has the segment, the segment enters an `ERROR` state with no data on disk.
@@ -204,7 +210,7 @@ Segments in `ERROR` state with no completed replica on any server indicate a non
 
 Non-committing replicas rely on downloading the segment from the committing server or deep store. Pauseless consumption implements a waited download mechanism that repeatedly checks for the download URL in ZK metadata and attempts peer download. If downloads are consistently slow, consider:
 
-* Increasing the download timeout.
+* Increasing `realtime.segment.pauseless.download.timeoutSeconds` in the stream config map.
 * Ensuring `peerSegmentDownloadScheme` is configured correctly.
 * Verifying network connectivity between servers.
 

--- a/reference/configuration-reference/plugin-reference.md
+++ b/reference/configuration-reference/plugin-reference.md
@@ -46,6 +46,7 @@ This section covers the configuration side of each plugin family: which implemen
 | realtime.segment.flush.threshold.rows | Row count based flush threshold for realtime segments. If this value is set to 0, then the consumers adjust the number of rows consumed by a partition so the completed segment is the correct size (unless threshold.time is reached first) |
 | realtime.segment.flush.autotune.initialRows | Initial number of rows to use for `SegmentSizeBasedFlushThresholdUpdater` . This threshold updater is used by the controller to compute the new segment's flush threshold based on the previous segment's size. Warning: This flush threshold updater is used only when `realtime.segment.flush.threshold.rows` is set to `<=0` . Otherwise, the `DefaultFlushThresholdUpdater` is used. |
 | realtime.segment.commit.timeoutSeconds | Time threshold that controller will wait for the segment to be built by the server |
+| realtime.segment.pauseless.download.timeoutSeconds | For pauseless consumption, the time in seconds that a replica waits for a committed segment to become downloadable from deep store or a peer server before timing out. Default: `600` seconds. Pinot prefers this key over the older `segmentDownloadTimeoutMinutes` setting. |
 
 ### Kafka 3.x / 4.x
 


### PR DESCRIPTION
## Summary
- document the pauseless segment download timeout stream config in the plugin reference
- add the timeout and fallback behavior to the pauseless consumption runbook
- point operators to the new seconds-based key instead of the deprecated minutes-based setting

## Evidence
- apache/pinot#15316 introduced `realtime.segment.pauseless.download.timeoutSeconds`
- current Pinot server code prefers the seconds-based key, falls back to `segmentDownloadTimeoutMinutes`, and defaults to 600 seconds

## Validation
- python3 scripts/validate-docs.py --changed-only=<(printf "%s\n" reference/configuration-reference/plugin-reference.md operate-pinot/pauseless-consumption.md)
- git diff --check