### PR TITLE
docs: update default Scala version to 2.13 (apache/pinot#18100)

### DIFF
--- a/build-with-pinot/connectors-clients-apis/spark-pinot-connector/README.md
+++ b/build-with-pinot/connectors-clients-apis/spark-pinot-connector/README.md
@@ -358,7 +358,7 @@ Welcome to
    /___/ .__/\_,_/_/ /_/\_\   version 3.5.1
       /_/
 
-Using Scala version 2.12.18 (OpenJDK 64-Bit Server VM, Java 17.0.15)
+Using Scala version 2.13 (default) (OpenJDK 64-Bit Server VM, Java 17.0.15)
 Type in expressions to have them evaluated.
 Type :help for more information.
 

--- a/build-with-pinot/ingestion/stream-ingestion/kafka-connector-versions.md
+++ b/build-with-pinot/ingestion/stream-ingestion/kafka-connector-versions.md
@@ -11,7 +11,7 @@ Apache Pinot provides multiple Kafka connector versions to match different Kafka
 
 | Connector Plugin | Kafka Client Version | Notes |
 |---|---|---|
-| `pinot-kafka-3.0` | 3.9.x | Recommended for Kafka 3.x clusters. Requires Scala dependency. |
+| `pinot-kafka-3.0` | 3.9.x | Recommended for Kafka 3.x clusters. Built with Scala 2.13 (default); use `-Pscala-2.12` profile for Scala 2.12. |
 | `pinot-kafka-4.0` | 4.1.x | Recommended for Kafka 4.x clusters (KRaft mode). Pure Java — no Scala dependency. |
 
 {% hint style="warning" %}
@@ -68,6 +68,14 @@ The Kafka 4.0 connector is fully compatible with all existing Kafka consumer con
 ## Kafka 3.0 Connector
 
 The Kafka 3.0 connector (`pinot-kafka-3.0`) supports Apache Kafka 3.x brokers. This is the most widely deployed connector version.
+
+### Scala Version
+
+The Kafka 3.0 connector is built with **Scala 2.13** by default. If you need Scala 2.12 compatibility, build Pinot with the `-Pscala-2.12` Maven profile:
+
+```
+mvn clean install -Pscala-2.12 -DskipTests
+```
 
 ### Configuration
 

--- a/developers/developers-and-contributors/code-setup.md
+++ b/developers/developers-and-contributors/code-setup.md
@@ -38,6 +38,23 @@ Run the following maven command to set up the project.
 $mvn install package -DskipTests -Pbin-dist -DdownloadSources -DdownloadJavadocs
 ```
 
+### Scala Version
+
+As of recent versions, Pinot defaults to **Scala 2.13** for all Scala-based dependencies and connectors (Spark, Kafka 3.x, etc.). 
+
+If you need to build with **Scala 2.12** for compatibility with your environment, use the Maven profile:
+
+```
+# compile with Scala 2.12
+$ mvn install package -DskipTests -Pbin-dist -Pscala-2.12 -DdownloadSources -DdownloadJavadocs
+```
+
+This affects connectors and libraries like:
+- Spark Pinot Connector
+- Kafka 3.0 Connector
+- Any other Scala-based dependencies
+
+
 ### Set up IDE
 
 Import the project into your favorite IDE. Set up stylesheet according to your IDE. We have provided instructions for intellij and eclipse. If you are using other IDEs, ensure you use stylesheet based on [this](https://github.com/apache/pinot/blob/master/config/codestyle-intellij.xml).


### PR DESCRIPTION
## Summary

Documentation update to reflect the default Scala version change in Apache Pinot PR #18100.

The default Scala version has been changed from 2.12 to 2.13 for all Scala-based dependencies and connectors.

## Changes

- Updated Spark Pinot Connector README to reference Scala 2.13 as the default version
- Updated Kafka Connector Versions documentation to document Scala 2.13 as default with `-Pscala-2.12` profile option for compatibility
- Added "Scala Version" section to Code Setup guide explaining the default version change and how to build with Scala 2.12 if needed

## Files Changed

- `build-with-pinot/connectors-clients-apis/spark-pinot-connector/README.md`
- `build-with-pinot/ingestion/stream-ingestion/kafka-connector-versions.md`
- `developers/developers-and-contributors/code-setup.md`

## Related

Apache Pinot PR: https://github.com/apache/pinot/pull/18100