### PR TITLE
docs: add bitwise scalar functions documentation (apache/pinot#18115)

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -390,6 +390,7 @@
   * [hypot](functions/math/hypot.md)
   * [byteswapInt](functions/math/byteswapint.md)
   * [byteswapLong](functions/math/byteswaplong.md)
+  * [Bitwise Functions](functions/math/bitwise.md)
 * [Miscellaneous Functions](functions/misc/README.md)
   * [caseWhen](functions/misc/casewhen.md)
   * [isSubnetOf](functions/misc/issubnetof.md)

--- a/functions/math/README.md
+++ b/functions/math/README.md
@@ -159,3 +159,59 @@ Reverses the byte order of a long value.
 
 Usage: `byteswapLong(col)`\
 Example: `SELECT byteswapLong(longCol) FROM myTable`
+
+## Bitwise Functions
+
+[**bitAnd(a, b)** / **bit_and(a, b)**](bitwise.md)\
+Performs a bitwise AND operation on two values.
+
+Usage: `bitAnd(a, b)` or `bit_and(a, b)`\
+Example: `SELECT bitAnd(12, 10) FROM myTable` returns `8`
+
+[**bitOr(a, b)** / **bit_or(a, b)**](bitwise.md)\
+Performs a bitwise OR operation on two values.
+
+Usage: `bitOr(a, b)` or `bit_or(a, b)`\
+Example: `SELECT bitOr(8, 4) FROM myTable` returns `12`
+
+[**bitXor(a, b)** / **bit_xor(a, b)**](bitwise.md)\
+Performs a bitwise XOR operation on two values.
+
+Usage: `bitXor(a, b)` or `bit_xor(a, b)`\
+Example: `SELECT bitXor(12, 10) FROM myTable` returns `6`
+
+[**bitNot(a)**](bitwise.md)\
+Performs a bitwise NOT operation, inverting all bits of a value.
+
+Usage: `bitNot(a)`\
+Example: `SELECT bitNot(0) FROM myTable` returns `-1`
+
+[**bitMask(n)**](bitwise.md)\
+Creates a bitmask with a single bit set at position n.
+
+Usage: `bitMask(n)`\
+Example: `SELECT bitMask(3) FROM myTable` returns `8`
+
+[**bitShiftLeft(a, n)**](bitwise.md)\
+Performs a left bit shift operation.
+
+Usage: `bitShiftLeft(a, n)`\
+Example: `SELECT bitShiftLeft(1, 2) FROM myTable` returns `4`
+
+[**bitShiftRight(a, n)**](bitwise.md)\
+Performs an arithmetic right bit shift operation (sign-extending).
+
+Usage: `bitShiftRight(a, n)`\
+Example: `SELECT bitShiftRight(8, 2) FROM myTable` returns `2`
+
+[**bitShiftRightUnsigned(a, n)** / **bitShiftRightLogical(a, n)**](bitwise.md)\
+Performs a logical (unsigned) right bit shift operation, filling with zeros.
+
+Usage: `bitShiftRightUnsigned(a, n)` or `bitShiftRightLogical(a, n)`\
+Example: `SELECT bitShiftRightUnsigned(intCol, 1) FROM myTable`
+
+[**bitExtract(a, n)** / **extractBit(a, n)**](bitwise.md)\
+Extracts the bit at position n, returning 1 if the bit is set, 0 otherwise. Always returns INT.
+
+Usage: `bitExtract(a, n)` or `extractBit(a, n)`\
+Example: `SELECT bitExtract(12, 2) FROM myTable` returns `1`

--- a/functions/math/bitwise.md
+++ b/functions/math/bitwise.md
@@ -1,0 +1,326 @@
+---
+description: >-
+  This section contains reference documentation for bitwise scalar functions.
+---
+
+# Bitwise Functions
+
+Bitwise scalar functions perform bitwise operations on INT and LONG integer types.
+
+## Type Behavior
+
+- **INT inputs**: When all arguments are INT, the result is INT
+- **Mixed or LONG inputs**: When any argument is LONG, the result is LONG
+- **bitExtract**: Always returns INT, regardless of input types
+
+## bitAnd / bit_and
+
+Performs a bitwise AND operation on two values.
+
+### Signature
+
+> bitAnd(a, b)
+> bit_and(a, b)
+
+| Argument | Type | Description |
+| -------- | ---- | ----------- |
+| `a`      | INT or LONG | First value |
+| `b`      | INT or LONG | Second value |
+
+Returns: **INT** (if both INT) or **LONG** (if any LONG)
+
+### Usage Examples
+
+```sql
+SELECT bitAnd(12, 10) AS value
+FROM myTable
+```
+
+| value |
+| ----- |
+| 8     |
+
+```sql
+SELECT bitAnd(intCol, 3) AS masked
+FROM myTable
+```
+
+## bitOr / bit_or
+
+Performs a bitwise OR operation on two values.
+
+### Signature
+
+> bitOr(a, b)
+> bit_or(a, b)
+
+| Argument | Type | Description |
+| -------- | ---- | ----------- |
+| `a`      | INT or LONG | First value |
+| `b`      | INT or LONG | Second value |
+
+Returns: **INT** (if both INT) or **LONG** (if any LONG)
+
+### Usage Examples
+
+```sql
+SELECT bitOr(8, 4) AS value
+FROM myTable
+```
+
+| value |
+| ----- |
+| 12    |
+
+```sql
+SELECT bitOr(intCol, 8) AS flags
+FROM myTable
+```
+
+## bitXor / bit_xor
+
+Performs a bitwise XOR (exclusive OR) operation on two values.
+
+### Signature
+
+> bitXor(a, b)
+> bit_xor(a, b)
+
+| Argument | Type | Description |
+| -------- | ---- | ----------- |
+| `a`      | INT or LONG | First value |
+| `b`      | INT or LONG | Second value |
+
+Returns: **INT** (if both INT) or **LONG** (if any LONG)
+
+### Usage Examples
+
+```sql
+SELECT bitXor(12, 10) AS value
+FROM myTable
+```
+
+| value |
+| ----- |
+| 6     |
+
+```sql
+SELECT bitXor(intCol, 1) AS toggled
+FROM myTable
+```
+
+## bitNot
+
+Performs a bitwise NOT operation, inverting all bits of a value.
+
+### Signature
+
+> bitNot(a)
+
+| Argument | Type | Description |
+| -------- | ---- | ----------- |
+| `a`      | INT or LONG | Value to invert |
+
+Returns: **INT** (if INT) or **LONG** (if LONG)
+
+### Usage Examples
+
+```sql
+SELECT bitNot(0) AS value
+FROM myTable
+```
+
+| value  |
+| ------ |
+| -1     |
+
+```sql
+SELECT bitNot(intCol) AS inverted
+FROM myTable
+```
+
+## bitMask
+
+Creates a bitmask with a single bit set at position n.
+
+### Signature
+
+> bitMask(n)
+
+| Argument | Type | Description |
+| -------- | ---- | ----------- |
+| `n`      | INT | Bit position (0-indexed) |
+
+Returns: **INT**
+
+### Usage Examples
+
+```sql
+SELECT bitMask(0) AS value
+FROM myTable
+```
+
+| value |
+| ----- |
+| 1     |
+
+```sql
+SELECT bitMask(3) AS value
+FROM myTable
+```
+
+| value |
+| ----- |
+| 8     |
+
+```sql
+SELECT bitMask(6) AS flags
+FROM myTable
+```
+
+## bitShiftLeft
+
+Performs a left bit shift operation.
+
+### Signature
+
+> bitShiftLeft(a, n)
+
+| Argument | Type | Description |
+| -------- | ---- | ----------- |
+| `a`      | INT or LONG | Value to shift |
+| `n`      | INT | Number of positions to shift |
+
+Returns: **INT** (if a is INT) or **LONG** (if a is LONG)
+
+### Usage Examples
+
+```sql
+SELECT bitShiftLeft(1, 2) AS value
+FROM myTable
+```
+
+| value |
+| ----- |
+| 4     |
+
+```sql
+SELECT bitShiftLeft(intCol, 2) AS shifted
+FROM myTable
+```
+
+## bitShiftRight
+
+Performs an arithmetic right bit shift operation (sign-extending).
+
+### Signature
+
+> bitShiftRight(a, n)
+
+| Argument | Type | Description |
+| -------- | ---- | ----------- |
+| `a`      | INT or LONG | Value to shift |
+| `n`      | INT | Number of positions to shift |
+
+Returns: **INT** (if a is INT) or **LONG** (if a is LONG)
+
+### Usage Examples
+
+```sql
+SELECT bitShiftRight(8, 2) AS value
+FROM myTable
+```
+
+| value |
+| ----- |
+| 2     |
+
+```sql
+SELECT bitShiftRight(intCol, 1) AS shifted
+FROM myTable
+```
+
+## bitShiftRightUnsigned / bitShiftRightLogical
+
+Performs a logical (unsigned) right bit shift operation, filling with zeros.
+
+### Signature
+
+> bitShiftRightUnsigned(a, n)
+> bitShiftRightLogical(a, n)
+
+| Argument | Type | Description |
+| -------- | ---- | ----------- |
+| `a`      | INT or LONG | Value to shift |
+| `n`      | INT | Number of positions to shift |
+
+Returns: **INT** (if a is INT) or **LONG** (if a is LONG)
+
+### Usage Examples
+
+```sql
+SELECT bitShiftRightUnsigned(-1, 1) AS value
+FROM myTable
+```
+
+| value |
+| ----- |
+| 2147483647 |
+
+```sql
+SELECT bitShiftRightUnsigned(intCol, 1) AS shifted
+FROM myTable
+```
+
+## bitExtract / extractBit
+
+Extracts the bit at position n, returning 1 if the bit is set, 0 otherwise.
+
+### Signature
+
+> bitExtract(a, n)
+> extractBit(a, n)
+
+| Argument | Type | Description |
+| -------- | ---- | ----------- |
+| `a`      | INT or LONG | Value to extract from |
+| `n`      | INT | Bit position (0-indexed) |
+
+Returns: **INT** (always, regardless of input type)
+
+### Usage Examples
+
+```sql
+SELECT bitExtract(12, 2) AS value
+FROM myTable
+```
+
+| value |
+| ----- |
+| 1     |
+
+```sql
+SELECT bitExtract(12, 0) AS value
+FROM myTable
+```
+
+| value |
+| ----- |
+| 0     |
+
+```sql
+SELECT id FROM myTable WHERE bitExtract(flags, 2) = 1
+```
+
+## Combined Usage Example
+
+```sql
+SELECT 
+  id,
+  bitAnd(flags, 15) AS lower_nibble,
+  bitOr(flags, 128) AS set_high_bit,
+  bitExtract(status, 3) AS is_active,
+  bitShiftLeft(count, 2) AS quad_count
+FROM myTable
+WHERE bitExtract(flags, 2) = 1
+```


### PR DESCRIPTION
This PR adds comprehensive documentation for the new polymorphic bitwise scalar functions added in apache/pinot#18115.

Documentation includes:
- bitAnd / bit_and - Bitwise AND operation
- bitOr / bit_or - Bitwise OR operation
- bitXor / bit_xor - Bitwise XOR operation
- bitNot - Bitwise NOT operation
- bitMask - Creates a bitmask with a single bit set
- bitShiftLeft - Left bit shift operation
- bitShiftRight - Arithmetic right bit shift (sign-extending)
- bitShiftRightUnsigned / bitShiftRightLogical - Logical right bit shift
- bitExtract / extractBit - Extract bit at position

All functions work with INT and LONG types with proper type behavior documented.

Related: apache/pinot#18115