### PR TITLE
Document IndexType dictionary-contract SPI upgrade

### DIFF
--- a/developers/plugin-architecture/README.md
+++ b/developers/plugin-architecture/README.md
@@ -114,6 +114,15 @@ OpChain Converter plugins provide custom implementations for converting logical 
 
 Plugins can be developed with no restriction. There are some standards that have to be followed, though. The plugin has to implement the interfaces from [pinot-spi](https://github.com/apache/pinot/tree/master/pinot-spi/src/main/java/org/apache/pinot/spi).
 
+Custom segment or index extensions that depend on `pinot-segment-spi` are a
+separate, more upgrade-sensitive path than the stable plugin families listed
+above. Revalidate these extensions on every Pinot upgrade. For example, Pinot
+1.6.0 adds two required `IndexType` methods for custom index implementations:
+`requiresDictionary(FieldSpec, C)` and
+`shouldInvalidateOnDictionaryChange(FieldSpec, C)`. See the
+[upgrade notes](../../operate-pinot/upgrade-notes.md) before upgrading custom
+segment/index extensions.
+
 {% content-ref url="write-custom-plugins/" %}
 [write-custom-plugins](write-custom-plugins/)
 {% endcontent-ref %}

--- a/operate-pinot/upgrade-notes.md
+++ b/operate-pinot/upgrade-notes.md
@@ -71,6 +71,30 @@ that implements `ColumnMetadata` or `MapIndexReader`, or that calls
 `ColumnPartitionMetadata.extractPartitions(...)`, before upgrading to Pinot
 1.6.0.
 
+### IndexType SPI now requires explicit dictionary-contract methods
+
+Apache Pinot 1.6.0 also changes the `IndexType<C, IR, IC>` SPI for custom
+index implementations. [PR #18365](https://github.com/apache/pinot/pull/18365)
+adds two new abstract methods that every `IndexType` implementation must
+define:
+
+- `requiresDictionary(FieldSpec, C)` returns `true` when the index's on-disk
+  representation depends on dictionary IDs and cannot be built or read without
+  a dictionary on the column.
+- `shouldInvalidateOnDictionaryChange(FieldSpec, C)` returns `true` when the
+  existing on-disk index must be deleted and rebuilt if the column gains or
+  loses a dictionary across segment reload.
+
+Pinot uses these hooks during segment creation and reload to decide whether it
+must materialize a shared standalone dictionary for RAW forward-index columns
+and whether existing index files can be reused safely. Built-in inverted, FST,
+and IFST indexes require a dictionary; the built-in range index works with or
+without a dictionary but must be rebuilt when dictionary state changes.
+
+**Action required for custom index authors.** Recompile any external
+`IndexType` plugin against Pinot 1.6.0 and implement both methods before
+upgrading. Older binaries will fail with `AbstractMethodError` until updated.
+
 ### Removal of deprecated controller configuration constants
 
 


### PR DESCRIPTION
## Summary

- document the new `IndexType` dictionary-contract SPI requirements in the upgrade notes for Pinot 1.6.0
- add a developer-facing warning in the plugin architecture guide for custom segment/index extensions built on `pinot-segment-spi`

## Reader impact

Readers who maintain custom index extensions now have a clear upgrade note that Pinot 1.6.0 adds two required `IndexType` methods: `requiresDictionary(...)` and `shouldInvalidateOnDictionaryChange(...)`.

## Structural changes

- no navigation changes
- no file moves or redirects
- updated existing developer/operator pages only

## Cross-checked against apache/pinot

- `pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/IndexType.java`
- `pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/DictionaryIndexConfig.java`
- `pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/inverted/InvertedIndexType.java`
- `pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/range/RangeIndexType.java`
- `pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/range/RangeIndexTypeTest.java`
- upstream PR: apache/pinot#18365

## Validation

- `git diff --check`
- lightweight relative Markdown link and `content-ref` target validation for edited files
