### PR TITLE
docs: cover partial upsert FORCE_OVERWRITE (#15107)

### DIFF
--- a/build-with-pinot/ingestion/upsert-and-dedup/upsert.md
+++ b/build-with-pinot/ingestion/upsert-and-dedup/upsert.md
@@ -137,15 +137,22 @@ Pinot supports the following partial upsert strategies:
 | IGNORE    | Ignore the new value, keep the existing value (v0.10.0+)                  |
 | MAX       | Keep the maximum value betwen the existing value and new value (v0.12.0+) |
 | MIN       | Keep the minimum value betwen the existing value and new value (v0.12.0+) |
+| FORCE_OVERWRITE | Always replace the existing value with the incoming value, including `null` (v1.4.0+) |
 
 {% hint style="info" %}
-With partial upsert, if the value is `null` in either the existing record or the new coming record, Pinot will ignore the upsert strategy and the `null` value:
+For partial upsert strategies other than `FORCE_OVERWRITE`, if the value is `null` in either the existing record or the incoming record, Pinot ignores the upsert strategy and keeps the non-null value:
 
 (`null`, _newValue_) -> _newValue_
 
 (_oldValue_, `null`) -> _oldValue_
 
 (`null`, `null`) -> `null`
+{% endhint %}
+
+Use `FORCE_OVERWRITE` when an incoming `null` should clear the previously stored value:
+
+(_oldValue_, `null`) -> `null`
+
 ### Post-Partial-Upsert Transforms (Derived Columns)
 
 When using partial upserts, you may have derived columns that need to be recomputed after the row is merged from the incoming record and the existing record. The `postPartialUpsertTransformConfigs` feature allows you to apply transformation functions to compute derived columns from the fully merged row.


### PR DESCRIPTION
## Summary
- add the missing `FORCE_OVERWRITE` partial upsert strategy to the upsert guide
- clarify that the usual null-skipping behavior does not apply to `FORCE_OVERWRITE`
- document the null-clearing behavior that motivated apache/pinot#15107

## Evidence
- apache/pinot#15107 added `FORCE_OVERWRITE` to `UpsertConfig.Strategy`
- Pinot's partial upsert tests show `FORCE_OVERWRITE` replaces the previous value even when the incoming value is `null`

## Validation
- python3 scripts/validate-docs.py --changed-only=<(printf "%s\n" build-with-pinot/ingestion/upsert-and-dedup/upsert.md)
- git diff --check