### PR TITLE
Document scalar functions added in apache/pinot#18409

### DIFF
--- a/build-with-pinot/querying-and-sql/function-index.md
+++ b/build-with-pinot/querying-and-sql/function-index.md
@@ -93,20 +93,27 @@ For full details, see [String Functions](../../functions/string/).
 | [`STARTSWITH`](../../functions/string/startswith.md) | `STARTSWITH(str, prefix)` | BOOLEAN | Checks if string starts with prefix | Both |
 | `ENDSWITH` | `ENDSWITH(str, suffix)` | BOOLEAN | Checks if string ends with suffix | Both |
 | `CONTAINS` | `CONTAINS(str, substring)` | BOOLEAN | Checks if string contains substring | Both |
+| `ASCII` | `ASCII(str)` | INT | Returns the first character code, or 0 for empty string | Both |
 | [`REPLACE`](../../functions/string/replace.md) | `REPLACE(str, target, replacement)` | STRING | Replaces occurrences of target | Both |
 | [`REMOVE`](../../functions/string/remove.md) | `REMOVE(str, search)` | STRING | Removes all occurrences of search string | Both |
 | `SPLIT` | `SPLIT(str, delimiter [, limit])` | STRING[] | Splits string by delimiter | Both |
 | [`SPLITPART`](../../functions/string/splitpart.md) | `SPLITPART(str, delimiter, index)` or `SPLITPART(str, delimiter, limit, index)` | STRING | Returns the selected element after splitting; negative indices count from the end | Both |
+| `SUBSTRINGINDEX` / `SUBSTRING_INDEX` | `SUBSTRINGINDEX(str, delimiter, count)` | STRING | Returns text before the Nth delimiter, or after it when count is negative | Both |
+| `FIRSTLINE` | `FIRSTLINE(str)` | STRING | Returns the first line using `\n`, `\r\n`, or `\r` as delimiters | Both |
 | `REPEAT` | `REPEAT(str, times)` | STRING | Repeats string N times | Both |
 | [`REGEXP_EXTRACT`](../../functions/string/regexpextract.md) | `REGEXP_EXTRACT(str, pattern [, group])` | STRING | Extracts regex match from string | Both |
 | [`CHR`](../../functions/string/chr.md) | `CHR(codepoint)` | STRING | Returns character for Unicode code point | Both |
 | [`CODEPOINT`](../../functions/string/codepoint.md) | `CODEPOINT(str)` | INT | Returns Unicode code point of first character | Both |
 | `NORMALIZE` | `NORMALIZE(str [, form])` | STRING | Normalizes Unicode string | Both |
 | `STRCMP` | `STRCMP(str1, str2)` | INT | Compares two strings lexicographically | Both |
+| `STARTSWITHCASEINSENSITIVE` | `STARTSWITHCASEINSENSITIVE(str, prefix)` | BOOLEAN | Checks whether a string starts with a prefix, ignoring case | Both |
+| `ENDSWITHCASEINSENSITIVE` | `ENDSWITHCASEINSENSITIVE(str, suffix)` | BOOLEAN | Checks whether a string ends with a suffix, ignoring case | Both |
 | `HAMMINGDISTANCE` | `HAMMINGDISTANCE(str1, str2)` | INT | Hamming distance between two strings | Both |
 | [`LEVENSTEINDISTANCE`](../../functions/string/levenshtein_distance.md) | `LEVENSTEINDISTANCE(str1, str2)` | INT | Levenshtein edit distance | Both |
 | [`SOUNDEX`](../../functions/string/soundex.md) | `SOUNDEX(str)` | STRING | Returns the four-character Soundex code for a string | Both |
 | [`DIFFERENCE`](../../functions/string/difference.md) | `DIFFERENCE(str1, str2)` | INT | Returns a 0-4 similarity score by comparing Soundex codes | Both |
+| `SPACE` | `SPACE(count)` | STRING | Returns a string made of count spaces | Both |
+| `ISVALIDASCII` | `ISVALIDASCII(str)` | BOOLEAN | Returns true when every character is in the ASCII range | Both |
 
 ---
 
@@ -123,9 +130,13 @@ For full details, see [Math Functions](../../functions/math/).
 | `LN` / `LOG` | `LN(val)` | DOUBLE | Natural logarithm | Both |
 | `LOG2` | `LOG2(val)` | DOUBLE | Base-2 logarithm | Both |
 | `LOG10` | `LOG10(val)` | DOUBLE | Base-10 logarithm | Both |
+| `LOG1P` | `LOG1P(val)` | DOUBLE | Natural logarithm of `1 + val` | Both |
 | [`SQRT`](../../functions/math/sqrt.md) | `SQRT(val)` | DOUBLE | Square root | Both |
+| `CBRT` | `CBRT(val)` | DOUBLE | Cube root | Both |
 | `SIGN` | `SIGN(val)` | DOUBLE | Sign of a number (-1, 0, 1) | Both |
 | `POW` / `POWER` | `POW(base, exp)` | DOUBLE | Raises base to exponent | Both |
+| `EXP2` | `EXP2(val)` | DOUBLE | Returns `2` raised to the given power | Both |
+| `EXP10` | `EXP10(val)` | DOUBLE | Returns `10` raised to the given power | Both |
 | [`MOD`](../../functions/math/mod.md) | `MOD(a, b)` | DOUBLE | Modulo operation | Both |
 | `ROUNDDECIMAL` | `ROUNDDECIMAL(val [, scale])` | DOUBLE | Rounds to specified decimal places | Both |
 | `TRUNCATE` | `TRUNCATE(val [, scale])` | DOUBLE | Truncates to specified decimal places | Both |
@@ -137,6 +148,10 @@ For full details, see [Math Functions](../../functions/math/).
 | `LCM` | `LCM(a, b)` | LONG | Least common multiple | Both |
 | `HYPOT` | `HYPOT(a, b)` | DOUBLE | Hypotenuse (sqrt(a^2 + b^2)) | Both |
 | `NEGATE` | `NEGATE(val)` | DOUBLE | Negates the value | Both |
+| `SIGMOID` | `SIGMOID(val)` | DOUBLE | Logistic sigmoid `1 / (1 + e^(-val))` | Both |
+| `PI` | `PI()` | DOUBLE | Mathematical constant pi | Both |
+| `E` / `EULER` | `E()` | DOUBLE | Euler's number, base of the natural logarithm | Both |
+| `BITCOUNT` | `BITCOUNT(val)` | INT | Number of set bits in a long value | Both |
 | `RAND` | `RAND([seed])` | DOUBLE | Random number between 0 and 1 | Both |
 | `SIN` | `SIN(val)` | DOUBLE | Sine | Both |
 | `COS` | `COS(val)` | DOUBLE | Cosine | Both |
@@ -389,6 +404,14 @@ For full details, see [IP Address Functions](../../functions/ip-address/).
 | `IPPREFIX` | `IPPREFIX(addr, prefixLen)` | STRING | Returns CIDR prefix for IP address | Both |
 | `IPSUBNETMIN` | `IPSUBNETMIN(prefix)` | STRING | Returns lowest IP in subnet | Both |
 | `IPSUBNETMAX` | `IPSUBNETMAX(prefix)` | STRING | Returns highest IP in subnet | Both |
+| `ISIPV4STRING` | `ISIPV4STRING(ip)` | BOOLEAN | Checks whether the input is a plain IPv4 address string | Both |
+| `ISIPV6STRING` | `ISIPV6STRING(ip)` | BOOLEAN | Checks whether the input is a plain IPv6 address string | Both |
+| `IPV4TOLONG` | `IPV4TOLONG(ip)` | LONG | Converts an IPv4 string to an unsigned 32-bit long | Both |
+| `LONGTOIPV4` | `LONGTOIPV4(value)` | STRING | Converts an unsigned 32-bit long to IPv4 text | Both |
+| `IPV6TOBYTES` | `IPV6TOBYTES(ip)` | BYTES | Converts an IPv6 string to a 16-byte value | Both |
+| `BYTESTOIPV6` | `BYTESTOIPV6(bytes)` | STRING | Converts a 16-byte IPv6 value to canonical text | Both |
+| `IPV4TOIPV6` | `IPV4TOIPV6(ip)` | STRING | Converts an IPv4 string to its IPv4-mapped IPv6 form | Both |
+| `IPV4CIDRTORANGE` | `IPV4CIDRTORANGE(cidr)` | STRING[] | Returns the lower and upper IPv4 addresses for a CIDR range | Both |
 
 ---
 

--- a/functions/ip-address/README.md
+++ b/functions/ip-address/README.md
@@ -61,3 +61,110 @@ FROM myTable
 LIMIT 1
 -- Returns '192.168.1.255'
 ```
+
+## isIPv4String
+
+```sql
+isIPv4String(ipString)
+```
+
+Returns `true` when the input is a valid IPv4 address string without a CIDR prefix.
+
+```sql
+SELECT isIPv4String('192.168.1.1') AS valid_v4
+-- Returns true
+```
+
+## isIPv6String
+
+```sql
+isIPv6String(ipString)
+```
+
+Returns `true` when the input is a valid IPv6 address string without a CIDR prefix.
+
+```sql
+SELECT isIPv6String('2001:db8::1') AS valid_v6
+-- Returns true
+```
+
+## ipv4ToLong
+
+```sql
+ipv4ToLong(ipString)
+```
+
+Converts an IPv4 address string to its unsigned 32-bit integer representation as a `LONG`.
+
+```sql
+SELECT ipv4ToLong('192.168.1.1') AS ip_as_long
+-- Returns 3232235777
+```
+
+## longToIpv4
+
+```sql
+longToIpv4(value)
+```
+
+Converts an unsigned 32-bit `LONG` value in the IPv4 range back to dotted-decimal IPv4 text.
+
+```sql
+SELECT longToIpv4(3232235777) AS ip_text
+-- Returns '192.168.1.1'
+```
+
+## ipv6ToBytes
+
+```sql
+ipv6ToBytes(ipString)
+```
+
+Converts an IPv6 address string to a 16-byte `BYTES` value.
+
+```sql
+SELECT ipv6ToBytes('2001:db8::1') AS ip_bytes
+FROM myTable
+LIMIT 1
+```
+
+## bytesToIpv6
+
+```sql
+bytesToIpv6(bytes)
+```
+
+Converts a 16-byte IPv6 `BYTES` value to canonical IPv6 text.
+
+```sql
+SELECT bytesToIpv6(ipv6ToBytes('2001:db8::1')) AS ip_text
+-- Returns '2001:db8::1'
+```
+
+## ipv4ToIpv6
+
+```sql
+ipv4ToIpv6(ipString)
+```
+
+Maps an IPv4 address to its IPv4-mapped IPv6 representation.
+
+```sql
+SELECT ipv4ToIpv6('192.168.1.1') AS mapped_ip
+-- Returns '::ffff:c0a8:101'
+```
+
+## ipv4CIDRToRange
+
+```sql
+ipv4CIDRToRange(cidr)
+```
+
+Returns a two-element `STRING[]` containing the minimum and maximum IPv4 addresses covered by the CIDR range.
+
+```sql
+SELECT ipv4CIDRToRange('192.168.1.0/24') AS ip_range
+FROM myTable
+LIMIT 1
+-- Returns ['192.168.1.0', '192.168.1.255']
+```

--- a/functions/math/README.md
+++ b/functions/math/README.md
@@ -160,6 +160,54 @@ Reverses the byte order of a long value.
 Usage: `byteswapLong(col)`\
 Example: `SELECT byteswapLong(longCol) FROM myTable`
 
+**cbrt(col)**\
+Returns the cube root of a value.
+
+Usage: `cbrt(col)`\
+Example: `SELECT cbrt(27)` returns `3.0`
+
+**exp2(col)**\
+Returns `2` raised to the given power.
+
+Usage: `exp2(col)`\
+Example: `SELECT exp2(10)` returns `1024.0`
+
+**exp10(col)**\
+Returns `10` raised to the given power.
+
+Usage: `exp10(col)`\
+Example: `SELECT exp10(3)` returns `1000.0`
+
+**log1p(col)**\
+Returns the natural logarithm of `1 + col`.
+
+Usage: `log1p(col)`\
+Example: `SELECT log1p(1)` returns approximately `0.6931471805599453`
+
+**sigmoid(col)**\
+Returns the logistic sigmoid `1 / (1 + e^(-col))`.
+
+Usage: `sigmoid(col)`\
+Example: `SELECT sigmoid(0)` returns `0.5`
+
+**pi()**\
+Returns the mathematical constant pi.
+
+Usage: `pi()`\
+Example: `SELECT pi()` returns approximately `3.141592653589793`
+
+**e()** / **euler()**\
+Returns Euler's number, the base of the natural logarithm.
+
+Usage: `e()` or `euler()`\
+Example: `SELECT e()` returns approximately `2.718281828459045`
+
+**bitCount(col)**\
+Returns the number of set bits in the binary representation of a `LONG` value.
+
+Usage: `bitCount(col)`\
+Example: `SELECT bitCount(255)` returns `8`
+
 ## Bitwise Functions
 
 [**bitAnd(a, b)** / **bit_and(a, b)**](bitwise.md)\

--- a/functions/string/README.md
+++ b/functions/string/README.md
@@ -73,14 +73,32 @@ Returns `true` if the input string contains the specified substring, `false` oth
 Usage: `contains(col, substring)`\
 Example: `SELECT contains(playerName, 'john') FROM myTable`
 
+**ascii(col)**\
+Returns the integer code of the first character. Empty strings return `0`.
+
+Usage: `ascii(col)`\
+Example: `SELECT ascii('A') FROM myTable` returns `65`
+
 [**STARTSWITH(col, prefix)**](startswith.md)\
 returns `true` if columns starts with prefix string.
+
+**startsWithCaseInsensitive(col, prefix)**\
+Returns `true` if the input string starts with `prefix`, ignoring case.
+
+Usage: `startsWithCaseInsensitive(col, prefix)`\
+Example: `SELECT startsWithCaseInsensitive('Hello World', 'hello') FROM myTable` returns `true`
 
 **endsWith(col, suffix)**\
 Returns `true` if the input string ends with the specified suffix, `false` otherwise.
 
 Usage: `endsWith(col, suffix)`\
 Example: `SELECT endsWith(playerName, 'son') FROM myTable`
+
+**endsWithCaseInsensitive(col, suffix)**\
+Returns `true` if the input string ends with `suffix`, ignoring case.
+
+Usage: `endsWithCaseInsensitive(col, suffix)`\
+Example: `SELECT endsWithCaseInsensitive('Hello World', 'WORLD') FROM myTable` returns `true`
 
 **strcmp(string1, string2)**\
 Compares two strings lexicographically. Returns `0` if equal, a value less than `0` if the first string is lexicographically less than the second, and a value greater than `0` if the first string is lexicographically greater.
@@ -131,6 +149,19 @@ Usage: `splitPart(col, delimiter, index)` or `splitPart(col, delimiter, limit, i
 Example: `SELECT splitPart('a,b,c', ',', 1) FROM myTable` returns `'b'`\
 Example: `SELECT splitPart('a,b,c', ',', -1) FROM myTable` returns `'c'`
 
+**substringIndex(col, delimiter, count)** / **substring_index(col, delimiter, count)**\
+Returns the substring before the `count`th delimiter when `count` is positive, or after the `count`th delimiter from the right when `count` is negative. Returns an empty string when `count = 0` or `delimiter` is empty.
+
+Usage: `substringIndex(col, delimiter, count)` or `substring_index(col, delimiter, count)`\
+Example: `SELECT substringIndex('a.b.c.d', '.', 2) FROM myTable` returns `'a.b'`\
+Example: `SELECT substring_index('a.b.c.d', '.', -2) FROM myTable` returns `'c.d'`
+
+**firstLine(col)**\
+Returns the first line of the input string and stops at `\n`, `\r\n`, or `\r`.
+
+Usage: `firstLine(col)`\
+Example: `SELECT firstLine('hello\\nworld') FROM myTable` returns `'hello'`
+
 **normalize(col)** / **normalize(col, form)**\
 Normalizes a Unicode string. Without a form argument, uses NFC normalization. The optional `form` parameter can be `NFC`, `NFD`, `NFKC`, or `NFKD`.
 
@@ -173,6 +204,12 @@ Converts a string to an ASCII encoded byte array.
 Usage: `toAscii(col)`\
 Example: `SELECT toAscii(stringCol) FROM myTable`
 
+**space(count)**\
+Returns a string made of `count` space characters. Non-positive counts return an empty string.
+
+Usage: `space(count)`\
+Example: `SELECT space(5) FROM myTable` returns `'     '`
+
 **toBase64(bytes)**\
 Encodes binary data (byte array) to a Base64 encoded string.
 
@@ -205,6 +242,12 @@ Returns `true` if the input string is valid JSON, `false` otherwise.
 
 Usage: `isJson(col)`\
 Example: `SELECT isJson('{"key":"value"}') FROM myTable` returns `true`
+
+**isValidASCII(col)**\
+Returns `true` if every character in the string is in the ASCII range `0-127`.
+
+Usage: `isValidASCII(col)`\
+Example: `SELECT isValidASCII('Hello World 123!@#') FROM myTable` returns `true`
 
 [**urlEncoding(string)**](url.md)\
 url-encode a string with UTF-8 format


### PR DESCRIPTION
## Summary

- documents the new scalar math, string, and IP address functions added by apache/pinot#18409 on the existing category pages
- adds the same functions to the query function index so readers can discover them from the A-Z reference

## Source cross-checks

- verified signatures, aliases, and return types against `pinot-common` scalar function implementations
- verified examples and edge-case wording against `ArithmeticFunctionsTest`, `IpAddressFunctionsTest`, `StringFunctionsTest`, and `ScalarTransformFunctionWrapperTest` in the local `apache/pinot` checkout

## Validation

- `git diff --check`
