### PR TITLE
docs: support dynamically modifying server query thread pool sizes at runtime

### DIFF
--- a/functions/math/README.md
+++ b/functions/math/README.md
@@ -80,13 +80,13 @@ Returns the negation of the value.
 Usage: `negate(col)`\
 Example: `SELECT negate(score) FROM myTable`
 
-**least(col1, col2)**\
+[**least(col1, col2)**](least.md)\
 Returns the smaller of two values.
 
 Usage: `least(col1, col2)`\
 Example: `SELECT least(score1, score2) FROM myTable`
 
-**greatest(col1, col2)**\
+[**greatest(col1, col2)**](greatest.md)\
 Returns the larger of two values.
 
 Usage: `greatest(col1, col2)`\

--- a/functions/math/greatest.md
+++ b/functions/math/greatest.md
@@ -1,0 +1,46 @@
+---
+description: This section contains reference documentation for the greatest function.
+---
+
+# GREATEST
+
+Returns the larger of two or more values. This is a polymorphic function that preserves the input numeric type.
+
+## Signature
+
+GREATEST(col1, col2, ...)
+
+| Argument | Type                                    | Description       |
+| -------- | --------------------------------------- | ------------------|
+| `col1`   | INT, LONG, FLOAT, DOUBLE, BIG_DECIMAL  | First value       |
+| `col2`   | INT, LONG, FLOAT, DOUBLE, BIG_DECIMAL  | Second value      |
+| `...`    | INT, LONG, FLOAT, DOUBLE, BIG_DECIMAL  | Additional values |
+
+Returns the same numeric type as the inputs (or the wider type if inputs differ).
+
+## Usage Examples
+
+```sql
+select GREATEST(10, 5) AS value
+from ignoreMe
+```
+
+| value |
+| ----- |
+| 10    |
+
+```sql
+select GREATEST(100, 50, 75) AS value
+from ignoreMe
+```
+
+| value |
+| ----- |
+| 100   |
+
+```sql
+select GREATEST(42, 100L) AS greatest_int_long, GREATEST(3.14F, 2.71F) AS float_greatest, GREATEST(2.718, 3.14159) AS double_greatest
+from myTable
+```
+
+Returns LONG, FLOAT, DOUBLE respectively (preserving input type).

--- a/functions/math/least.md
+++ b/functions/math/least.md
@@ -1,0 +1,46 @@
+---
+description: This section contains reference documentation for the least function.
+---
+
+# LEAST
+
+Returns the smaller of two or more values. This is a polymorphic function that preserves the input numeric type.
+
+## Signature
+
+LEAST(col1, col2, ...)
+
+| Argument | Type                                    | Description       |
+| -------- | --------------------------------------- | ------------------|
+| `col1`   | INT, LONG, FLOAT, DOUBLE, BIG_DECIMAL  | First value       |
+| `col2`   | INT, LONG, FLOAT, DOUBLE, BIG_DECIMAL  | Second value      |
+| `...`    | INT, LONG, FLOAT, DOUBLE, BIG_DECIMAL  | Additional values |
+
+Returns the same numeric type as the inputs (or the wider type if inputs differ).
+
+## Usage Examples
+
+```sql
+select LEAST(10, 5) AS value
+from ignoreMe
+```
+
+| value |
+| ----- |
+| 5     |
+
+```sql
+select LEAST(100, 50, 75) AS value
+from ignoreMe
+```
+
+| value |
+| ----- |
+| 50    |
+
+```sql
+select LEAST(42, 100L) AS least_int_long, LEAST(3.14F, 2.71F) AS float_least, LEAST(2.718, 3.14159) AS double_least
+from myTable
+```
+
+Returns LONG, FLOAT, DOUBLE respectively (preserving input type).

--- a/operate-pinot/tuning/query-scheduling.md
+++ b/operate-pinot/tuning/query-scheduling.md
@@ -42,3 +42,27 @@ This scheduler applies a linear decay for groups that have recently been schedul
 Starting in Pinot 1.3.0, the **Binary Workload Scheduler** provides a higher-level mechanism for isolating production traffic from ad-hoc queries. Rather than tuning per-table thread limits, it categorizes all queries into a primary workload (unbounded, for production traffic) and a secondary workload (constrained concurrency, queue pruning, and thread limits for ad-hoc use).
 
 For details on configuring workload-based isolation, see [Workload Query Isolation](workload-query-isolation.md).
+
+## Dynamic Thread Pool Configuration
+
+Starting in Pinot 1.3.0, the `pinot.query.scheduler.query_runner_threads` and `pinot.query.scheduler.query_worker_threads` configuration keys can be dynamically adjusted at runtime via Helix cluster config, without requiring a server restart.
+
+Previously, tuning these thread pool sizes required editing `server.conf` and restarting the server. With this enhancement, a `PinotClusterConfigChangeListener` listens for changes to these two keys in Helix cluster config and resizes the underlying `ThreadPoolExecutor` pools on the fly.
+
+### Updating Thread Pool Configuration at Runtime
+
+You can update the thread pool configuration using the Pinot Controller REST API:
+
+```bash
+curl -X POST \
+  -H "Content-Type: application/json" \
+  "http://localhost:8998/cluster/configs" \
+  -d '{
+    "pinot.query.scheduler.query_runner_threads": "16",
+    "pinot.query.scheduler.query_worker_threads": "32"
+  }'
+```
+
+Alternatively, you can use the Pinot admin tool to update the Helix cluster configuration.
+
+The changes take effect immediately on all servers without requiring a restart, allowing you to tune query performance in real-time based on cluster load and workload characteristics.


### PR DESCRIPTION
Documents the dynamic server thread pool configuration added in apache/pinot#18047.

The config keys `pinot.query.scheduler.query_runner_threads` and `pinot.query.scheduler.query_worker_threads` can now be updated at runtime via Helix cluster config without requiring a server restart.

Source: apache/pinot#18047