### PR TITLE
docs: add realtime byte ingestion metrics

### DIFF
--- a/operate-pinot/metrics-and-monitoring.md
+++ b/operate-pinot/metrics-and-monitoring.md
@@ -88,6 +88,8 @@ Servers store segments and execute queries. Monitoring servers helps detect inge
 | `REALTIME_INGESTION_DELAY_MS` | Gauge | Delay in milliseconds between event production and Pinot consumption. Per-partition metric. | > 5 minutes (300000ms) for most use cases; adjust based on freshness SLA |
 | `LLC_PARTITION_CONSUMING` | Gauge | Binary: 1 if low-level consumption is healthy, 0 if unhealthy. Per table-partition. | = 0 on any partition |
 | `REALTIME_CONSUMPTION_EXCEPTIONS` | Meter | Exceptions during real-time consumption. | > 0 sustained |
+| `REALTIME_BYTES_CONSUMED` | Meter | Serialized bytes Pinot successfully consumes from a real-time stream. Use it with `REALTIME_ROWS_CONSUMED` to spot abrupt payload-size changes. | Sudden drop or spike vs. baseline |
+| `REALTIME_BYTES_DROPPED` | Meter | Serialized bytes Pinot drops during real-time ingestion because records were filtered out or failed decode, transform, or indexing. | > 0 sustained |
 | `QUERY_EXECUTION_EXCEPTIONS` | Meter | Exceptions during query execution on the server. | > 1% of queries |
 | `QUERIES` | Meter | Query rate hitting this server. | Sudden drop or spike vs. baseline |
 | `NUM_MISSING_SEGMENTS` | Meter | Segments the broker expected but the server did not have. | > 0 sustained |

--- a/reference/configuration-reference/monitoring-metrics.md
+++ b/reference/configuration-reference/monitoring-metrics.md
@@ -32,6 +32,8 @@ Pinot provides metrics out of the box so that you can monitor every aspect of pe
 | REALTIME_INGESTION_DELAY_MS | Per partition metric that measures the delay in milliseconds from the time an event was produced to the stream that feeds Pinot until the event was consumed by Pinot. Partitions that are not actively consuming due to lack of events will report 0 delay. Partitions that are stuck or falling behind will report their last measured delay aged by the time since the sample was taken: this enables the user to monitor partitions that have events queued but where Pinot is falling behind in consumption. This metric assumes event timestamps is UTC time zone, if timestamps are using other timezones, the delay shown will be offset. |  |
 | ROWS_WITH_ERRORS | number of rows that either didn't get transformed or didn't get indexed. |  |
 | REALTIME_ROWS_CONSUMED | total number of records consumed from input |  |
+| REALTIME_BYTES_CONSUMED | total serialized bytes consumed from real-time input |  |
+| REALTIME_BYTES_DROPPED | total serialized bytes dropped during real-time ingestion because Pinot rejected or failed to process the records |  |
 | INVALID_REALTIME_ROWS_DROPPED | number of records that were filtered based on FilterConfig specified in table config |  |
 | REALTIME_CONSUMPTION_EXCEPTIONS | number of rows that were not consumed because of some exception. It doesn't track exceptions during transformation and indexing. |  |
 | RELOAD_FAILURES | Number of failures occurred while reloading segments |  |


### PR DESCRIPTION
## Summary
- document the realtime byte consumption and drop counters in the metrics reference
- add the same counters to the production monitoring guide

## Source
- apache/pinot#14496

## Validation
- python3 scripts/validate-docs.py --changed-only=<(printf '%s\\n' reference/configuration-reference/monitoring-metrics.md operate-pinot/metrics-and-monitoring.md)\n- git diff --check