### PR TITLE
docs: add MSE broker thread gauge metric (#15189)

### DIFF
--- a/reference/configuration-reference/monitoring-metrics.md
+++ b/reference/configuration-reference/monitoring-metrics.md
@@ -78,6 +78,7 @@ Pinot provides metrics out of the box so that you can monitor every aspect of pe
 | --- | --- | --- |
 | UNHEALTHY_SERVERS | Number of unhealthy servers detected |  |
 | QUERY_QUOTA_CAPACITY_UTILIZATION_RATE | percentage of configured rate limit being used on each broker |  |
+| ESTIMATED_MSE_SERVER_THREADS | Estimated number of server query threads currently consumed by all running multi-stage queries on this broker. This gauge is emitted even when MSE query throttling is not configured, so it can be used as a standalone view of broker-side MSE workload. |  |
 | MAX_BURST_QPS |  |  |
 | QUERY_RATE_LIMIT_DISABLED | 1 if rate limit is enabled on broker, 0 otherwise |  |
 | REQUEST_SIZE | Query String length on each broker |  |


### PR DESCRIPTION
## Summary
- add the missing `ESTIMATED_MSE_SERVER_THREADS` broker gauge to the monitoring metrics reference
- describe it as a per-broker view of current multi-stage query server-thread usage

## Evidence
- apache/pinot#15189 added the broker gauge
- current Pinot code exports it as `pinot.broker.estimatedMseServerThreads` and integration tests verify the JMX metric

## Validation
- python3 scripts/validate-docs.py --changed-only=<(printf "%s\n" reference/configuration-reference/monitoring-metrics.md)
- git diff --check