### PR TITLE
docs: Raise Pinot Java baseline to 21 (apache/pinot#18046)

### DIFF
--- a/basics/getting-started/install/README.md
+++ b/basics/getting-started/install/README.md
@@ -12,7 +12,7 @@ Select the right installation method for your use case and deploy a Pinot cluste
 
 | Method | Best for | Time | Prerequisites |
 |---|---|---|---|
-| [Local](local.md) | Development, debugging | 10 min | JDK 11+ |
+| [Local](local.md) | Development, debugging | 10 min | JDK 21+ |
 | [Docker](docker.md) | Quick evaluation, CI | 5 min | Docker |
 | [Kubernetes](kubernetes.md) | Staging, production | 15 min | K8s cluster, Helm |
 | [Managed Kubernetes](managed-kubernetes/) | Production on cloud | 20 min | Cloud account, CLI tools |

--- a/basics/getting-started/install/docker.md
+++ b/basics/getting-started/install/docker.md
@@ -287,6 +287,12 @@ docker container ls -a
 
 You should see containers for ZooKeeper, Controller, Broker, Server, and Minion all in a healthy state. Open the Pinot Query Console at [http://localhost:9000](http://localhost:9000) to confirm the cluster is ready.
 
+## Docker image versions
+
+Pinot Docker images are built with **JDK 21** by default. For forward-looking compatibility testing, a **JDK 25** image variant is also available. Previous JDK 11 and JDK 17 image variants are no longer published starting with this release.
+
+If you are running deployments pinned to older JDK 11 or JDK 17 image tags (e.g., `apachepinot/pinot:1.4.0-java-11` or `apachepinot/pinot:1.4.0-java-17`), you must update to the JDK 21 image tag before adopting this release.
+
 ## Next step
 
 Your cluster is running. Continue to [First table and schema](../first-table-and-schema.md) to load data.

--- a/basics/getting-started/install/local.md
+++ b/basics/getting-started/install/local.md
@@ -10,8 +10,12 @@ Start a multi-component Pinot cluster directly on your machine without container
 
 ## Prerequisites
 
-* JDK 11 or 21 (JDK 17 should work but is not officially supported)
+* JDK 21 or later (required for building and running Pinot services)
 * Apache Maven 3.6+ (only if building from source)
+
+{% hint style="info" %}
+**Note:** The SPI and Java/JDBC client modules (`pinot-spi`, `pinot-java-client`, `pinot-jdbc-client`) remain compatible with Java 11 for external JVM consumers.
+{% endhint %}
 
 ## Steps
 

--- a/basics/getting-started/pinot-versions.md
+++ b/basics/getting-started/pinot-versions.md
@@ -43,12 +43,12 @@ Start Here pages never use the `latest` Docker tag. Always pin to a specific ver
 
 | Requirement | Detail |
 | --- | --- |
-| Recommended JDK | **JDK 11** or **JDK 21** |
-| JDK 17 | Should work but is not officially supported |
+| **Build/Runtime baseline** | **JDK 21+** (required for Pinot services) |
+| **Client libraries** | JDK 11+ (SPI and Java/JDBC client artifacts remain compatible with Java 11) |
 | Pinot 1.0+ minimum | JDK 11 or higher required |
 | JDK 8 support | Pinot **0.12.1** is the last version that supports JDK 8 |
 
-If you are running JDK 8 and cannot upgrade, use Pinot 0.12.1. For all new deployments, JDK 11 or 21 is recommended.
+**Starting with this release:** Pinot services require **JDK 21 or later** for building and runtime. The SPI and Java/JDBC client modules (`pinot-spi`, `pinot-java-client`, `pinot-jdbc-client`) are compiled to Java 11 bytecode for backward compatibility with external JVM consumers.
 
 ## Release links
 

--- a/developers/developers-and-contributors/extending-pinot/README.md
+++ b/developers/developers-and-contributors/extending-pinot/README.md
@@ -49,4 +49,4 @@ Before extending Pinot, make sure you have:
 
 * A local Pinot development environment set up (see [Dev Environment Setup](../code-setup.md))
 * Familiarity with Pinot's [architecture and components](../../../basics/concepts/)
-* Java 11+ and Maven for building
+* Java 21+ and Maven for building

--- a/operate-pinot/deployment.md
+++ b/operate-pinot/deployment.md
@@ -11,7 +11,7 @@ This section covers everything you need to deploy an Apache Pinot cluster, from 
 
 ## Prerequisites
 
-- Java 11 or later installed (or Docker if using container-based deployment).
+- Java 21 or later installed (or Docker if using container-based deployment).
 - A running Apache ZooKeeper ensemble (three nodes recommended for production).
 - Access to a deep store (local filesystem for development; S3, GCS, HDFS, or ADLS for production).
 - The Pinot binary distribution downloaded from [pinot.apache.org/download](https://pinot.apache.org/download) or the official Docker image.


### PR DESCRIPTION
Updates documentation to reflect the Java 21 baseline for Pinot services build and runtime.

## Changes

- Updated Java version requirements to JDK 21+ for building and running Pinot services
- Added note that SPI and Java/JDBC client modules remain compatible with Java 11
- Added Docker image version information noting JDK 21 default and JDK 25 forward-looking variant
- Documented that deployments must move to JDK 21 image tags before adopting this release

## Related PRs

Upstream: https://github.com/apache/pinot/pull/18046

## Files Updated

- basics/getting-started/install/local.md
- basics/getting-started/install/README.md
- basics/getting-started/pinot-versions.md
- basics/getting-started/install/docker.md
- operate-pinot/deployment.md
- developers/developers-and-contributors/extending-pinot/README.md