### PR TITLE
docs: cover pause status details

### DIFF
--- a/build-with-pinot/ingestion/stream-ingestion/README.md
+++ b/build-with-pinot/ingestion/stream-ingestion/README.md
@@ -431,7 +431,7 @@ There are some scenarios in which you may want to pause the real-time ingestion 
 
 ```bash
 $ curl -X POST {controllerHost}/tables/{tableName}/pauseConsumption
-$ curl -X POST {controllerHost}/tables/{tableName}/resumeConsumption
+$ curl -X POST "{controllerHost}/tables/{tableName}/resumeConsumption?comment=maintenance-complete"
 ```
 
 For tables with many consuming segments, you can batch the pause request so the controller commits fewer segments at a time:
@@ -445,8 +445,10 @@ $ curl -X POST "{controllerHost}/tables/{tableName}/pauseConsumption?batchSize=5
 When a `Pause` request is issued, the controller instructs the real-time servers hosting your table to commit their consuming segments immediately. However, the commit process may take some time to complete. Note that `Pause` and `Resume` requests are async. An `OK` response means that instructions for pausing or resuming has been successfully sent to the real-time server. If you want to know if the consumption has actually stopped or resumed, issue a pause status request.
 
 ```bash
-$ curl -X POST {controllerHost}/tables/{tableName}/pauseStatus
+$ curl -X GET {controllerHost}/tables/{tableName}/pauseStatus
 ```
+
+The pause status response includes the current `pauseFlag`, the set of `consumingSegments`, the stored `reasonCode`, any persisted `comment`, and the controller-side `timestamp` for the current pause state. When no explicit comment was stored, Pinot returns a default paused or unpaused message.
 
 It's worth noting that consuming segments on real-time servers are stored in volatile memory, and their resources are allocated when the consuming segments are first created. These resources cannot be altered if consumption parameters are changed midway through consumption. It may take hours before these changes take effect. Furthermore, if the parameters are changed in an incompatible way (for example, changing the underlying stream with a completely new set of offsets, or changing the stream endpoint from which to consume messages), it will result in the table getting into an error state.
 
@@ -491,8 +493,8 @@ This API is async, as it doesn't wait for the segment commit to complete. But a 
 For incompatible parameter changes, an option is added to the resume request to handle the case of a completely new set of offsets. Operators can now follow a three-step process: First, issue a pause request. Second, change the consumption parameters. Finally, issue the resume request with the appropriate option. These steps will preserve the old data and allow the new data to be consumed immediately. All through the operation, queries will continue to be served.
 
 ```bash
-$ curl -X POST {controllerHost}/tables/{tableName}/resumeConsumption?resumeFrom=smallest
-$ curl -X POST {controllerHost}/tables/{tableName}/resumeConsumption?resumeFrom=largest
+$ curl -X POST {controllerHost}/tables/{tableName}/resumeConsumption?consumeFrom=smallest
+$ curl -X POST {controllerHost}/tables/{tableName}/resumeConsumption?consumeFrom=largest
 ```
 
 ## Handle partition changes in streams

--- a/reference/api-reference/controller-api.md
+++ b/reference/api-reference/controller-api.md
@@ -1308,10 +1308,57 @@ curl -X POST "http://localhost:9000/tables/myTable/pauseConsumption?comment=main
 
 Resume real-time consumption for a table.
 
+| Query parameter | Type | Meaning |
+| --- | --- | --- |
+| `comment` | string | Optional comment stored with the administrative resume state. |
+| `consumeFrom` | string | Optional resume offset policy. Use `lastConsumed` to continue from the offsets stored in Pinot metadata, `smallest` to restart from the earliest available offsets, or `largest` to restart from the latest available offsets. Default: `lastConsumed`. |
+
 **Request**
 
 ```
 curl -X POST "http://localhost:9000/tables/myTable/resumeConsumption" -H "accept: application/json"
+```
+
+Example with an administrative comment and an explicit resume policy:
+
+```bash
+curl -X POST "http://localhost:9000/tables/myTable/resumeConsumption?comment=maintenance-complete&consumeFrom=smallest" \
+  -H "accept: application/json"
+```
+
+### GET /tables/\<tableName>/pauseStatus
+
+Return the current pause state for a realtime table together with the currently consuming segments.
+
+**Request**
+
+```bash
+curl -X GET "http://localhost:9000/tables/myTable/pauseStatus" -H "accept: application/json"
+```
+
+**Response fields**
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `pauseFlag` | boolean | Whether Pinot currently considers the realtime table paused. |
+| `consumingSegments` | array of strings | Segment names that are still in the consuming state when the status is fetched. |
+| `reasonCode` | string | Pause reason code, such as `ADMINISTRATIVE` for operator-driven pauses or `STORAGE_QUOTA_EXCEEDED` for automatic storage-quota pauses. |
+| `comment` | string | Stored administrative or automatic pause comment. If no explicit comment was stored, Pinot returns a default paused or unpaused message. |
+| `timestamp` | string | Stored pause-state timestamp from the controller metadata. |
+
+**Example response**
+
+```json
+{
+  "pauseFlag": true,
+  "consumingSegments": [
+    "myTable__0__12__20250610T2140Z",
+    "myTable__1__12__20250610T2140Z"
+  ],
+  "reasonCode": "ADMINISTRATIVE",
+  "comment": "maintenance",
+  "timestamp": "<stored pause-state timestamp>"
+}
 ```
 
 ### GET /tables/\<tableName>/badLLCSegmentsPerPartition


### PR DESCRIPTION
## Summary
- document the expanded realtime pause status payload
- document the optional administrative comment on resume requests
- fix the stream-ingestion admin examples for pauseStatus and consumeFrom

## Source
- closes docs gap from apache/pinot#13803

## Validation
- python3 scripts/validate-docs.py --changed-only=<(printf '%s\\n' reference/api-reference/controller-api.md build-with-pinot/ingestion/stream-ingestion/README.md)\n- git diff --check