### PR TITLE
docs: clarify star-tree behavior with null handling

### DIFF
--- a/build-with-pinot/indexing/star-tree-index.md
+++ b/build-with-pinot/indexing/star-tree-index.md
@@ -404,6 +404,7 @@ For e.g if query contains `round(colA,600) as roundedValue from tableA group by 
 - `DISTINCT_COUNT` (exact), `SEGMENT_PARTITIONED_DISTINCT_COUNT`, and `PERCENTILE` (exact) are not supported because their intermediate results are unbounded.
 - `REGEXP_LIKE` predicates are not supported in star-tree queries.
 - `IS NULL` and `IS NOT NULL` are not supported because null value info is not stored in the star-tree index. Use `col = <default>` or `col != <default>` as workarounds.
+- When the query option `enableNullHandling=true` is used, Pinot can still use the star-tree index for a segment if the aggregated columns, filtered columns, and group-by columns involved in the query do not actually contain null values in that segment.
 - `OR` predicates across multiple dimensions are not supported (they cause double counting with pre-aggregated results).
 - `NOT` on top of `AND`/`OR` is not supported for the same double-counting reason.
 - All star-tree dimension columns should be dictionary-encoded.

--- a/build-with-pinot/querying-and-sql/null-value-support.md
+++ b/build-with-pinot/querying-and-sql/null-value-support.md
@@ -219,6 +219,8 @@ When the `enableNullHandling` option is set to `true`, the Pinot query engine us
 
 In this mode, some indexes may not be usable, and queries may be significantly more expensive. Performance degradation impacts all the columns in the table, including columns in the query that do not contain null values. This degradation happens even when table uses column based null storing.
 
+Star-tree is one exception to the all-or-nothing rule: Pinot can still use a star-tree index for a segment when `enableNullHandling=true` if the aggregated columns, filtered columns, and group-by columns used by the query do not contain null values in that segment. Predicates such as `IS NULL` and `IS NOT NULL` still cannot use the star-tree index.
+
 ### Examples queries
 
 #### Select Query


### PR DESCRIPTION
## Summary
- document when star-tree remains usable with `enableNullHandling=true`
- keep the existing `IS NULL` / `IS NOT NULL` limitation explicit
- link the behavior from the null-handling guide

## Source
- closes the docs gap identified from apache/pinot#14177

## Validation
- `python3 scripts/validate-docs.py --changed-only=<(printf '%s\\n' build-with-pinot/indexing/star-tree-index.md build-with-pinot/querying-and-sql/null-value-support.md)`\n- `git diff --check`