### PR TITLE
docs: add window ranking function pages and fix docs validation

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -451,6 +451,9 @@
 * [Unique Count and Cardinality Estimation Functions](build-with-pinot/querying-and-sql/unique-counting.md)
 * [Vector / Similarity Functions](functions/vector/README.md)
 * [Window Functions](functions/window/README.md)
+  * [ROW_NUMBER](functions/window/row_number.md)
+  * [RANK](functions/window/rank.md)
+  * [DENSE_RANK](functions/window/dense_rank.md)
 
 ## Workload Playbooks
 

--- a/build-with-pinot/querying-and-sql/function-index.md
+++ b/build-with-pinot/querying-and-sql/function-index.md
@@ -432,9 +432,9 @@ Window functions require the [multi-stage engine (MSE)](../../reference/configur
 
 | Function | Signature | Return Type | Description | Engine |
 |---|---|---|---|---|
-| `ROW_NUMBER` | `ROW_NUMBER() OVER (...)` | LONG | Sequential row number within partition | MSE |
-| `RANK` | `RANK() OVER (...)` | LONG | Rank with gaps for ties | MSE |
-| `DENSE_RANK` | `DENSE_RANK() OVER (...)` | LONG | Rank without gaps for ties | MSE |
+| [`ROW_NUMBER`](../../functions/window/row_number.md) | `ROW_NUMBER() OVER (...)` | LONG | Sequential row number within partition | MSE |
+| [`RANK`](../../functions/window/rank.md) | `RANK() OVER (...)` | LONG | Rank with gaps for ties | MSE |
+| [`DENSE_RANK`](../../functions/window/dense_rank.md) | `DENSE_RANK() OVER (...)` | LONG | Rank without gaps for ties | MSE |
 | `LAG` | `LAG(col [, offset [, default]]) OVER (...)` | varies | Value from a preceding row | MSE |
 | `LEAD` | `LEAD(col [, offset [, default]]) OVER (...)` | varies | Value from a following row | MSE |
 | `FIRST_VALUE` | `FIRST_VALUE(col) OVER (...)` | varies | First value in the window frame | MSE |

--- a/developers/plugin-architecture/write-custom-plugins/config-validator-spi.md
+++ b/developers/plugin-architecture/write-custom-plugins/config-validator-spi.md
@@ -212,4 +212,4 @@ Validation failures return HTTP 400 with the exception message in the response b
 ## See Also
 
 - [Plugin Architecture Overview](README.md)
-- [Pinot Configuration Reference](../../configuration/)
+- [Pinot Configuration Reference](../../../reference/configuration-reference/README.md)

--- a/functions/window/README.md
+++ b/functions/window/README.md
@@ -150,9 +150,9 @@ Supported window functions are listed in the following table.
 | [LAG](../../functions/aggregation/lag.md) | The `LAG` function provides access to a previous row within the same result set, without the need for a self-join. | `LAG(column_name, offset, default_value)` |  |
 | [FIRST_VALUE](../../functions/aggregation/first_value.md) | The `FIRST_VALUE` function returns the value from the first row in the window. | `FIRST_VALUE(salary)` |  |
 | [LAST_VALUE](../../functions/aggregation/last_value.md) | The `LAST_VALUE` function returns the value from the last row in the window | `LAST_VALUE(salary)` |  |
-| [ROW_NUMBER](../math/round.md) | Returns the number of the current row within its partition, counting from 1. | `ROW_NUMBER()` |  |
-| RANK | Returns the rank of the current row, with gaps - i.e., the `row_number` of the first row in its peer group. | `RANK()` |  |
-| DENSE_RANK | Returns the rank of the current row, without gaps. | `DENSE_RANK()` |  |
+| [ROW_NUMBER](row_number.md) | Returns the number of the current row within its partition, counting from 1. | `ROW_NUMBER()` |  |
+| [RANK](rank.md) | Returns the rank of the current row, with gaps - i.e., the `row_number` of the first row in its peer group. | `RANK()` |  |
+| [DENSE_RANK](dense_rank.md) | Returns the rank of the current row, without gaps. | `DENSE_RANK()` |  |
 
 Note that no window frame clause can be specified for `ROW_NUMBER`, `RANK`, and `DENSE_RANK` window functions since they're applied on the entire partition by definition. Similarly, no window frame clause can be specified for `LAG` and `LEAD` since the row `offset` is an input to those functions themselves.
 

--- a/functions/window/dense_rank.md
+++ b/functions/window/dense_rank.md
@@ -1,0 +1,77 @@
+---
+description: This section contains reference documentation for the DENSE_RANK window function.
+---
+
+# DENSE_RANK
+
+Returns the rank of the current row within its partition, without gaps for ties.
+
+`DENSE_RANK()` assigns the same rank to peer rows that compare equal under the window's `ORDER BY` clause. The next distinct value gets the next consecutive rank.
+
+## Signature
+
+```sql
+DENSE_RANK()
+```
+
+## Usage Notes
+
+* `DENSE_RANK()` takes no arguments.
+* Ranking restarts for each `PARTITION BY` group.
+* The row ranking is determined by the window's `ORDER BY` clause.
+* Equal rows receive the same rank, and subsequent ranks remain consecutive.
+* No explicit window frame clause can be specified for `DENSE_RANK()`.
+
+## Examples
+
+Rank salespeople by year-to-date sales without leaving gaps when values tie.
+
+```sql
+SELECT
+    FirstName,
+    LastName,
+    SalesYTD,
+    DENSE_RANK() OVER (ORDER BY SalesYTD DESC) AS sales_rank
+FROM Sales.vSalesPerson;
+```
+
+Output:
+
+| FirstName | LastName | SalesYTD | sales_rank |
+| --- | --- | --- | --- |
+| Joe | Smith | 2251368.34 | 1 |
+| Alice | Davis | 2151341.64 | 2 |
+| James | Jones | 2151341.64 | 2 |
+| Dane | Scott | 1251358.72 | 3 |
+
+Rank employees within each department by salary using consecutive ranks.
+
+```sql
+SELECT
+    department,
+    employee_name,
+    salary,
+    DENSE_RANK() OVER (
+        PARTITION BY department
+        ORDER BY salary DESC
+    ) AS salary_rank
+FROM employees;
+```
+
+Output:
+
+| department | employee_name | salary | salary_rank |
+| --- | --- | --- | --- |
+| Engineering | Alice | 160000 | 1 |
+| Engineering | Bob | 150000 | 2 |
+| Engineering | Carol | 150000 | 2 |
+| Engineering | Dave | 140000 | 3 |
+| Sales | Eve | 130000 | 1 |
+| Sales | Frank | 120000 | 2 |
+
+## Related Pages
+
+* [Window Functions](README.md)
+* [ROW_NUMBER](row_number.md)
+* [RANK](rank.md)
+* [Function Index](../../build-with-pinot/querying-and-sql/function-index.md)

--- a/functions/window/rank.md
+++ b/functions/window/rank.md
@@ -1,0 +1,77 @@
+---
+description: This section contains reference documentation for the RANK window function.
+---
+
+# RANK
+
+Returns the rank of the current row within its partition, with gaps for ties.
+
+`RANK()` assigns the same rank to peer rows that compare equal under the window's `ORDER BY` clause. The next rank then skips ahead by the number of tied rows.
+
+## Signature
+
+```sql
+RANK()
+```
+
+## Usage Notes
+
+* `RANK()` takes no arguments.
+* Ranking restarts for each `PARTITION BY` group.
+* The row ranking is determined by the window's `ORDER BY` clause.
+* Equal rows receive the same rank, and subsequent ranks contain gaps.
+* No explicit window frame clause can be specified for `RANK()`.
+
+## Examples
+
+Rank salespeople by year-to-date sales, leaving gaps when values tie.
+
+```sql
+SELECT
+    FirstName,
+    LastName,
+    SalesYTD,
+    RANK() OVER (ORDER BY SalesYTD DESC) AS sales_rank
+FROM Sales.vSalesPerson;
+```
+
+Output:
+
+| FirstName | LastName | SalesYTD | sales_rank |
+| --- | --- | --- | --- |
+| Joe | Smith | 2251368.34 | 1 |
+| Alice | Davis | 2151341.64 | 2 |
+| James | Jones | 2151341.64 | 2 |
+| Dane | Scott | 1251358.72 | 4 |
+
+Rank employees within each department by salary.
+
+```sql
+SELECT
+    department,
+    employee_name,
+    salary,
+    RANK() OVER (
+        PARTITION BY department
+        ORDER BY salary DESC
+    ) AS salary_rank
+FROM employees;
+```
+
+Output:
+
+| department | employee_name | salary | salary_rank |
+| --- | --- | --- | --- |
+| Engineering | Alice | 160000 | 1 |
+| Engineering | Bob | 150000 | 2 |
+| Engineering | Carol | 150000 | 2 |
+| Engineering | Dave | 140000 | 4 |
+| Sales | Eve | 130000 | 1 |
+| Sales | Frank | 120000 | 2 |
+
+## Related Pages
+
+* [Window Functions](README.md)
+* [ROW_NUMBER](row_number.md)
+* [DENSE_RANK](dense_rank.md)
+* [Function Index](../../build-with-pinot/querying-and-sql/function-index.md)

--- a/functions/window/row_number.md
+++ b/functions/window/row_number.md
@@ -1,0 +1,73 @@
+---
+description: This section contains reference documentation for the ROW_NUMBER window function.
+---
+
+# ROW_NUMBER
+
+Returns the sequential number of the current row within its partition, counting from 1.
+
+`ROW_NUMBER()` is commonly used to rank rows after sorting them inside each partition. For deterministic results, specify an `ORDER BY` clause in the window definition.
+
+## Signature
+
+```sql
+ROW_NUMBER()
+```
+
+## Usage Notes
+
+* `ROW_NUMBER()` takes no arguments.
+* Numbering restarts for each `PARTITION BY` group.
+* The row order is determined by the window's `ORDER BY` clause.
+* No explicit window frame clause can be specified for `ROW_NUMBER()`.
+
+## Examples
+
+Assign a row number to each salesperson by year-to-date sales.
+
+```sql
+SELECT
+    ROW_NUMBER() OVER (ORDER BY SalesYTD DESC) AS Row,
+    FirstName,
+    LastName,
+    SalesYTD AS "Total sales YTD"
+FROM Sales.vSalesPerson;
+```
+
+Output:
+
+| Row | FirstName | LastName | Total sales YTD |
+| --- | --- | --- | --- |
+| 1 | Joe | Smith | 2251368.34 |
+| 2 | Alice | Davis | 2151341.64 |
+| 3 | James | Jones | 1551363.54 |
+| 4 | Dane | Scott | 1251358.72 |
+
+Assign a row number within each customer partition, ordered by payment time.
+
+```sql
+SELECT
+    customer_id,
+    payment_date,
+    amount,
+    ROW_NUMBER() OVER (
+        PARTITION BY customer_id
+        ORDER BY payment_date
+    ) AS payment_number
+FROM payment;
+```
+
+Output:
+
+| customer_id | payment_date | amount | payment_number |
+| --- | --- | --- | --- |
+| 1 | 2023-02-14 23:22:38.996577 | 5.99 | 1 |
+| 1 | 2023-02-15 16:31:19.996577 | 0.99 | 2 |
+| 1 | 2023-02-15 19:37:12.996577 | 9.99 | 3 |
+| 2 | 2023-02-17 19:23:24.996577 | 2.99 | 1 |
+| 2 | 2023-02-17 19:24:10.996577 | 0.99 | 2 |
+
+## Related Pages
+
+* [Window Functions](README.md)
+* [Function Index](../../build-with-pinot/querying-and-sql/function-index.md)


### PR DESCRIPTION
## Summary
- add standalone docs for `ROW_NUMBER`, `RANK`, and `DENSE_RANK` under `functions/window/`
- link the new pages from the window overview, function index, and `SUMMARY.md`
- remove the stale tracked `pinot-site` gitlink that caused checkout cleanup warnings
- fix a broken configuration-reference link in `config-validator-spi.md` so the full docs audit passes

## User Manual
Users can now open dedicated reference pages for Pinot window ranking functions:
- `ROW_NUMBER` for sequential numbering within a partition
- `RANK` for ranking with gaps on ties
- `DENSE_RANK` for ranking without gaps on ties

The window functions overview page and function index now link directly to those pages.

## Sample Queries
```sql
SELECT
    customer_id,
    payment_date,
    amount,
    ROW_NUMBER() OVER (PARTITION BY customer_id ORDER BY payment_date) AS payment_number
FROM payment;
```

```sql
SELECT
    FirstName,
    LastName,
    SalesYTD,
    RANK() OVER (ORDER BY SalesYTD DESC) AS sales_rank,
    DENSE_RANK() OVER (ORDER BY SalesYTD DESC) AS dense_sales_rank
FROM Sales.vSalesPerson;
```

## Validation
- `python3 scripts/validate-docs.py --changed-only=<(printf '%s\\n' SUMMARY.md build-with-pinot/querying-and-sql/function-index.md functions/window/README.md functions/window/row_number.md functions/window/rank.md functions/window/dense_rank.md)`
- `python3 scripts/validate-docs.py`
- inspected GitHub Actions failures for PR #741 and reproduced the failing full-audit job locally before fixing the broken link