### PR TITLE
docs: add IVF_PQ vector backend documentation (apache/pinot#18090)

### DIFF
--- a/build-with-pinot/indexing/vector-index.md
+++ b/build-with-pinot/indexing/vector-index.md
@@ -381,6 +381,37 @@ WHERE vectorSimilarity(embedding, ARRAY[1.1, 1.1, ...], 10)
 ORDER BY dist ASC LIMIT 10
 ```
 
+## Index Debug Information
+
+All vector index backends (HNSW, IVF_FLAT, and IVF_PQ) now support the `getIndexDebugInfo()` method, which provides detailed statistics and diagnostic information about the index. This is useful for monitoring, debugging, and understanding index behavior at runtime.
+
+### Using getIndexDebugInfo()
+
+The debug info is available through the Pinot segment metadata and includes:
+
+* **Index configuration**: The exact parameters used to build the index
+* **Index statistics**: Number of vectors indexed, memory usage, codebook information (for IVF_PQ)
+* **Build time**: Time taken to construct the index
+* **Backend-specific metrics**:
+  * HNSW: Graph structure info (number of nodes, edges, layers)
+  * IVF_FLAT: Cluster distribution and inverted list statistics
+  * IVF_PQ: Quantization codebook details, compression metrics
+
+### Accessing Debug Information
+
+Debug information can be accessed through:
+
+1. **Query explain output**: When running with `explainAskingServers=true`, segment-level index debug info is included
+2. **REST API**: Via the segment metadata endpoint
+3. **Pinot shell/client**: Using server-side utilities
+
+Example REST endpoint:
+```
+GET /tables/{tableName}/segments/{segmentName}/metadata
+```
+
+This endpoint returns detailed segment metadata including vector index debug information.
+
 ## Backward Compatibility
 
 Existing HNSW and IVF_FLAT configurations continue to work without modification. The vector index implementation is fully backward compatible:


### PR DESCRIPTION
Adds documentation for the new IVF_PQ vector backend introduced in apache/pinot#18090.

Key additions:
- IVF_PQ as a new vectorIndexType option alongside HNSW and IVF_FLAT
- Comprehensive config properties table: nlist, pqM, pqNbits, trainSampleSize, trainingSeed
- Detailed comparison of when to use IVF_PQ vs IVF_FLAT vs HNSW
- Memory-efficient compressed vector storage (up to 32x compression)
- Example table configuration showing how to enable IVF_PQ
- Information about getIndexDebugInfo() now available for all vector backends
- Query-time tuning options for IVF_PQ (vectorNprobe, vectorExactRerank, vectorMaxCandidates)

Upstream PR: https://github.com/apache/pinot/pull/18090