### PR TITLE
docs: document groovy static analyzer configs

### DIFF
--- a/build-with-pinot/ingestion/ingestion-level-transformations.md
+++ b/build-with-pinot/ingestion/ingestion-level-transformations.md
@@ -43,6 +43,34 @@ Allowing executable Groovy in ingestion transformation can be a security vulnera
 
 If not set, Groovy for ingestion transformation is disabled by default.
 
+#### Groovy static analysis
+
+Pinot can also apply static analysis to Groovy scripts before compiling them. This is configured with cluster-level Groovy analyzer configs:
+
+- `pinot.groovy.all.static.analyzer`: default analyzer for both query-time and ingestion-time Groovy
+- `pinot.groovy.ingestion.static.analyzer`: ingestion-specific override used when Pinot validates Groovy in table configs
+- `pinot.groovy.query.static.analyzer`: query-specific override used when Pinot validates Groovy in broker queries
+
+If the ingestion-specific or query-specific config is not set, Pinot falls back to `pinot.groovy.all.static.analyzer`. If none of these cluster configs are set, Groovy static analysis is disabled.
+
+Each static analyzer config is a JSON object with these fields:
+
+- `allowedReceivers`: fully qualified receiver classes Groovy method calls can target
+- `allowedImports`: fully qualified imports allowed in the script
+- `allowedStaticImports`: fully qualified static imports allowed in the script
+- `disallowedMethodNames`: method names Pinot rejects even if the receiver is otherwise allowed
+- `methodDefinitionAllowed`: whether Groovy method definitions are allowed inside the script
+
+Static analysis does not enable Groovy by itself. You still need `controller.disable.ingestion.groovy=false` to use Groovy in ingestion transforms.
+
+Use the controller API to inspect and update these configs:
+
+- `GET /cluster/configs/groovy/staticAnalyzerConfig/default` returns Pinot's built-in sample config
+- `GET /cluster/configs/groovy/staticAnalyzerConfig` returns the cluster's current Groovy static analyzer config overrides
+- `POST /cluster/configs/groovy/staticAnalyzerConfig` updates one or more of the Groovy analyzer configs
+
+The full request and response examples for these endpoints are in the [controller API reference](../../reference/api-reference/controller-api.md#groovy-static-analysis-configs).
+
 ### Built-in Pinot functions
 
 All the functions defined in [this directory](https://github.com/apache/pinot/tree/02cb2d4970c71a2ea5b4c140a860fbf220e11bd3/pinot-common/src/main/java/org/apache/pinot/common/function/scalar) annotated with `@ScalarFunction` (for example, [toEpochSeconds](https://github.com/apache/pinot/blob/02cb2d4970c71a2ea5b4c140a860fbf220e11bd3/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/DateTimeFunctions.java#L78)) are supported ingestion transformation functions.

--- a/reference/api-reference/controller-api.md
+++ b/reference/api-reference/controller-api.md
@@ -10,7 +10,7 @@ The controller exposes the administrative API surface for cluster, schema, table
 
 | Family | Representative endpoints |
 | --- | --- |
-| Cluster | `GET /cluster/configs`, `POST /cluster/configs`, `DELETE /cluster/configs/{configName}`, `GET /cluster/info` |
+| Cluster | `GET /cluster/configs`, `POST /cluster/configs`, `DELETE /cluster/configs/{configName}`, `GET /cluster/configs/groovy/staticAnalyzerConfig`, `POST /cluster/configs/groovy/staticAnalyzerConfig`, `GET /cluster/configs/groovy/staticAnalyzerConfig/default`, `GET /cluster/info` |
 | Health and leadership | `GET /health`, `GET /leader/tables` |
 | Query validation | `POST /validateMultiStageQuery`, `POST /query/tableNames` |
 | Schema | `GET /schemas`, `GET /schemas/{schemaName}`, `POST /schemas`, `PUT /schemas/{schemaName}`, `DELETE /schemas/{schemaName}` |
@@ -170,6 +170,159 @@ curl -X DELETE "http://localhost:9000/cluster/configs/custom.cluster.prop"
 ```
 {
   "status": "Deleted cluster config: custom.cluster.prop"
+}
+```
+
+### Groovy static analysis configs
+
+Pinot stores Groovy static analysis settings as cluster configs. These configs are keyed by:
+
+- `pinot.groovy.all.static.analyzer`
+- `pinot.groovy.ingestion.static.analyzer`
+- `pinot.groovy.query.static.analyzer`
+
+The ingestion-specific and query-specific configs override `pinot.groovy.all.static.analyzer` for their respective contexts. `POST /cluster/configs/groovy/staticAnalyzerConfig` rejects any other top-level config key.
+
+Each config value is a JSON object with these fields:
+
+- `allowedReceivers`
+- `allowedImports`
+- `allowedStaticImports`
+- `disallowedMethodNames`
+- `methodDefinitionAllowed`
+
+### GET /cluster/configs/groovy/staticAnalyzerConfig
+
+Return the currently configured Groovy static analyzer configs, keyed by cluster config name.
+
+**Request**
+
+```bash
+curl -X GET "http://localhost:9000/cluster/configs/groovy/staticAnalyzerConfig" -H "accept: application/json"
+```
+
+**Response**
+
+```json
+{
+  "pinot.groovy.all.static.analyzer": {
+    "allowedReceivers": [
+      "java.lang.String",
+      "java.lang.Math",
+      "java.util.List",
+      "java.lang.Object",
+      "java.util.Map"
+    ],
+    "allowedImports": [
+      "java.lang.Math",
+      "java.util.List",
+      "java.lang.String",
+      "java.util.Map"
+    ],
+    "allowedStaticImports": [
+      "java.lang.Math",
+      "java.util.List",
+      "java.lang.String",
+      "java.util.Map"
+    ],
+    "disallowedMethodNames": [
+      "execute",
+      "invoke"
+    ],
+    "methodDefinitionAllowed": false
+  }
+}
+```
+
+### POST /cluster/configs/groovy/staticAnalyzerConfig
+
+Update one or more Groovy static analyzer configs. The request body is a map keyed by one or more of the three supported config names listed above.
+
+**Request**
+
+```bash
+curl -X POST "http://localhost:9000/cluster/configs/groovy/staticAnalyzerConfig" \
+  -H "accept: application/json" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "pinot.groovy.ingestion.static.analyzer": {
+      "allowedReceivers": [
+        "java.lang.String",
+        "java.lang.Math",
+        "java.util.List",
+        "java.lang.Object",
+        "java.util.Map"
+      ],
+      "allowedImports": [
+        "java.lang.Math",
+        "java.util.List",
+        "java.lang.String",
+        "java.util.Map"
+      ],
+      "allowedStaticImports": [
+        "java.lang.Math",
+        "java.util.List",
+        "java.lang.String",
+        "java.util.Map"
+      ],
+      "disallowedMethodNames": [
+        "execute",
+        "invoke"
+      ],
+      "methodDefinitionAllowed": false
+    }
+  }'
+```
+
+**Response**
+
+```json
+{
+  "status": "Updated Groovy Static Analyzer config."
+}
+```
+
+### GET /cluster/configs/groovy/staticAnalyzerConfig/default
+
+Return Pinot's built-in default Groovy static analyzer config. Use this endpoint to fetch a full sample payload before editing cluster overrides.
+
+**Request**
+
+```bash
+curl -X GET "http://localhost:9000/cluster/configs/groovy/staticAnalyzerConfig/default" \
+  -H "accept: application/json"
+```
+
+**Response**
+
+```json
+{
+  "pinot.groovy.all.static.analyzer": {
+    "allowedReceivers": [
+      "java.lang.String",
+      "java.lang.Math",
+      "java.util.List",
+      "java.lang.Object",
+      "java.util.Map"
+    ],
+    "allowedImports": [
+      "java.lang.Math",
+      "java.util.List",
+      "java.lang.String",
+      "java.util.Map"
+    ],
+    "allowedStaticImports": [
+      "java.lang.Math",
+      "java.util.List",
+      "java.lang.String",
+      "java.util.Map"
+    ],
+    "disallowedMethodNames": [
+      "execute",
+      "invoke"
+    ],
+    "methodDefinitionAllowed": false
+  }
 }
 ```
 


### PR DESCRIPTION
## Summary
- document Groovy static analyzer cluster configs and fallback behavior
- add controller API coverage for the Groovy static analyzer endpoints
- point the ingestion Groovy guide at the controller APIs for sample and override payloads

## Source
- apache/pinot#14844

## Validation
- python3 scripts/validate-docs.py --changed-only=<(printf '%s\\n' build-with-pinot/ingestion/ingestion-level-transformations.md reference/api-reference/controller-api.md)\n- git diff --check