### PR TITLE
docs: document polymorphic arithmetic scalar functions (apache/pinot#18171)

### DIFF
--- a/functions/math/README.md
+++ b/functions/math/README.md
@@ -80,14 +80,14 @@ Returns the negation of the value.
 Usage: `negate(col)`\
 Example: `SELECT negate(score) FROM myTable`
 
-**least(col1, col2)**\
-Returns the smaller of two values.
+[**least(col1, col2)**](least.md)\
+Returns the smaller of two values. Polymorphic across INT, LONG, FLOAT, DOUBLE, BIG_DECIMAL.
 
 Usage: `least(col1, col2)`\
 Example: `SELECT least(score1, score2) FROM myTable`
 
-**greatest(col1, col2)**\
-Returns the larger of two values.
+[**greatest(col1, col2)**](greatest.md)\
+Returns the larger of two values. Polymorphic across INT, LONG, FLOAT, DOUBLE, BIG_DECIMAL.
 
 Usage: `greatest(col1, col2)`\
 Example: `SELECT greatest(score1, score2) FROM myTable`

--- a/functions/math/abs.md
+++ b/functions/math/abs.md
@@ -4,11 +4,17 @@ description: This section contains reference documentation for the abs function.
 
 # ABS
 
-Absolute of a value
+Absolute value of a number. This is a polymorphic function that preserves the input numeric type.
 
 ## Signature
 
-> ABS(col1)
+ABS(col1)
+
+| Argument | Type                                    | Description           |
+| -------- | --------------------------------------- | --------------------- |
+| `col1`   | INT, LONG, FLOAT, DOUBLE, BIG_DECIMAL  | Value to get absolute |
+
+Returns the same type as the input argument.
 
 ## Usage Examples
 
@@ -29,3 +35,10 @@ from ignoreMe
 | value |
 | ----- |
 | 12.1  |
+
+```sql
+select ABS(-42) AS int_abs, ABS(-1000000L) AS long_abs, ABS(-3.14F) AS float_abs, ABS(-2.718) AS double_abs
+from myTable
+```
+
+Returns INT, LONG, FLOAT, DOUBLE respectively (preserving input type).

--- a/functions/math/greatest.md
+++ b/functions/math/greatest.md
@@ -1,0 +1,46 @@
+---
+description: >-
+  This section contains reference documentation for the greatest function.
+---
+
+# greatest
+
+Returns the larger of two values. This is a polymorphic function that preserves the input numeric type.
+
+## Signature
+
+greatest(col1, col2)
+
+| Argument | Type                                    | Description |
+| -------- | --------------------------------------- | ----------- |
+| `col1`   | INT, LONG, FLOAT, DOUBLE, BIG_DECIMAL  | First value |
+| `col2`   | INT, LONG, FLOAT, DOUBLE, BIG_DECIMAL  | Second value|
+
+Returns the same numeric type as the inputs (or the wider type if inputs differ).
+
+## Usage Examples
+
+```sql
+SELECT greatest(10, 5) AS value
+FROM myTable
+```
+
+| value |
+| ----- |
+| 10    |
+
+```sql
+SELECT greatest(10.5, 10.3) AS value
+FROM myTable
+```
+
+| value |
+| ----- |
+| 10.5  |
+
+```sql
+SELECT greatest(100, 50L) AS mixed_int_long, greatest(3.14F, 2.71F) AS float_greatest, greatest(3.14, 2.71) AS double_greatest
+FROM myTable
+```
+
+Returns INT/LONG, FLOAT, DOUBLE respectively (preserving input type or the wider type).

--- a/functions/math/least.md
+++ b/functions/math/least.md
@@ -1,0 +1,46 @@
+---
+description: >-
+  This section contains reference documentation for the least function.
+---
+
+# least
+
+Returns the smaller of two values. This is a polymorphic function that preserves the input numeric type.
+
+## Signature
+
+least(col1, col2)
+
+| Argument | Type                                    | Description |
+| -------- | --------------------------------------- | ----------- |
+| `col1`   | INT, LONG, FLOAT, DOUBLE, BIG_DECIMAL  | First value |
+| `col2`   | INT, LONG, FLOAT, DOUBLE, BIG_DECIMAL  | Second value|
+
+Returns the same numeric type as the inputs (or the wider type if inputs differ).
+
+## Usage Examples
+
+```sql
+SELECT least(10, 5) AS value
+FROM myTable
+```
+
+| value |
+| ----- |
+| 5     |
+
+```sql
+SELECT least(10.5, 10.3) AS value
+FROM myTable
+```
+
+| value |
+| ----- |
+| 10.3  |
+
+```sql
+SELECT least(100, 50L) AS mixed_int_long, least(3.14F, 2.71F) AS float_least, least(3.14, 2.71) AS double_least
+FROM myTable
+```
+
+Returns INT/LONG, FLOAT, DOUBLE respectively (preserving input type or the wider type).

--- a/functions/math/mod.md
+++ b/functions/math/mod.md
@@ -4,11 +4,18 @@ description: This section contains reference documentation for the MOD function.
 
 # MOD
 
-Modulo of two values
+Modulo (remainder) of two values. This is a polymorphic function that preserves the input numeric type.
 
 ## Signature
 
-> MOD(col1, col2)
+MOD(col1, col2)
+
+| Argument | Type                                    | Description |
+| -------- | --------------------------------------- | ----------- |
+| `col1`   | INT, LONG, FLOAT, DOUBLE, BIG_DECIMAL  | Dividend    |
+| `col2`   | INT, LONG, FLOAT, DOUBLE, BIG_DECIMAL  | Divisor     |
+
+Returns the same numeric type as the inputs (or the wider type if inputs differ).
 
 ## Usage Examples
 
@@ -29,3 +36,10 @@ from ignoreMe
 | value |
 | ----- |
 | 0     |
+
+```sql
+select MOD(12L, 5) AS long_mod, MOD(12.5F, 5.0F) AS float_mod, MOD(12.5, 5.0) AS double_mod
+from myTable
+```
+
+Returns LONG, FLOAT, DOUBLE respectively (preserving input type).

--- a/functions/math/moduloorzero.md
+++ b/functions/math/moduloorzero.md
@@ -5,18 +5,18 @@ description: >-
 
 # moduloOrZero
 
-Same as [MOD](mod.md) but returns zero when dividing by zero or when dividing `Long.MIN_VALUE` by `-1`.
+Same as [MOD](mod.md) but returns zero when dividing by zero or when dividing `Long.MIN_VALUE` by `-1`. This is a polymorphic function that preserves the input numeric type.
 
 ## Signature
 
-> moduloOrZero(col1, col2)
+moduloOrZero(col1, col2)
 
-| Argument | Type   | Description |
-| -------- | ------ | ----------- |
-| `col1`   | DOUBLE | Dividend    |
-| `col2`   | DOUBLE | Divisor     |
+| Argument | Type                                    | Description |
+| -------- | --------------------------------------- | ----------- |
+| `col1`   | INT, LONG, FLOAT, DOUBLE, BIG_DECIMAL  | Dividend    |
+| `col2`   | INT, LONG, FLOAT, DOUBLE, BIG_DECIMAL  | Divisor     |
 
-Returns: **DOUBLE**
+Returns the same numeric type as the inputs (or the wider type if inputs differ).
 
 ## Usage Examples
 
@@ -27,7 +27,7 @@ FROM myTable
 
 | value |
 | ----- |
-| 1.0   |
+| 1     |
 
 ```sql
 SELECT moduloOrZero(10, 0) AS value
@@ -36,4 +36,11 @@ FROM myTable
 
 | value |
 | ----- |
-| 0.0   |
+| 0     |
+
+```sql
+SELECT moduloOrZero(10L, 3L) AS long_modulo, moduloOrZero(10.5F, 3.0F) AS float_modulo, moduloOrZero(10.5, 3.0) AS double_modulo
+FROM myTable
+```
+
+Returns LONG, FLOAT, DOUBLE respectively (preserving input type).

--- a/functions/math/negate.md
+++ b/functions/math/negate.md
@@ -5,17 +5,17 @@ description: >-
 
 # negate
 
-Returns the negation of the input value.
+Returns the negation of the input value. This is a polymorphic function that preserves the input numeric type.
 
 ## Signature
 
-> negate(col)
+negate(col)
 
-| Argument | Type   | Description      |
-| -------- | ------ | ---------------- |
-| `col`    | DOUBLE | Value to negate  |
+| Argument | Type                                    | Description     |
+| -------- | --------------------------------------- | ---------------- |
+| `col`    | INT, LONG, FLOAT, DOUBLE, BIG_DECIMAL  | Value to negate  |
 
-Returns: **DOUBLE**
+Returns the same type as the input argument.
 
 ## Usage Examples
 
@@ -35,4 +35,11 @@ FROM myTable
 
 | value |
 | ----- |
-| 10.0  |
+| 10    |
+
+```sql
+SELECT negate(100) AS int_neg, negate(1000000L) AS long_neg, negate(3.14F) AS float_neg, negate(2.718) AS double_neg
+FROM myTable
+```
+
+Returns INT, LONG, FLOAT, DOUBLE respectively (preserving input type).

--- a/functions/math/positivemodulo.md
+++ b/functions/math/positivemodulo.md
@@ -5,18 +5,18 @@ description: >-
 
 # positiveModulo
 
-Returns the modulo of two values, always returning a non-negative result. If the standard modulo result is negative, it adds the absolute value of the divisor to produce a positive result.
+Returns the modulo of two values, always returning a non-negative result. If the standard modulo result is negative, it adds the absolute value of the divisor to produce a positive result. This is a polymorphic function that preserves the input numeric type.
 
 ## Signature
 
-> positiveModulo(col1, col2)
+positiveModulo(col1, col2)
 
-| Argument | Type   | Description |
-| -------- | ------ | ----------- |
-| `col1`   | DOUBLE | Dividend    |
-| `col2`   | DOUBLE | Divisor     |
+| Argument | Type                                    | Description |
+| -------- | --------------------------------------- | ----------- |
+| `col1`   | INT, LONG, FLOAT, DOUBLE, BIG_DECIMAL  | Dividend    |
+| `col2`   | INT, LONG, FLOAT, DOUBLE, BIG_DECIMAL  | Divisor     |
 
-Returns: **DOUBLE**
+Returns the same numeric type as the inputs (or the wider type if inputs differ).
 
 ## Usage Examples
 
@@ -27,7 +27,7 @@ FROM myTable
 
 | value |
 | ----- |
-| 1.0   |
+| 1     |
 
 ```sql
 SELECT positiveModulo(-7, 3) AS value
@@ -36,4 +36,11 @@ FROM myTable
 
 | value |
 | ----- |
-| 2.0   |
+| 2     |
+
+```sql
+SELECT positiveModulo(10L, 3L) AS long_modulo, positiveModulo(-7.5F, 3.0F) AS float_modulo, positiveModulo(-7.5, 3.0) AS double_modulo
+FROM myTable
+```
+
+Returns LONG, FLOAT, DOUBLE respectively (preserving input type).


### PR DESCRIPTION
This PR documents the polymorphic arithmetic scalar functions added in apache/pinot#18171:

- `abs`, `negate`, `mod`, `moduloOrZero`, `positiveModulo`, `least`, `greatest` are now type-preserving across INT, LONG, FLOAT, DOUBLE, BIG_DECIMAL
- Previously all coerced to DOUBLE; now returns the input numeric type
- Works in SELECT, WHERE, HAVING, both single-stage and multi-stage engines

Upstream PR: https://github.com/apache/pinot/pull/18171