### PR TITLE
docs: correct raw bitmap release note

### DIFF
--- a/reference/releases/1.5.0.md
+++ b/reference/releases/1.5.0.md
@@ -206,7 +206,6 @@ Lucene text index files can now be combined and merged into the `columns.psf` se
 New feature to build segments in columnar fashion for columnar input data sources (e.g., Pinot segments, Parquet files). This significantly improves segment rebuild performance for minion operations like schema or index config changes.
 
 ### Other Indexing Improvements
-- Raw bitmap inverted index creator and reader. [#17060](https://github.com/apache/pinot/pull/17060)
 - Enable JSON index for MAP data type. [#16808](https://github.com/apache/pinot/pull/16808)
 - Match prefix phrase query Lucene parser. [#16476](https://github.com/apache/pinot/pull/16476)
 - NoDict hybrid cardinality: exact counting up to 2,048, then HLL++ with +10% cap. [#17186](https://github.com/apache/pinot/pull/17186)


### PR DESCRIPTION
## What changed for readers
- Removes the stale 1.5.0 release-note bullet that claimed raw bitmap inverted index support shipped.
- Leaves the release notes aligned with current Pinot behavior and the existing indexing docs, which already state that raw value forward indexes do not support inverted indexes.

## Structural changes
- Narrow release-note correction only in `reference/releases/1.5.0.md`.
- No navigation or page-move changes.

## Source cross-checks
- Cross-checked `apache/pinot#18410`, which reverts `#17060`.
- Verified the local Pinot source still rejects inverted indexes on raw columns via `pinot-core/src/test/resources/TableIndexingTest.csv`.

## Validation
- `git diff --check`
