### PR TITLE
docs: add retention creation time fallback config (apache/pinot#18148)

### DIFF
--- a/basics/concepts/segment-retention.md
+++ b/basics/concepts/segment-retention.md
@@ -18,6 +18,12 @@ There are a couple of scenarios where segments in offline tables won't be purged
 * If the segment doesn't have an end time. This would happen if the segment doesn't contain a time column.
 * If the segment's table has a `segmentIngestionType` of `REFRESH`.
 
+## Handling segments with invalid end times
+
+By default, when a segment's end time is invalid or missing, the retention manager skips it entirely, and the segment is never deleted regardless of the retention policy. To enable automatic cleanup of such segments, you can enable the creation time fallback by setting `controller.retentionManager.enableCreationTimeFallback` to `true` in the cluster configuration. When enabled, the retention manager will use the segment's creation time (`segmentZKMetadata.getCreationTime()`) as a fallback if the end time is invalid.
+
+This configuration is **dynamic** and does not require a controller restart to take effect. It can be updated through the cluster config change listener.
+
 If the retention period isn't specified, segments aren't purged from tables.
 
 The retention manager initially moves these segments into a _Deleted Segments_ area, from where they will eventually be permanently removed. The duration that deleted segments are kept is controlled by the `controller.deleted.segments.retentionInDays` configuration (default: 7 days).

--- a/reference/configuration-reference/controller.md
+++ b/reference/configuration-reference/controller.md
@@ -163,12 +163,13 @@ When `controller.realtime.segment.partialOfflineReplicaRepairEnabled` is enabled
 
 This task manages retention of segments for all tables. During the run, it looks at the `retentionTimeUnit` and `retentionTimeValue` inside the `segmentsConfig` of every table, and deletes segments which are older than the retention. The deleted segments are moved to a DeletedSegments folder colocated with the dataDir on segment store, and permanently deleted from that folder in a configurable number of days.
 
-| Config | Default Value |
-| --- | --- |
-| controller.retention.frequencyPeriod | 6h |
-| controller.retentionManager.initialDelayInSeconds | between 2m-5m |
-| controller.deleted.segments.retentionInDays | 7d |
-| controller.enable.hybrid.table.retention.strategy | false |
+| Config | Default Value | Description |
+| --- | --- | --- |
+| controller.retention.frequencyPeriod | 6h | Frequency at which the retention manager runs |
+| controller.retentionManager.initialDelayInSeconds | between 2m-5m | Randomized initial delay before first retention manager run |
+| controller.retentionManager.enableCreationTimeFallback | false | If true, use segment creation time as fallback when end time is invalid/missing, enabling cleanup of such segments; dynamic config, no restart needed |
+| controller.deleted.segments.retentionInDays | 7d | Duration for which to retain deleted segments |
+| controller.enable.hybrid.table.retention.strategy | false | If true, use hybrid retention strategy for hybrid tables |
 
 If `controller.enable.hybrid.table.retention.strategy` is set to true, the retention manager will use the hybrid 
 retention strategy. In this strategy, the retention manager calculates a time boundary by looking at the maximum end


### PR DESCRIPTION
Adds documentation for the new `controller.retentionManager.enableCreationTimeFallback` cluster configuration.

## Related Upstream PR
- apache/pinot#18148: Add support for handling scenarios where end time is invalid during RetentionManager run

## Changes
- Updated `basics/concepts/segment-retention.md` with a new section explaining the creation time fallback feature
- Updated `reference/configuration-reference/controller.md` to document the new configuration parameter with full descriptions

## Details
When a segment's end time is invalid or missing, the retention manager can now use the segment's creation time as a fallback (when enabled). This is a dynamic configuration that does not require a controller restart.