### PR TITLE
Document MV BIG_DECIMAL and BYTES support

### DIFF
--- a/basics/components/table/segment/README.md
+++ b/basics/components/table/segment/README.md
@@ -13,7 +13,7 @@ Pinot achieves this by breaking the data into smaller chunks known as **segments
 
 A **segment is a horizontal shard representing a chunk of table data** with some number of rows. The segment stores data for all columns of the table. Each segment packs the data in a **columnar fashion**, along with the **dictionaries and indices** for the columns. The segment is laid out in a columnar format so that it can be directly mapped into memory for serving queries.
 
-Columns can be **single or multi-valued** and the following types are supported: **STRING, BOOLEAN, INT, LONG, FLOAT, DOUBLE, TIMESTAMP or BYTES**. Only single-valued **BIG\_DECIMAL** data type is supported.
+Columns can be **single or multi-valued** and the following types are supported: **STRING, BOOLEAN, INT, LONG, FLOAT, DOUBLE, BIG\_DECIMAL, TIMESTAMP, and BYTES**.
 
 Columns may be declared to be **metric or dimension (or specifically as a time dimension)** in the schema. Columns can have default null values. For example, the default null value of a integer column can be 0. The default value for bytes columns must be hex-encoded before it's added to the schema.
 

--- a/functions/aggregation/arrayagg.md
+++ b/functions/aggregation/arrayagg.md
@@ -4,7 +4,7 @@ description: This section contains reference documentation for the ARRAYAGG func
 
 # ARRAYAGG
 
-Aggregates values from rows into an array. Supports collecting values of type INT, LONG, FLOAT, DOUBLE, and STRING. Use the optional `DISTINCT` keyword to collect only distinct values.
+Aggregates values from rows into an array. Supports collecting values of type `INT`, `LONG`, `FLOAT`, `DOUBLE`, `BIG_DECIMAL`, `STRING`, and `BYTES`. Use the optional `DISTINCT` keyword to collect only distinct values.
 
 ## Signature
 
@@ -12,7 +12,7 @@ Aggregates values from rows into an array. Supports collecting values of type IN
 >
 > ARRAYAGG(colName, 'dataType', 'DISTINCT')
 
-The `dataType` parameter must be one of: `INT`, `LONG`, `FLOAT`, `DOUBLE`, `STRING`.
+The `dataType` parameter must be one of: `INT`, `LONG`, `FLOAT`, `DOUBLE`, `BIG_DECIMAL`, `STRING`, or `BYTES`.
 
 ## Usage Examples
 
@@ -37,3 +37,5 @@ WHERE playerName = 'Barry Bonds'
 | leagues      |
 | ------------ |
 | [NL, AL]     |
+
+When the input column is multi-value, Pinot flattens each row's values into the output array before applying the optional distinct step.

--- a/functions/array/README.md
+++ b/functions/array/README.md
@@ -19,7 +19,7 @@ ARRAY_AGG(dataColumn, 'dataType' [, isDistinct])
 #### **Arguments**:
 
 * dataColumn - The input column or expression to aggregate. Can be a scalar or an array type.
-* 'dataType' - The element type of the resulting array. Must be a string literal (e.g., 'STRING', 'INT', 'LONG', 'DOUBLE').
+* 'dataType' - The element type of the resulting array. Must be a string literal (for example, 'STRING', 'INT', 'LONG', 'DOUBLE', 'BIG_DECIMAL', or 'BYTES').
 * isDistinct _(optional) -_ Boolean flag to include only distinct elements. Defaults to false.
 
 #### **Returns**:
@@ -63,7 +63,7 @@ allTags
 * When the input column is an array, all sub-arrays are flattened before aggregation.
 * When isDistinct is true, duplicate elements are removed from the final array.
 * The order of elements in the output array is not guaranteed.
-* Supports both scalar and array input types for numeric and string data.
+* Supports both scalar and array input types for `INT`, `LONG`, `FLOAT`, `DOUBLE`, `BIG_DECIMAL`, `STRING`, and `BYTES`.
 
 ***
 
@@ -452,6 +452,8 @@ SELECT intersectIndices(ARRAY[1, 3, 5], ARRAY[3, 5]);
 Returns true if the two input arrays have at least one element in common, and false otherwise.
 
 This function is useful for checking whether two arrays share any overlapping values — for example, to test whether a user’s assigned tags intersect with a set of filter tags.\
+
+Supported array element types: `INT`, `LONG`, `FLOAT`, `DOUBLE`, `BIG_DECIMAL`, `STRING`, and `BYTES`.
 
 
 **Syntax**:&#x20;

--- a/functions/array/array_agg.md
+++ b/functions/array/array_agg.md
@@ -4,7 +4,7 @@ description: This section contains reference documentation for the ARRAY_AGG fun
 
 # ARRAY\_AGG
 
-Concatenates the input values into an array.
+Concatenates the input values into an array. Supported element types are `INT`, `LONG`, `FLOAT`, `DOUBLE`, `BIG_DECIMAL`, `STRING`, and `BYTES`.
 
 
 
@@ -20,8 +20,8 @@ Concatenates the input values into an array.
 SELECT ARRAY_AGG(firstName, 'STRING', true) AS firstNames from transcript;
 ```
 
-
-
 | firstNames    |
 | ------------- |
 | Bob,Nick,Lucy |
+
+When the input expression is multi-value, Pinot flattens the per-row values into the output array before applying the optional distinct step.

--- a/functions/array/arraylength.md
+++ b/functions/array/arraylength.md
@@ -4,7 +4,11 @@ description: This section contains reference documentation for the ARRAYLENGTH f
 
 # ARRAYLENGTH
 
-Returns the length of a multi-value column
+Returns the length of a multi-value column or array expression. Pinot also accepts the alias `CARDINALITY`.
+
+## Supported Types
+
+`ARRAYLENGTH` supports arrays of `INT`, `LONG`, `FLOAT`, `DOUBLE`, `BIG_DECIMAL`, `STRING`, and `BYTES`.
 
 ## Signature
 

--- a/functions/array/arraysoverlap.md
+++ b/functions/array/arraysoverlap.md
@@ -22,7 +22,9 @@ Pinot also accepts `ARRAYSOVERLAP`.
 | `LONG[]` | `BOOLEAN` |
 | `FLOAT[]` | `BOOLEAN` |
 | `DOUBLE[]` | `BOOLEAN` |
+| `BIG_DECIMAL[]` | `BOOLEAN` |
 | `STRING[]` | `BOOLEAN` |
+| `BYTES[]` | `BOOLEAN` |
 
 Both arguments must have the same array type.
 

--- a/functions/type-conversion/README.md
+++ b/functions/type-conversion/README.md
@@ -24,6 +24,8 @@ Converts a value to the specified target type. This is the standard SQL cast syn
 | `BYTES` | `VARBINARY` | Byte array |
 | `BIG_DECIMAL` | `DECIMAL` | Arbitrary-precision decimal |
 
+For array-valued casts, Pinot supports `CAST(expr AS DECIMAL ARRAY)` in standard SQL. In the single-stage engine, Pinot also accepts the Pinot-specific target name `BIG_DECIMAL_ARRAY`.
+
 ```sql
 SELECT CAST(revenue AS DOUBLE) AS revenue_double,
        CAST(zipCode AS VARCHAR) AS zip_string,

--- a/reference/configuration-reference/schema.md
+++ b/reference/configuration-reference/schema.md
@@ -118,7 +118,7 @@ Pinot supports the following schema data types:
 | `LONG` | [Long.MIN_VALUE](https://docs.oracle.com/javase/7/docs/api/java/lang/Long.html#MIN_VALUE) | `0` |
 | `FLOAT` | [Float.NEGATIVE_INFINITY](https://docs.oracle.com/javase/7/docs/api/java/lang/Float.html#NEGATIVE_INFINITY) | `0.0` |
 | `DOUBLE` | [Double.NEGATIVE_INFINITY](https://docs.oracle.com/javase/7/docs/api/java/lang/Double.html#NEGATIVE_INFINITY) | `0.0` |
-| `BIG_DECIMAL` | Not supported | `0.0` |
+| `BIG_DECIMAL` | `0.0` | `0.0` |
 | `BOOLEAN` | `0` (`false`) | N/A |
 | `TIMESTAMP` | `0` (`1970-01-01 00:00:00 UTC`) | N/A |
 | `STRING` | `"null"` | N/A |
@@ -179,9 +179,9 @@ Define one dimension field spec for each dimension column.
 | `name` | Name of the dimension column. |
 | `description` | Optional human-readable description of the column. |
 | `tags` | Optional list of tags for categorizing the column. |
-| `dataType` | Data type of the dimension column. Supported types are `INT`, `LONG`, `FLOAT`, `DOUBLE`, `BOOLEAN`, `TIMESTAMP`, `STRING`, `BYTES`, and `JSON`. |
+| `dataType` | Data type of the dimension column. Supported types are `INT`, `LONG`, `FLOAT`, `DOUBLE`, `BIG_DECIMAL`, `BOOLEAN`, `TIMESTAMP`, `STRING`, `BYTES`, and `JSON`. |
 | `defaultNullValue` | Value Pinot should write when the source record is null. If omitted, Pinot uses the internal default for the type. |
-| `singleValueField` | Whether the column is single-valued. If `false`, Pinot stores a multi-value list, preserves order, and allows duplicates. The default null value for a multi-value column is a single-element list containing the configured or internal null value. |
+| `singleValueField` | Whether the column is single-valued. If `false`, Pinot stores a multi-value list, preserves order, and allows duplicates. This includes `BIG_DECIMAL` and `BYTES` dimension columns. The default null value for a multi-value column is a single-element list containing the configured or internal null value. |
 
 ## MetricFieldSpecs
 


### PR DESCRIPTION
## Summary
- document MV `BIG_DECIMAL` and MV `BYTES` support in the schema reference and segment overview
- update array and cast docs to cover `ARRAYAGG`/`ARRAY_AGG`, `ARRAYLENGTH`, `ARRAYS_OVERLAP`, and `DECIMAL ARRAY`
- keep the change scoped to existing reference pages without reorganizing navigation

## Cross-checks
- verified behavior against `apache/pinot` merge commit `aad170afaa58a64d8d3ca3f4c6aba207beca1109`
- used `BigDecimalTypeTest`, `BytesMvTypeTest`, `ArrayTest`, `ArrayLengthScalarFunction`, `ArraysOverlapScalarFunction`, and `CastTransformFunction` as the source of truth

## Validation
- `git diff --check`
- verified relative Markdown links and `content-ref` targets in all edited files
