### PR TITLE
docs: update Helm deployment docs for Helm 3 migration (apache/pinot#17860)

### DIFF
--- a/basics/getting-started/install/kubernetes.md
+++ b/basics/getting-started/install/kubernetes.md
@@ -8,6 +8,18 @@ description: Deploy a Pinot cluster on Kubernetes using Helm.
 
 Deploy a production-ready Pinot cluster on Kubernetes with Helm charts.
 
+{% hint style="warning" %}
+**Helm 3 Migration:** Pinot Helm charts have been upgraded to Helm 3 (apiVersion v2). If you are upgrading from older Helm charts (v1), please note:
+- **Minimum Helm version:** Helm 3.0+ is required
+- **Dependency management:** Use `helm dependency build` (not `helm dependency update`)
+- **Dependency file:** Charts now use `Chart.yaml` for dependency declarations (not `requirements.yaml`)
+- **Lock file:** Uses `Chart.lock` (not `requirements.lock`)
+- **Chart archives:** No longer checked into the repository; automatically fetched via `helm dependency build`
+- **Chart versions:** No longer use the `-SNAPSHOT` suffix
+
+For detailed upgrade instructions, see the [Upgrade Guide](#upgrading-from-helm-v1-charts) below.
+{% endhint %}
+
 {% hint style="info" %}
 The examples in this guide are sample configurations for reference. For production deployments, customize settings as needed -- especially security features like TLS and authentication.
 {% endhint %}
@@ -18,7 +30,7 @@ The examples in this guide are sample configurations for reference. For producti
   * [Docker Desktop with Kubernetes enabled](https://docs.docker.com/docker-for-mac/kubernetes/)
   * [Minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/) -- start with sufficient resources: `minikube start --vm=true --cpus=4 --memory=8g --disk-size=50g`
   * A managed cloud cluster -- see [Managed Kubernetes](managed-kubernetes/) for AWS, GCP, and Azure setup guides
-* [Helm 3](https://helm.sh/docs/intro/install/)
+* **Helm 3** (apiVersion v2) -- Required for Pinot Helm charts. [Install Helm 3](https://helm.sh/docs/intro/install/)
 * [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
 
 ## Steps
@@ -60,10 +72,14 @@ helm install pinot pinot/pinot \
 ```bash
 git clone https://github.com/apache/pinot.git
 cd pinot/helm/pinot
-helm dependency update
+helm dependency build
 kubectl create ns pinot-quickstart
 helm install -n pinot-quickstart pinot ./pinot
 ```
+
+{% hint style="info" %}
+**Helm 3 Migration (v2):** As of the recent migration to Helm 3 apiVersion v2, the Pinot charts now use `Chart.yaml` for dependency declarations (instead of `requirements.yaml`) and `Chart.lock` (instead of `requirements.lock`). The `helm dependency build` command fetches dependencies from the chart repository automatically.
+{% endhint %}
 {% endtab %}
 {% endtabs %}
 
@@ -98,3 +114,60 @@ kubectl delete ns pinot-quickstart
 ## Next step
 
 Your cluster is running. Continue to [First table and schema](../first-table-and-schema.md) to load data.
+
+## Upgrading from Helm v1 charts
+
+If you are upgrading from older Pinot Helm charts (apiVersion v1), follow these steps:
+
+### 1. Update Helm repository
+
+```bash
+helm repo update pinot
+```
+
+### 2. Back up your configuration
+
+Save your current `values.yaml` in case you need to reference it:
+
+```bash
+helm get values pinot -n pinot-quickstart > values-backup.yaml
+```
+
+### 3. Uninstall old release (optional but recommended)
+
+If upgrading from v1 charts, it's safest to uninstall and reinstall:
+
+```bash
+helm uninstall pinot -n pinot-quickstart
+```
+
+### 4. Reinstall with new Helm v2 charts
+
+```bash
+helm install pinot pinot/pinot \
+    -n pinot-quickstart \
+    --set cluster.name=pinot \
+    --set server.replicaCount=2 \
+    -f values-backup.yaml
+```
+
+### Key changes in Helm v2 charts
+
+- **apiVersion:** Changed from `v1` to `v2`
+- **Chart type:** Added explicit `type: application`
+- **Dependencies:** Now declared in `Chart.yaml` instead of `requirements.yaml`
+- **Lock file:** Changed from `requirements.lock` to `Chart.lock`
+- **Dependency fetching:** Use `helm dependency build` instead of `helm dependency update`
+- **Chart versions:** No longer include `-SNAPSHOT` suffix (uses standard SemVer)
+- **Chart icons:** Now include official Apache Pinot icons
+
+### If deploying from source
+
+When deploying directly from the Git repository, always run `helm dependency build` before installing:
+
+```bash
+git clone https://github.com/apache/pinot.git
+cd pinot/helm/pinot
+helm dependency build  # Required for Helm 3 v2 charts
+helm install pinot . -n pinot-quickstart
+```

--- a/operate-pinot/kubernetes/deployment-pinot-on-kubernetes.md
+++ b/operate-pinot/kubernetes/deployment-pinot-on-kubernetes.md
@@ -4,6 +4,10 @@ Pinot community has provided a Helm-based [Kubernetes install guide](../../basic
 
 You can deploy it as simple as run a `helm install` command.
 
+{% hint style="info" %}
+**Helm 3 (v2 apiVersion):** Pinot Helm charts now require Helm 3.0+ with support for apiVersion v2. When deploying from source, always run `helm dependency build` to fetch chart dependencies. See the [Helm 3 Migration Notice](helm-chart-reference.md#helm-3-migration-notice) for details.
+{% endhint %}
+
 However there are a few things to be noted before starting the benchmark/production.
 
 ## Container Resources

--- a/operate-pinot/kubernetes/helm-chart-reference.md
+++ b/operate-pinot/kubernetes/helm-chart-reference.md
@@ -11,11 +11,48 @@ This page provides a comprehensive reference for the Apache Pinot Helm chart con
 | App Version | `1.0.0` |
 | Source | [github.com/apache/pinot/tree/master/helm](https://github.com/apache/pinot/tree/master/helm) |
 | Maintainer | `dev@pinot.apache.org` |
+| Helm API Version | `v2` (Helm 3+) |
+
+## Helm 3 Migration Notice
+
+The Pinot Helm charts have been migrated to **Helm 3 (apiVersion v2)** to follow Helm best practices and improve maintainability. Key changes:
+
+### Chart Structure Changes
+
+- **apiVersion:** Upgraded from `v1` to `v2`
+- **Chart type:** Added explicit `type: application`
+- **Dependencies:** Now declared in `Chart.yaml` (previously `requirements.yaml`)
+- **Lock file:** Renamed from `requirements.lock` to `Chart.lock`
+- **Chart versions:** No longer use `-SNAPSHOT` suffix; standard SemVer only
+- **Chart archives:** No longer checked into the repository; fetched dynamically via `helm dependency build`
+- **Icons:** Added official Apache Pinot icons for both charts
+
+### Migration Impact for Users
+
+If you deployed Pinot using older Helm v1 charts:
+
+1. **Helm 3 is required:** Update to Helm 3.0+ if you haven't already
+2. **Rebuild dependencies:** Always run `helm dependency build` when deploying from source
+3. **Use latest chart versions:** Pull the newest chart version from the Pinot Helm repository
+4. **Update your CI/CD:** Replace `helm dependency update` with `helm dependency build` in deployment scripts
+
+### Upgrading Your Deployment
+
+```bash
+# Update Helm repository
+helm repo update pinot
+
+# For source deployments, fetch dependencies
+helm dependency build
+
+# Upgrade your release
+helm upgrade pinot pinot/pinot -n pinot-quickstart -f values.yaml
+```
 
 ## Prerequisites
 
 * Kubernetes 1.20+
-* Helm 3.x
+* **Helm 3.0+** (apiVersion v2 support required) -- [Install Helm 3](https://helm.sh/docs/intro/install/)
 * `kubectl` configured to connect to your cluster
 * Persistent volume provisioner support in the cluster (for controller, server, and ZooKeeper data)
 * A StorageClass appropriate for your cloud provider:


### PR DESCRIPTION
Updates Helm deployment documentation to reflect migration from apiVersion v1 to v2 (Helm 3).

## Changes

Updated three key documentation files:

1. **basics/getting-started/install/kubernetes.md**
   - Added warning banner about Helm 3 requirements
   - Clarified Helm 3 requirement in prerequisites
   - Updated Git-based deployment to use `helm dependency build`
   - Added new section with upgrade instructions from Helm v1 charts
   - Documented key changes in Helm v2 charts (apiVersion, Chart.yaml, Chart.lock, etc.)

2. **operate-pinot/kubernetes/helm-chart-reference.md**
   - Added comprehensive Helm 3 Migration Notice section
   - Documented chart structure changes (apiVersion, dependencies in Chart.yaml, Chart.lock)
   - Explained migration impact for users
   - Provided upgrade instructions
   - Updated prerequisites to emphasize Helm 3.0+

3. **operate-pinot/kubernetes/deployment-pinot-on-kubernetes.md**
   - Added info box about Helm 3 requirements
   - Link to migration notice for reference

## Key Documentation Additions

- **Minimum Helm version:** Helm 3.0+ is required
- **Dependency management:** Use `helm dependency build` instead of `helm dependency update`
- **Dependency file:** Chart.yaml (not requirements.yaml)
- **Lock file:** Chart.lock (not requirements.lock)
- **Chart archives:** No longer checked in; fetched dynamically
- **Chart versions:** Standard SemVer without -SNAPSHOT suffix

## Upstream PR

Documentation for: https://github.com/apache/pinot/pull/17860

Upstream changes: Migration of Pinot Helm charts to Helm 3 (apiVersion v2) with cleaned-up artifacts.