### PR TITLE
docs: add secondary workload query metrics

### DIFF
--- a/operate-pinot/tuning/workload-query-isolation.md
+++ b/operate-pinot/tuning/workload-query-isolation.md
@@ -208,6 +208,11 @@ Resource usage (CPU time, allocated bytes) is tracked at the thread level and ch
 | `NUM_SECONDARY_QUERIES` | Meter (per-table) | Number of secondary queries received. |
 | `NUM_SECONDARY_QUERIES_SCHEDULED` | Meter (per-table) | Number of secondary queries that were dequeued and scheduled for execution. |
 | `SECONDARY_Q_WAIT_TIME_MS` | Timer (per-table) | Time a secondary query spent waiting in the queue before being scheduled. |
+| `SECONDARY_WORKLOAD_QUERY_TOTAL_TIME_MS` | Timer (global) | End-to-end broker query time for secondary-workload queries only. |
+| `SECONDARY_WORKLOAD_BROKER_RESPONSES_WITH_TIMEOUTS` | Meter (global) | Number of secondary-workload queries that timed out. |
+| `SECONDARY_WORKLOAD_BROKER_RESPONSES_WITH_PARTIAL_SERVERS_RESPONDED` | Meter (global) | Number of secondary-workload queries that returned partial results because not all servers responded. |
+
+These broker metrics are the secondary-workload counterparts of the standard broker timeout, partial-response, and total-query-time metrics, so they let you separate ad-hoc or background query health from primary query traffic.
 
 ### WorkloadScheduler Metrics
 

--- a/reference/configuration-reference/monitoring-metrics.md
+++ b/reference/configuration-reference/monitoring-metrics.md
@@ -97,6 +97,9 @@ Pinot provides metrics out of the box so that you can monitor every aspect of pe
 | RESPONSE_MERGE_EXCEPTIONS | Number of queries that failed while merging responses from multiple servers. This can be due to schema inconsitency or any other issues |  |
 | BROKER_RESPONSES_WITH_PROCESSING_EXCEPTIONS | Number of queries where atleast one exception occured |  |
 | BROKER_RESPONSES_WITH_PARTIAL_SERVERS_RESPONDED | Number of queries with incomplete results due to missing responses from servers |  |
+| SECONDARY_WORKLOAD_BROKER_RESPONSES_WITH_PARTIAL_SERVERS_RESPONDED | Number of secondary-workload queries with incomplete results due to missing responses from servers |  |
+| SECONDARY_WORKLOAD_BROKER_RESPONSES_WITH_TIMEOUTS | Number of secondary-workload queries that timed out |  |
+| SECONDARY_WORKLOAD_QUERY_TOTAL_TIME_MS | Total broker query time for secondary-workload queries only |  |
 | BROKER_RESPONSES_WITH_NUM_GROUPS_LIMIT_REACHED | Number of queries where total number of groups exceeded configured limit (default limit - 100K) |  |
 | DOCUMENTS_SCANNED | Total number of documents read from segments in each query |  |
 | ENTRIES_SCANNED_IN_FILTER |  |  |


### PR DESCRIPTION
## Summary
- add the secondary-workload timeout, partial-response, and total-time broker metrics
- surface those metrics in the workload isolation guide
- add them to the broker monitoring metrics reference

## Source
- apache/pinot#14553

## Validation
- python3 scripts/validate-docs.py --changed-only=<(printf '%s\\n' operate-pinot/tuning/workload-query-isolation.md reference/configuration-reference/monitoring-metrics.md)\n- git diff --check