### PR TITLE
docs: update native text index page to reflect removal in Pinot 1.5.0

### DIFF
--- a/build-with-pinot/indexing/native-text-index.md
+++ b/build-with-pinot/indexing/native-text-index.md
@@ -9,9 +9,9 @@ description: >-
 
 
 {% hint style="danger" %}
-**Deprecated**
+**Removed**
 
-This index is deprecated, and subject to be removed after releasing **1.4.0**. Please use Lucene based [Text Index](text-search-support.md).
+The native text index was deprecated in Pinot 1.3.0 and has been **removed as of Pinot 1.5.0**. Please migrate to the Lucene-based [Text Index](text-search-support.md).
 {% endhint %}
 
 ## Native text index
@@ -85,7 +85,7 @@ The native text index is supported on STRING columns only.
 
 ## Migration
 
-Since the native text index is deprecated and will be removed after the 1.4.0 release, migrate to the standard [text index](text-search-support.md) by:
+Since the native text index has been removed in Pinot 1.5.0, migrate to the standard [text index](text-search-support.md) by:
 
 1. Replacing `"indexType": "NATIVE_TEXT"` with the equivalent text index configuration in `fieldConfigList`.
 2. Using `TEXT_MATCH` or `TEXT_CONTAINS` functions in your queries as before.


### PR DESCRIPTION
## Description

Updates the native text index documentation to reflect that the index has been removed as of Pinot 1.5.0, rather than stating it is deprecated with a future removal date.

## Related Issue

The native text index was deprecated in Pinot 1.3.0 with removal planned after 1.4.0. Both Pinot 1.4.0 and 1.5.0 have shipped, and the removal has taken effect. The documentation still referenced a future removal date that has now passed.

## Changes Made

- Updated the danger hint box from "deprecated, subject to be removed after releasing 1.4.0" to "Removed as of Pinot 1.5.0"
- Updated the Migration section text from "will be removed after the 1.4.0 release" to "has been removed in Pinot 1.5.0"