### PR TITLE
docs: add ColumnMetadata SPI upgrade note

### DIFF
--- a/developers/developers-and-contributors/code-modules-and-organization.md
+++ b/developers/developers-and-contributors/code-modules-and-organization.md
@@ -15,7 +15,7 @@ These modules define the interfaces, data types, and shared utilities that the r
 | Module | Description |
 | --- | --- |
 | `pinot-spi` | Service Provider Interface -- defines plugin contracts for file systems, stream ingestion, input formats, metrics, authentication, and more. All plugin implementations depend on this module. |
-| `pinot-segment-spi` | Segment-level SPI -- abstractions for column data sources, readers, and segment metadata used by both local and remote segment implementations. |
+| `pinot-segment-spi` | Segment-level SPI -- abstractions for column data sources, readers, and segment metadata used by both local and remote segment implementations. Many of these interfaces are `@InterfaceAudience.Private`, so custom implementations that compile against them should be revalidated on each Pinot upgrade. |
 | `pinot-common` | Shared classes used across Pinot components including table config definitions, metrics helpers, Zookeeper metadata models, request/response formats, and common utilities. |
 
 ## Segment Storage

--- a/operate-pinot/upgrade-notes.md
+++ b/operate-pinot/upgrade-notes.md
@@ -34,6 +34,43 @@ The following `@Deprecated(forRemoval = true)` wrapper methods in `PinotTaskMana
 
 *Source: [PR #18275](https://github.com/apache/pinot/pull/18275)*
 
+### Segment SPI upgrade for custom segment and index extensions
+
+Apache Pinot 1.6.0 changes several `@InterfaceAudience.Private` types in
+`pinot-segment-spi`. This is a developer-facing compatibility change for
+custom code that implements Pinot's segment-level interfaces. It does not
+change query syntax, table configuration, or normal segment readability for
+clusters that only use built-in Pinot components.
+
+The breaking changes in [PR #18280](https://github.com/apache/pinot/pull/18280)
+include:
+
+- `ColumnMetadata` now requires explicit implementations for
+  `isMinMaxValueInvalid()`, `getLengthOfShortestElement()`,
+  `getLengthOfLongestElement()`, `isAscii()`, `getNumIndexes()`,
+  `getIndexType()`, `getIndexSize()`, and `getIndexSizeFor()`.
+- `ColumnMetadata.getIndexSizeMap()` has been removed.
+- `ColumnMetadata.INDEX_NOT_FOUND` has been renamed to `UNAVAILABLE`.
+- `ColumnMetadata.getColumnMaxLength()` is deprecated for removal. Migrate to
+  `getLengthOfLongestElement()`.
+- `MapIndexReader` no longer has the reader generic parameter, and the API has
+  been simplified from `getKeyIndexes()` / `getKeyMetadata()` to
+  `getIndexes()` / `getColumnMetadata()`. The legacy helper methods
+  `getKeyReader()`, `getKeyFieldSpec()`, and `getKeyStoredType()` were also
+  removed.
+- `ColumnPartitionMetadata.extractPartitions(...)` now returns `IntSet`
+  instead of `Set<Integer>`, so downstream binaries must be recompiled.
+
+Segment backward compatibility is preserved. Pinot still reads the legacy
+`lengthOfEachEntry` metadata key when `lengthOfLongestElement` is absent, and
+new segments additionally persist `lengthOfShortestElement`,
+`lengthOfLongestElement`, and `isAscii`.
+
+**Action required for extension authors.** Rebuild and retest any custom code
+that implements `ColumnMetadata` or `MapIndexReader`, or that calls
+`ColumnPartitionMetadata.extractPartitions(...)`, before upgrading to Pinot
+1.6.0.
+
 ### Removal of deprecated controller configuration constants
 
 


### PR DESCRIPTION
## Summary

- add an upcoming-upgrade note for the `apache/pinot#18280` `pinot-segment-spi` compatibility change
- clarify in the developer module overview that `pinot-segment-spi` contains private segment extension points that should be revalidated on upgrade

## What changed for readers

- operators and extension authors now have an explicit upgrade warning for the `ColumnMetadata`, `MapIndexReader`, and `ColumnPartitionMetadata.extractPartitions(...)` API changes
- developers reading the module map now have a clearer signal that `pinot-segment-spi` is not a stable public plugin surface

## Cross-checked against apache/pinot

- `pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/ColumnMetadata.java`
- `pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/MapIndexReader.java`
- `pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/metadata/ColumnPartitionMetadata.java`
- `pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/V1Constants.java`
- `pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/metadata/ColumnMetadataImpl.java`
- merged upstream PR `apache/pinot#18280`

## Validation

- `git diff --check`
- lightweight relative link validation for edited files
