### PR TITLE
Add SOUNDEX and DIFFERENCE function docs

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -431,6 +431,8 @@
   * [rtrim](functions/string/rtrim.md)
   * [length](functions/string/length.md)
   * [levenshtein_distance](functions/string/levenshtein_distance.md)
+  * [soundex](functions/string/soundex.md)
+  * [difference](functions/string/difference.md)
   * [splitPart](functions/string/splitpart.md)
   * [strpos](functions/string/strpos.md)
   * [startswith](functions/string/startswith.md)

--- a/build-with-pinot/querying-and-sql/function-index.md
+++ b/build-with-pinot/querying-and-sql/function-index.md
@@ -105,6 +105,8 @@ For full details, see [String Functions](../../functions/string/).
 | `STRCMP` | `STRCMP(str1, str2)` | INT | Compares two strings lexicographically | Both |
 | `HAMMINGDISTANCE` | `HAMMINGDISTANCE(str1, str2)` | INT | Hamming distance between two strings | Both |
 | [`LEVENSTEINDISTANCE`](../../functions/string/levenshtein_distance.md) | `LEVENSTEINDISTANCE(str1, str2)` | INT | Levenshtein edit distance | Both |
+| [`SOUNDEX`](../../functions/string/soundex.md) | `SOUNDEX(str)` | STRING | Returns the four-character Soundex code for a string | Both |
+| [`DIFFERENCE`](../../functions/string/difference.md) | `DIFFERENCE(str1, str2)` | INT | Returns a 0-4 similarity score by comparing Soundex codes | Both |
 
 ---
 

--- a/functions/string/README.md
+++ b/functions/string/README.md
@@ -46,6 +46,12 @@ calculate length of the string
 [**levenshtein_distance(string1, string2)**](levenshtein_distance.md)\
 Returns the Levenshtein edit distance between two strings
 
+[**SOUNDEX(string)**](soundex.md)\
+Returns the four-character Soundex code for a string. Empty strings return `0000`.
+
+[**DIFFERENCE(string1, string2)**](difference.md)\
+Compares two Soundex codes and returns a similarity score from `0` to `4`.
+
 **hammingDistance(string1, string2)**\
 Returns the Hamming distance between two strings of equal length. Returns -1 if the strings have different lengths.
 

--- a/functions/string/difference.md
+++ b/functions/string/difference.md
@@ -1,0 +1,65 @@
+---
+description: This section contains reference documentation for the difference function.
+---
+
+# difference
+
+Returns a similarity score from `0` to `4` by comparing the four-character Soundex codes for two strings.
+
+A score of `4` means the Soundex codes are identical. A score of `0` means no Soundex positions match.
+
+## Signature
+
+> difference(string1, string2) -> int
+
+## Usage Examples
+
+```sql
+SELECT difference('Robert', 'Rupert') AS value
+FROM ignoreMe
+```
+
+| value |
+| ----- |
+| 4     |
+
+```sql
+SELECT difference('Smith', 'Johnson') AS value
+FROM ignoreMe
+```
+
+| value |
+| ----- |
+| 1     |
+
+```sql
+SELECT difference('Ann', 'Ann') AS value
+FROM ignoreMe
+```
+
+| value |
+| ----- |
+| 4     |
+
+```sql
+SELECT difference('', '') AS value
+FROM ignoreMe
+```
+
+| value |
+| ----- |
+| 4     |
+
+```sql
+SELECT difference('Robert', '') AS value
+FROM ignoreMe
+```
+
+| value |
+| ----- |
+| 0     |
+
+## Notes
+
+- `difference()` calls `soundex()` internally and compares the four Soundex characters position by position.
+- Pinot null-propagates this function when either argument is `null`.

--- a/functions/string/soundex.md
+++ b/functions/string/soundex.md
@@ -1,0 +1,56 @@
+---
+description: This section contains reference documentation for the soundex function.
+---
+
+# soundex
+
+Returns the four-character Soundex code for a string.
+
+Pinot returns `0000` for the empty string. If the input is `null`, Pinot returns `null`.
+
+## Signature
+
+> soundex(string) -> string
+
+## Usage Examples
+
+```sql
+SELECT soundex('Robert') AS value
+FROM ignoreMe
+```
+
+| value |
+| ----- |
+| R163  |
+
+```sql
+SELECT soundex('Rupert') AS value
+FROM ignoreMe
+```
+
+| value |
+| ----- |
+| R163  |
+
+```sql
+SELECT soundex('Ashcraft') AS value
+FROM ignoreMe
+```
+
+| value |
+| ----- |
+| A261  |
+
+```sql
+SELECT soundex('') AS value
+FROM ignoreMe
+```
+
+| value |
+| ----- |
+| 0000  |
+
+## Notes
+
+- `soundex('Robert')` and `soundex('Rupert')` return the same code because the function is designed for phonetic matching.
+- Pinot derives this behavior from `StringFunctions.soundex(...)` in `apache/pinot` merge commit `51e610d486bf8aadd647b4b69f34e9c70ef0ebea`.


### PR DESCRIPTION
## What changed for readers
- Added reference pages for the `SOUNDEX` and `DIFFERENCE` scalar functions.
- Linked both functions from the string function landing page and the SQL function index.
- Added both function pages to the docs navigation so they are directly discoverable.

## Structural changes
- No docs IA changes beyond adding the two new function entries to existing function-reference navigation.

## Cross-check against apache/pinot
- Verified behavior against `/Users/xiangfu/claude-workspace/pinot-doc-expert/pinot` at merge commit `51e610d486bf8aadd647b4b69f34e9c70ef0ebea`.
- Confirmed `soundex(null) -> null`, `soundex('') -> '0000'`, and the tested `difference()` examples from `StringFunctionsTest`.

## Validation
- `git diff --check`
- Lightweight Markdown link validation for the edited files
