### PR TITLE
Document dimension table segment assignment validation

### DIFF
--- a/build-with-pinot/ingestion/batch-ingestion/dim-table.md
+++ b/build-with-pinot/ingestion/batch-ingestion/dim-table.md
@@ -58,6 +58,7 @@ Mark a table as a dimension table by setting the following properties in the tab
 | --- | --- | --- |
 | `isDimTable` | Yes | Set to `true` to designate the table as a dimension table. |
 | `ingestionConfig.batchIngestionConfig.segmentIngestionType` | Yes | Must be set to `REFRESH`. Dimension tables use segment replacement rather than append semantics so that the in-memory hash map is rebuilt with the latest data. |
+| `validationConfig.segmentAssignmentStrategy` | No | If set, must be `allservers`. Leaving it unset also works because Pinot automatically uses all-servers assignment for dimension tables. |
 | `quota.storage` | Recommended | Storage quota for the table. Must not exceed the cluster-level `controller.dimTable.maxSize` (default 200 MB). |
 | `dimensionTableConfig.disablePreload` | No | Set to `true` to use memory-optimized mode (store only primary key and segment reference instead of full rows). Defaults to `false` (fast lookup). |
 | `dimensionTableConfig.errorOnDuplicatePrimaryKey` | No | Set to `true` to fail segment loading if duplicate primary keys are detected across segments. Defaults to `false` (last-loaded segment wins). |
@@ -65,6 +66,10 @@ Mark a table as a dimension table by setting the following properties in the tab
 ### Schema configuration
 
 Dimension table schemas use `dimensionFieldSpecs` instead of `metricFieldSpecs`. A `primaryKeyColumns` array is **required** -- it defines the key used for lookups.
+
+{% hint style="warning" %}
+Dimension tables always use the `allservers` segment assignment strategy so every segment is replicated to every server in the tenant. Do not configure balanced, replica-group, or round-robin segment assignment for a dimension table. Pinot now rejects those values during table validation.
+{% endhint %}
 
 ### Example table configuration
 
@@ -74,6 +79,9 @@ Dimension table schemas use `dimensionFieldSpecs` instead of `metricFieldSpecs`.
     "tableName": "dimBaseballTeams_OFFLINE",
     "tableType": "OFFLINE",
     "segmentsConfig": {
+    },
+    "validationConfig": {
+      "segmentAssignmentStrategy": "allservers"
     },
     "ingestionConfig": {
       "batchIngestionConfig": {

--- a/operate-pinot/segment-assignment.md
+++ b/operate-pinot/segment-assignment.md
@@ -8,6 +8,10 @@ description: >-
 
 Segment assignment refers to the strategy of assigning each segment from a table to the servers hosting the table. Picking the best segment assignment strategy can help reduce the overhead of the query routing, thus providing better performance.
 
+## Dimension Tables
+
+Dimension tables are a special case: Pinot always assigns their segments to all servers in the tenant so lookup queries can run locally on every server. If you set `validationConfig.segmentAssignmentStrategy` on a dimension table, the only supported value is `allservers`; leaving it unset also works. Balanced, replica-group, and round-robin strategies do not apply to dimension tables.
+
 ## Balanced Segment Assignment
 
 Balanced Segment Assignment is the default assignment strategy, where each segment is assigned to the server with the least segments already assigned. With this strategy, each server will have balanced query load, and each query will be routed to all the servers. It requires minimum configuration, and works well for small use cases.


### PR DESCRIPTION
## What changed for readers
- documents that dimension tables only support the `allservers` segment assignment strategy
- shows the exact `validationConfig.segmentAssignmentStrategy` setting to use, or that it can be omitted
- warns operators not to configure balanced, replica-group, or round-robin assignment on dimension tables

## Structural changes
- updated the dimension table ingestion page
- added a short dimension-table note to the segment assignment guide

## Cross-checked against apache/pinot
- `pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java`
- `pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/strategy/SegmentAssignmentStrategyFactory.java`
- `pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java`
- merge commit `168242b20855b7e8fd85a055b553b241314c612b`

## Validation
- `git diff --check`
- lightweight relative-link validation for the edited docs files
