### PR TITLE
docs: add stopOnDecodeError stream config option (apache/pinot#17071)

### DIFF
--- a/build-with-pinot/ingestion/stream-ingestion/README.md
+++ b/build-with-pinot/ingestion/stream-ingestion/README.md
@@ -277,6 +277,46 @@ Pinot checks the thresholds when it seals a consuming segment:
 
 This is useful when you prefer to drop an ingestion backlog instead of replaying a partition that has fallen far behind.
 
+### Handle decode errors during stream consumption
+
+By default, Pinot logs decode errors and silently drops the problematic row so that ingestion continues uninterrupted. However, in some scenarios you may prefer to stop ingestion immediately when a decode error occurs so you can investigate and resolve the issue.
+
+You can control this behavior using the `stopOnDecodeError` configuration parameter in your stream config:
+
+```json
+{
+  "tableName": "transcript",
+  "tableType": "REALTIME",
+  ...
+  "ingestionConfig": {
+    "streamIngestionConfig": {
+      "streamConfigMaps": [{
+        "streamType": "kafka",
+        "stream.kafka.topic.name": "transcript-topic",
+        "stopOnDecodeError": "true",
+        ...
+      }]
+    }
+  },
+  ...
+}
+```
+
+**Configuration options:**
+
+- `"stopOnDecodeError": "true"` - Consumption will immediately stop when a decode error occurs, and the error will be logged with full stack trace. This allows you to investigate the root cause in the server logs before resuming.
+- `"stopOnDecodeError": "false"` (default) - The first decode error will be logged, and subsequent errors will be silently dropped. The row with the decode error is skipped, and ingestion continues normally.
+
+Use `"stopOnDecodeError": "true"` when:
+- Data quality is critical and you need to catch decode errors immediately
+- You're developing or testing a new decoder implementation
+- You want to investigate unexpected data format issues
+
+Use `"stopOnDecodeError": "false"` (default) when:
+- You expect occasional malformed messages in your stream
+- You want ingestion to be resilient and continue despite individual bad records
+- Data loss from a few dropped rows is acceptable
+
 ### Throttle stream consumption
 
 There are some scenarios where the message rate in the input stream can come in bursts which can lead to long GC pauses on the Pinot servers or affect the ingestion rate of other real-time tables on the same server. If this happens to you, throttle the consumption rate during stream ingestion to better manage overall performance.

--- a/reference/configuration-reference/ingestion.md
+++ b/reference/configuration-reference/ingestion.md
@@ -37,7 +37,7 @@ The ingestion configuration (`ingestionConfig`) is a section of the [table confi
 | `realtime.segment.offsetAutoReset.enable` | When `true`, Pinot can skip a lagging realtime partition forward during segment commit instead of starting the next segment at the previous segment's `nextOffset`. Pinot only resets when at least one positive threshold below is configured. | Boolean. Default is `false`. |
 | `realtime.segment.offsetAutoReset.offsetThreshold` | If positive, Pinot resets the next segment to the latest stream offset when `latestOffset - nextOffset` exceeds this many offsets at commit time. | Integer. Default is `-1` (disabled). |
 | `realtime.segment.offsetAutoReset.timeThresholdSeconds` | If positive, Pinot resets the next segment to the latest stream offset when the next offset is older than this many seconds at commit time. Pinot compares the next offset against the stream position at `now - threshold`. | Long. Default is `-1` (disabled). |
-| `stream.[streamType].stopOnDecodeError` | When set to `true`, consumption stops with an error if a decode error occurs. When set to `false` (default), decode errors are logged and the problematic row is silently dropped. | Boolean. Default is `false`. |
+| `stopOnDecodeError` | When set to `true`, consumption stops with an error if a decode error occurs. When set to `false` (default), decode errors are logged and the problematic row is silently dropped. | Boolean. Default is `false`. |
 
 {% hint style="info" %}
 The number of rows per segment is computed using the following formula: `realtime.segment.flush.threshold.rows / maxPartitionsConsumedByServer` For example, if you set `realtime.segment.flush.threshold.rows = 1000` and each server consumes 10 partitions, the rows per segment is `1000/10 = 100`.


### PR DESCRIPTION
Documents the new stopOnDecodeError stream configuration parameter added in apache/pinot#17071.

When enabled, real-time consumption stops with an error on decode failures instead of silently dropping the row.

## Changes

1. Updated `reference/configuration-reference/ingestion.md` to correct the configuration key name from `stream.[streamType].stopOnDecodeError` to `stopOnDecodeError`
2. Added comprehensive documentation in `build-with-pinot/ingestion/stream-ingestion/README.md` with:
   - New section: "Handle decode errors during stream consumption"
   - Configuration examples
   - Use case guidelines for when to enable/disable this option

Upstream PR: https://github.com/apache/pinot/pull/17071