### PR TITLE
docs: Handle DST spring-forward gaps in fromDateTime() (apache/pinot#18311)

### DIFF
--- a/functions/datetime/fromdatetime.md
+++ b/functions/datetime/fromdatetime.md
@@ -8,7 +8,7 @@ Converts a formatted date-time string to milliseconds, based on the provided [Jo
 
 ## Signature
 
-> FromDateTime(dateTimeString, pattern)
+FromDateTime(dateTimeString, pattern)
 
 ## Usage Examples
 
@@ -56,3 +56,18 @@ FROM ignoreMe
 | epochMillis   |
 | ------------- |
 | 1565190733000 |
+
+## DST Handling
+
+When the parsed wall-clock time falls in a daylight saving time (DST) spring-forward gap (where a local time does not exist in the target timezone), `FromDateTime()` automatically shifts the time forward to the next valid instant. This behavior aligns with standard implementations in Trino, Spark, and BigQuery.
+
+**Example:** In 2026, Africa/Cairo observes a DST transition where midnight (00:00) does not exist on April 24th, jumping directly to 01:00. Parsing with this date returns the instant for 01:00 Cairo time:
+
+```sql
+SELECT FromDateTime('2026-04-24', 'yyyy-MM-dd', 'Africa/Cairo') AS epochMillis
+FROM ignoreMe
+```
+
+**Behavior Change:** The 4-argument overload `FromDateTime(ts, pattern, tz, defaultVal)` previously returned the `defaultVal` when encountering a DST-gap input. As of this change, it now returns the resolved instant instead, consistent with the 3-argument overload.
+
+**Error Handling:** Other parsing errors (unparseable input, out-of-range field values) continue to surface as exceptions, unchanged from previous behavior.


### PR DESCRIPTION
Updates documentation for fromDateTime() to explain DST spring-forward gap handling.

References: https://github.com/apache/pinot/pull/18311

Changes:
- Added DST Handling section explaining the behavior
- Documents that DST gaps are resolved by shifting forward to the next valid instant
- Notes behavior change in 4-argument overload
- Aligns with Trino/Spark/BigQuery implementations