### PR TITLE
docs: cover pauseless reingestion APIs

### DIFF
--- a/operate-pinot/pauseless-consumption.md
+++ b/operate-pinot/pauseless-consumption.md
@@ -120,9 +120,51 @@ When no server has the segment on disk, Pinot can recover by re-ingesting the da
 
 1. The `RealtimeSegmentValidationManager` detects an `ERROR` segment with no completed replica.
 2. The controller selects an alive server from the ideal state for that segment.
-3. The controller calls `POST /reingestSegment` on the selected server with the table name and segment name.
-4. The server re-consumes data from the stream for the offset range of the failed segment, builds the segment, and uploads it.
-5. The controller copies the segment to deep store, updates ZK metadata to `DONE`, and resets the segment to `ONLINE`.
+3. The controller calls `POST /reingestSegment/{segmentName}` on the selected server.
+4. The server re-consumes data for the failed LLC segment's offset range, builds the segment, copies the tarball to the segment store, and uploads reingestion metadata back to the controller.
+5. The controller finalizes the segment metadata, updates ZK metadata to `DONE`, and resets the segment to `ONLINE`.
+
+#### Server reingestion APIs
+
+The controller normally calls these server endpoints automatically during disaster recovery, but they are also useful when you need to inspect or trigger reingestion manually on a specific server.
+
+Start an asynchronous reingestion job for one LLC segment:
+
+```bash
+curl -X POST "http://server-host:8097/reingestSegment/myTable__0__17__20250320T1530Z" \
+  -H "accept: application/json"
+```
+
+Successful requests return a job object immediately while the reingestion continues in the background:
+
+```json
+{
+  "jobId": "4c8514dd-7804-4a55-a180-ef1d0b9b2855",
+  "segmentName": "myTable__0__17__20250320T1530Z",
+  "startTimeMs": 1743865200000
+}
+```
+
+This endpoint only accepts LLC realtime segment names. Pinot derives the realtime table from the segment name and rejects the request if the segment already has a download URL or is already being re-ingested on that server.
+
+List the reingestion jobs still running on that server:
+
+```bash
+curl -X GET "http://server-host:8097/reingestSegment/jobs" \
+  -H "accept: application/json"
+```
+
+```json
+[
+  {
+    "jobId": "4c8514dd-7804-4a55-a180-ef1d0b9b2855",
+    "segmentName": "myTable__0__17__20250320T1530Z",
+    "startTimeMs": 1743865200000
+  }
+]
+```
+
+The controller-side completion call that finalizes the reingested segment is documented in the [controller API reference](../reference/api-reference/controller-api.md#post-segmentsreingested).
 
 ### Disaster recovery modes
 

--- a/reference/api-reference/controller-api.md
+++ b/reference/api-reference/controller-api.md
@@ -16,7 +16,7 @@ The controller exposes the administrative API surface for cluster, schema, table
 | Schema | `GET /schemas`, `GET /schemas/{schemaName}`, `POST /schemas`, `PUT /schemas/{schemaName}`, `DELETE /schemas/{schemaName}` |
 | Table | `GET /tables`, `POST /tables`, `PUT /tables/{tableName}`, `DELETE /tables/{tableName}`, `POST /tableConfigs/validate` |
 | Logical tables | `GET /logicalTables`, `POST /logicalTables`, `PUT /logicalTables/{tableName}`, `DELETE /logicalTables/{tableName}` |
-| Segments | `GET /segments/{tableName}/invalidPartitionMetadata`, `POST /segments/{tableName}/reload`, `POST /segments/{tableNameWithType}/uploadFromServerToDeepstore`, `DELETE /deleteSegmentsFromSequenceNum/{tableNameWithType}`, `GET /segments/segmentReloadStatus/{jobId}`, `GET /segments/{tableNameWithType}/needReload` |
+| Segments | `GET /segments/{tableName}/invalidPartitionMetadata`, `POST /segments/{tableName}/reload`, `POST /segments/{tableNameWithType}/uploadFromServerToDeepstore`, `POST /segments/reingested`, `DELETE /deleteSegmentsFromSequenceNum/{tableNameWithType}`, `GET /segments/segmentReloadStatus/{jobId}`, `GET /segments/{tableNameWithType}/needReload` |
 | Tenant and instance management | `GET /tenants`, `GET /tenants/{tenantName}`, `GET /instances`, `POST /instances` |
 
 ## Swagger UI
@@ -743,6 +743,42 @@ curl -X POST "http://localhost:9000/segments/myTable_REALTIME/uploadFromServerTo
 ```
 
 If the table is not realtime, Pinot returns `400 Bad Request`. If named segments are missing from ZooKeeper metadata, Pinot skips them and only queues the segments it can resolve. When no segments remain after resolution, Pinot returns a success response saying there are no segments to upload.
+
+### POST /segments/reingested
+
+Finalize a reingested realtime segment upload. Pinot uses this endpoint during pauseless disaster recovery after a server has rebuilt a failed LLC segment and uploaded the segment tarball into the segment store.
+
+This endpoint only accepts realtime-table uploads in metadata mode. Operators usually do not call it directly; the server's reingestion flow calls it after `POST /reingestSegment/{segmentName}` finishes rebuilding the segment.
+
+| Query parameter | Type | Meaning |
+| --- | --- | --- |
+| `tableName` | string | Required raw table name. Pinot resolves the realtime table internally. |
+
+| Required header | Value |
+| --- | --- |
+| `UPLOAD_TYPE` | `METADATA` |
+| `DOWNLOAD_URI` | URI of the reingested segment tarball already copied to the segment store |
+| `COPY_SEGMENT_TO_DEEP_STORE` | `true` |
+
+**Request**
+
+```bash
+curl -X POST "http://localhost:9000/segments/reingested?tableName=myTable" \
+  -H "UPLOAD_TYPE: METADATA" \
+  -H "DOWNLOAD_URI: s3://my-bucket/myTable/myTable__0__17__20250320T1530Z.tmp.tar.gz" \
+  -H "COPY_SEGMENT_TO_DEEP_STORE: true" \
+  -F "file=@myTable__0__17__20250320T1530Z.metadata.tar.gz"
+```
+
+The multipart body contains one segment metadata tarball. Pinot reads the segment metadata from that tarball, updates the download URI, and marks the realtime segment as complete.
+
+**Response**
+
+```json
+{
+  "status": "Successfully uploaded reingested segment: myTable__0__17__20250320T1530Z of table: myTable_REALTIME"
+}
+```
 
 ### DELETE /deleteSegmentsFromSequenceNum/\{tableNameWithType\}
 


### PR DESCRIPTION
## Summary
- document the server-side pauseless reingestion endpoints used for disaster recovery
- add controller API coverage for `POST /segments/reingested`
- correct the pauseless recovery flow to match the actual endpoint shapes

## Source
- apache/pinot#14920

## Validation
- python3 scripts/validate-docs.py --changed-only=<(printf '%s\\n' operate-pinot/pauseless-consumption.md reference/api-reference/controller-api.md)\n- git diff --check