### PR TITLE
docs: cover custom partial upsert merger

### DIFF
--- a/build-with-pinot/ingestion/upsert-and-dedup/upsert.md
+++ b/build-with-pinot/ingestion/upsert-and-dedup/upsert.md
@@ -126,6 +126,26 @@ For example:
 ```
 {% endcode %}
 
+### Custom row merger for partial upsert
+
+If column-level `partialUpsertStrategies` are not expressive enough, you can provide a custom row merger class with `upsertConfig.partialUpsertMergerClass`.
+
+```json
+{
+  "upsertConfig": {
+    "mode": "PARTIAL",
+    "partialUpsertMergerClass": "org.apache.pinot.segment.local.upsert.merger.PartialUpsertMyCustomMerger"
+  },
+  "tableIndexConfig": {
+    "nullHandlingEnabled": true
+  }
+}
+```
+
+When `partialUpsertMergerClass` is set, Pinot instantiates that `PartialUpsertMerger` implementation instead of the built-in columnar partial-upsert merger. The custom merger class must be available on the server classpath and expose a constructor with `(List<String> primaryKeyColumns, List<String> comparisonColumns, UpsertConfig upsertConfig)`.
+
+`partialUpsertMergerClass` is mutually exclusive with `partialUpsertStrategies`. Pinot rejects table configs that try to set both at the same time.
+
 Pinot supports the following partial upsert strategies:
 
 | Strategy  | Description                                                               |


### PR DESCRIPTION
## Summary
- document partialUpsertMergerClass for partial upsert tables
- document the required merger constructor shape
- document that Pinot rejects configs which set both partialUpsertMergerClass and partialUpsertStrategies

## Source
- closes docs gap from apache/pinot#11983

## Validation
- python3 scripts/validate-docs.py --changed-only=<(printf '%s\\n' build-with-pinot/ingestion/upsert-and-dedup/upsert.md)\n- git diff --check