### PR TITLE
docs: bump version references from 1.4.0 to 1.5.0

### DIFF
--- a/basics/getting-started/install/docker.md
+++ b/basics/getting-started/install/docker.md
@@ -22,7 +22,7 @@ Start a multi-component Pinot cluster using Docker, suitable for local evaluatio
 ### 1. Set the image versions
 
 ```bash
-export PINOT_VERSION=1.4.0
+export PINOT_VERSION=1.5.0
 export PINOT_IMAGE=apachepinot/pinot:${PINOT_VERSION}
 export ZK_IMAGE=zookeeper:3.9.5
 export KAFKA_IMAGE=apache/kafka:4.0.0
@@ -68,7 +68,7 @@ services:
       start_period: 10s
 
   pinot-controller:
-    image: ${PINOT_IMAGE:-apachepinot/pinot:1.4.0}
+    image: ${PINOT_IMAGE:-apachepinot/pinot:1.5.0}
     command: "StartController -zkAddress pinot-zookeeper:2181"
     container_name: "pinot-controller"
     restart: unless-stopped
@@ -89,7 +89,7 @@ services:
       start_period: 10s
 
   pinot-broker:
-    image: ${PINOT_IMAGE:-apachepinot/pinot:1.4.0}
+    image: ${PINOT_IMAGE:-apachepinot/pinot:1.5.0}
     command: "StartBroker -zkAddress pinot-zookeeper:2181"
     container_name: "pinot-broker"
     restart: unless-stopped
@@ -110,7 +110,7 @@ services:
       start_period: 10s
 
   pinot-server:
-    image: ${PINOT_IMAGE:-apachepinot/pinot:1.4.0}
+    image: ${PINOT_IMAGE:-apachepinot/pinot:1.5.0}
     command: "StartServer -zkAddress pinot-zookeeper:2181"
     container_name: "pinot-server"
     restart: unless-stopped
@@ -131,7 +131,7 @@ services:
       start_period: 10s
 
   pinot-minion:
-    image: ${PINOT_IMAGE:-apachepinot/pinot:1.4.0}
+    image: ${PINOT_IMAGE:-apachepinot/pinot:1.5.0}
     command: "StartMinion -zkAddress pinot-zookeeper:2181"
     restart: unless-stopped
     container_name: "pinot-minion"

--- a/basics/getting-started/install/local.md
+++ b/basics/getting-started/install/local.md
@@ -24,7 +24,7 @@ Start a multi-component Pinot cluster directly on your machine without container
 {% tabs %}
 {% tab title="Download release" %}
 ```bash
-export PINOT_VERSION=1.4.0
+export PINOT_VERSION=1.5.0
 
 wget https://downloads.apache.org/pinot/apache-pinot-${PINOT_VERSION}/apache-pinot-${PINOT_VERSION}-bin.tar.gz
 ```

--- a/basics/getting-started/pinot-versions.md
+++ b/basics/getting-started/pinot-versions.md
@@ -9,7 +9,7 @@ description: Current Apache Pinot release version and how to pin versions in exa
 Know which Pinot version to use and how to pin versions in examples.
 
 {% hint style="warning" %}
-All code samples in the **Start Here** guide use `PINOT_VERSION=1.4.0`. If you are using a different version, set the variable accordingly before running any commands.
+All code samples in the **Start Here** guide use `PINOT_VERSION=1.5.0`. If you are using a different version, set the variable accordingly before running any commands.
 {% endhint %}
 
 This page is the single source of truth for version information across the Start Here guide and the wider documentation. When following tutorials or code samples, make sure the version you use matches your installed release.
@@ -18,16 +18,16 @@ This page is the single source of truth for version information across the Start
 
 | Artifact | Version |
 | --- | --- |
-| Apache Pinot binary | **1.4.0** |
-| Docker image | `apachepinot/pinot:1.4.0` |
-| Maven / Gradle clients | `1.4.0` |
+| Apache Pinot binary | **1.5.0** |
+| Docker image | `apachepinot/pinot:1.5.0` |
+| Maven / Gradle clients | `1.5.0` |
 
 ## Using PINOT\_VERSION in examples
 
 Most code samples in these docs set a `PINOT_VERSION` environment variable near the top of each snippet. Always verify that the value matches your installed version:
 
 ```bash
-export PINOT_VERSION=1.4.0
+export PINOT_VERSION=1.5.0
 
 # Then use ${PINOT_VERSION} in commands:
 docker pull apachepinot/pinot:${PINOT_VERSION}

--- a/basics/getting-started/ten-minute-quickstart.md
+++ b/basics/getting-started/ten-minute-quickstart.md
@@ -18,7 +18,7 @@ By the end of this guide you will have a fully functional Apache Pinot cluster r
 **1. Set the Pinot version**
 
 ```bash
-export PINOT_VERSION=1.4.0
+export PINOT_VERSION=1.5.0
 ```
 
 See the [Version reference](pinot-versions.md) page for the current stable release.

--- a/tutorials/data-ingestion/batch-data-ingestion-in-practice.md
+++ b/tutorials/data-ingestion/batch-data-ingestion-in-practice.md
@@ -409,7 +409,7 @@ Or put all the required plugins jars to CLASSPATH, then set `-Dplugins.dir=${CLA
 {% endhint %}
 
 ```
-export PINOT_VERSION=1.4.0 #set to the Pinot version you have installed
+export PINOT_VERSION=1.5.0 #set to the Pinot version you have installed
 export PINOT_DISTRIBUTION_DIR=${PINOT_ROOT_DIR}/build/
 cd ${PINOT_DISTRIBUTION_DIR}
 ${SPARK_HOME}/bin/spark-submit \
@@ -564,7 +564,7 @@ pushJobSpec:
 Ensure parameter `PINOT_ROOT_DIR` and `PINOT_VERSION` are set properly.
 
 ```
-export PINOT_VERSION=1.4.0 #set to the Pinot version you have installed
+export PINOT_VERSION=1.5.0 #set to the Pinot version you have installed
 export PINOT_DISTRIBUTION_DIR=${PINOT_ROOT_DIR}/build/
 export HADOOP_CLIENT_OPTS="-Dplugins.dir=${PINOT_DISTRIBUTION_DIR}/plugins -Dlog4j2.configurationFile=${PINOT_DISTRIBUTION_DIR}/conf/pinot-ingestion-job-log4j2.xml"
 hadoop jar  \


### PR DESCRIPTION
## Description

Updates all getting-started guides and tutorials to reference Apache Pinot 1.5.0 (released April 2026) instead of the outdated 1.4.0.

## Changes Made

- `basics/getting-started/pinot-versions.md`: Updated current stable release from 1.4.0 to 1.5.0 (binary, Docker image, Maven/Gradle references and example export)
- `basics/getting-started/ten-minute-quickstart.md`: Updated PINOT_VERSION export from 1.4.0 to 1.5.0
- `basics/getting-started/install/docker.md`: Updated PINOT_VERSION export and all hardcoded 1.4.0 fallback image tags in docker-compose to 1.5.0
- `basics/getting-started/install/local.md`: Updated PINOT_VERSION export from 1.4.0 to 1.5.0
- `tutorials/data-ingestion/batch-data-ingestion-in-practice.md`: Updated two PINOT_VERSION exports from 1.4.0 to 1.5.0

## Testing Done

- [x] Verified all version strings are consistently updated to 1.5.0
- [x] No other content changes; purely a version string replacement