### PR TITLE
docs: fix error auto-reset scope and default

### DIFF
--- a/operate-pinot/segment-lifecycle-and-repair.md
+++ b/operate-pinot/segment-lifecycle-and-repair.md
@@ -38,6 +38,8 @@ POST /segments/{tableNameWithType}/reset?errorSegmentsOnly=true
 
 **UI.** The Pinot Data Explorer table detail screen includes a **Reset Segment** action. You can also filter segments by the ERROR state to find candidates quickly.
 
+If you want Pinot to retry this automatically during periodic validation, enable `controller.segment.error.autoReset`. That controller setting applies to both offline and realtime validation tasks and is disabled by default.
+
 {% hint style="warning" %}
 Reset does **not** re-download or rebuild the segment. If the underlying segment data on the server is corrupted, follow up with a [reload](#reload-a-segment) using `forceDownload=true`.
 {% endhint %}

--- a/reference/configuration-reference/controller.md
+++ b/reference/configuration-reference/controller.md
@@ -146,11 +146,11 @@ This task does not fix consumption stalled due to
 | controller.realtime.segment.deepStoreUploadRetryEnabled | false |
 | controller.realtime.segment.deepStoreUploadRetry.timeoutMs | -1 |
 | controller.realtime.segment.deepStoreUploadRetry.parallelism | 1 |
-| controller.segment.error.autoReset | true |
+| controller.segment.error.autoReset | false |
 | controller.realtime.segment.partialOfflineReplicaRepairEnabled | false |
 | controller.segment.disaster.recovery.mode | DEFAULT |
 
-`controller.segment.error.autoReset` controls whether the controller's periodic realtime-segment validation task automatically resets segments in `ERROR` state so they can retry normal recovery. Pinot enables this by default.
+`controller.segment.error.autoReset` controls whether the controller's periodic offline and realtime segment validation tasks automatically reset segments in `ERROR` state so they can retry normal recovery. Pinot leaves this disabled by default.
 
 When `controller.realtime.segment.partialOfflineReplicaRepairEnabled` is enabled, the controller's periodic validation task automatically resets OFFLINE replicas back to CONSUMING for IN_PROGRESS segments that have a mix of CONSUMING and OFFLINE replicas. This handles cases where a replica's startup fails (for example, due to Kafka consumer initialization errors) while other replicas continue normally. Enable only after verifying that OFFLINE replicas are caused by transient failures rather than persistent errors.
 


### PR DESCRIPTION
## Summary
- fix the default value for `controller.segment.error.autoReset`
- document that the setting applies to both offline and realtime validation tasks
- link the operator repair guide to the same controller behavior

## Source
- apache/pinot#14217

## Validation
- python3 scripts/validate-docs.py --changed-only=<(printf '%s\\n' reference/configuration-reference/controller.md operate-pinot/segment-lifecycle-and-repair.md)\n- git diff --check