### PR TITLE
docs: document record extractor type preservation

### DIFF
--- a/build-with-pinot/ingestion/pinot-input-formats.md
+++ b/build-with-pinot/ingestion/pinot-input-formats.md
@@ -146,8 +146,12 @@ className: 'org.apache.pinot.plugin.inputformat.parquet.ParquetNativeRecordReade
 For the support of DECIMAL and other parquet native data types, always use `ParquetNativeRecordReader`.
 {% endhint %}
 
+`ParquetNativeRecordReader` preserves primitive values in their native Pinot-compatible form during extraction. For example, a Parquet `BOOLEAN` stays a Pinot `BOOLEAN` instead of being stringified.
+
+| Parquet Data Type | Pinot Data Type | Comment |
+| ----------------- | --------------- | ------- |
+| BOOLEAN           | BOOLEAN         | Preserved as a native boolean value. |
 | INT96 | LONG | Parquet`INT96` type converts **nanoseconds** to Pinot `INT64` type of **milliseconds** |
-| -------------------- | --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
 | INT64                | LONG                              |                                                                                                                                                     |
 | INT32                | INT                               |                                                                                                                                                     |
 | FLOAT                | FLOAT                             |                                                                                                                                                     |
@@ -171,7 +175,7 @@ Real struct fields named `element` are preserved; only schema-identified LIST an
 
 **Backward incompatibility:** If you have ingestion pipelines or transform expressions that worked around the previous broken shape (for example, selecting `data.element` instead of `data` for an array column), you will need to update those queries and transforms.
 
-**MAP order caveat:** Parquet does not guarantee that MAP entries are returned in any particular order. If you require stable ordering of key-value pairs, use `LIST<STRUCT<key, value>>` instead.
+**MAP ordering:** Parquet itself does not preserve source MAP entry order. Pinot canonicalizes ingested MAP and JSON output by sorting map keys when it serializes the value, so query results are deterministic but do not preserve the original insertion order. If the original pair order matters, model the field as `LIST<STRUCT<key, value>>` instead.
 
 
 ### ORC

--- a/developers/plugin-architecture/write-custom-plugins/record-reader.md
+++ b/developers/plugin-architecture/write-custom-plugins/record-reader.md
@@ -13,6 +13,8 @@ To index the file into Pinot segment, simply implement the interface and plug it
 
 [GenericRow](https://github.com/apache/blob/master/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/GenericRow.java) is the record abstraction which the index engine can read and index with. It is a map from column name (String) to column value (Object). For multi-valued column, the value should be an object array (Object\[]).
 
+When you build on `BaseRecordExtractor`, keep primitive single-value fields in their native types where possible. The default implementation preserves `Number`, `Boolean`, and `byte[]` values as-is, materializes `ByteBuffer` as `byte[]`, and only falls back to `toString()` for other single-value objects.
+
 ### Contracts for Record Reader
 
 There are several contracts for record readers that developers should follow when implementing their own record readers:


### PR DESCRIPTION
## Summary
- document that `ParquetNativeRecordReader` now preserves native primitive values during extraction, including `BOOLEAN`
- update the Parquet MAP ordering note to explain that Pinot canonicalizes serialized MAP/JSON output while not preserving source insertion order
- document the `BaseRecordExtractor` single-value contract for custom record-reader authors

## Cross-checks against apache/pinot
- verified `BaseRecordExtractor#convertSingleValue` now preserves `Number`, `Boolean`, and `byte[]`, while materializing `ByteBuffer` as `byte[]`
- verified `ParquetNativeRecordExtractor` now returns native booleans for Parquet `BOOLEAN`
- verified `MapUtils` and `PinotDataType.MAP` now canonicalize serialized map output by sorting keys
- checked the PR regression tests covering primitive preservation and deterministic map serialization

## Validation
- `git diff --check`
- lightweight relative-link validation for edited files
