### PR TITLE
docs: Fix Parquet LIST/MAP wrapper extraction (apache/pinot#18325)

### DIFF
--- a/build-with-pinot/ingestion/pinot-input-formats.md
+++ b/build-with-pinot/ingestion/pinot-input-formats.md
@@ -160,6 +160,19 @@ For the support of DECIMAL and other parquet native data types, always use `Parq
 | REPEATED             | MULTIVALUE/MAP (represented as MV | if parquet original type is LIST, then it is converted to MULTIVALUE column otherwise a MAP column.                                                 |
 
 For `ParquetAvroRecordReader` , you can refer to the [Avro section above](pinot-input-formats.md#avro) for the type conversions.
+#### LIST and MAP wrapper extraction
+
+Parquet LIST and MAP wrapper structs are now properly unwrapped when ingesting via `ParquetNativeRecordReader` and `ParquetAvroRecordReader`. Previously, schema-identified LIST and MAP columns had their wrapper elements exposed in the data:
+
+- An `array<string>` field previously came back as `[{"element": "abc"}, {"element": "xyz"}]` — now it correctly comes back as `["abc", "xyz"]`.
+- A `map<string,string>` field previously came back as `{"key_value":[{"key":"k","value":"v"}]}` — now it correctly comes back as `{"k":"v"}`.
+
+Real struct fields named `element` are preserved; only schema-identified LIST and MAP wrappers are normalized. The readers support both the standard 3-level Parquet LIST encoding and legacy 2-level encodings (repeated primitive, repeated multi-field group, or repeated single-field group not named `element`).
+
+**Backward incompatibility:** If you have ingestion pipelines or transform expressions that worked around the previous broken shape (for example, selecting `data.element` instead of `data` for an array column), you will need to update those queries and transforms.
+
+**MAP order caveat:** Parquet does not guarantee that MAP entries are returned in any particular order. If you require stable ordering of key-value pairs, use `LIST<STRUCT<key, value>>` instead.
+
 
 ### ORC
 


### PR DESCRIPTION
This PR documents the fix for Parquet LIST/MAP wrapper extraction in the native and Avro-backed Parquet readers.

## Upstream PR
- apache/pinot#18325: Fix Parquet LIST/MAP wrapper extraction in native and Avro readers

## Changes
Updated `build-with-pinot/ingestion/pinot-input-formats.md` with documentation of:
- Proper unwrapping of Parquet LIST and MAP wrapper structs
- Examples of corrected behavior for array and map fields
- Support for both standard 3-level and legacy 2-level Parquet LIST encodings
- **Backward incompatibility warning:** Pipelines that worked around the previous broken shape need updates
- MAP order caveat for Parquet readers

## Backward Incompatibility
This is a **backward incompatible** change. Users who relied on the previous broken shape (accessing `data.element` for array columns) will need to update their queries and transforms to use the correct flat array access pattern.