### PR TITLE
docs: pin Docker image tags from :latest to 1.5.0 in tutorials

### DIFF
--- a/tutorials/deep-storage/use-s3-and-pinot-in-docker.md
+++ b/tutorials/deep-storage/use-s3-and-pinot-in-docker.md
@@ -92,7 +92,7 @@ docker run --rm -ti \
     --env AWS_ACCESS_KEY_ID=<aws-access-key-id> \
     --env AWS_SECRET_ACCESS_KEY=<aws-secret-access-key> \
     --mount type=bind,source=/tmp/pinot-s3-docker,target=/tmp \
-    apachepinot/pinot:latest StartController \
+    apachepinot/pinot:1.5.0 StartController \
     -configFileName /tmp/controller.conf
 ```
 
@@ -106,7 +106,7 @@ docker run --rm -ti \
     --network=pinot-demo \
     --env AWS_ACCESS_KEY_ID=<aws-access-key-id> \
     --env AWS_SECRET_ACCESS_KEY=<aws-secret-access-key> \
-    apachepinot/pinot:latest StartBroker \
+    apachepinot/pinot:1.5.0 StartBroker \
     -zkAddress zookeeper:2181 -clusterName pinot-s3-example-docker
 ```
 
@@ -140,7 +140,7 @@ docker run --rm -ti \
     --env AWS_ACCESS_KEY_ID=<aws-access-key-id> \
     --env AWS_SECRET_ACCESS_KEY=<aws-secret-access-key> \
     --mount type=bind,source=/tmp/pinot-s3-docker,target=/tmp \
-    apachepinot/pinot:latest StartServer \
+    apachepinot/pinot:1.5.0 StartServer \
     -zkAddress zookeeper:2181 -clusterName pinot-s3-example-docker \
     -configFileName /tmp/server.conf
 ```
@@ -155,7 +155,7 @@ You can also mount your table conf and schema files to the container and run it.
 docker run --rm -ti \
     --name pinot-ingestion-job \
     --network=pinot-demo \
-    apachepinot/pinot:latest AddTable \
+    apachepinot/pinot:1.5.0 AddTable \
     -controllerHost pinot-controller \
     -controllerPort 9000 \
     -schemaFile examples/batch/airlineStats/airlineStats_schema.json \
@@ -318,7 +318,7 @@ docker run --rm -ti \
     --env AWS_ACCESS_KEY_ID=<aws-access-key-id> \
     --env AWS_SECRET_ACCESS_KEY=<aws-secret-access-key> \
     --mount type=bind,source=/tmp/pinot-s3-docker,target=/tmp \
-    apachepinot/pinot:latest LaunchDataIngestionJob \
+    apachepinot/pinot:1.5.0 LaunchDataIngestionJob \
     -jobSpecFile /tmp/ingestionJobSpec.yaml
 ```
 

--- a/tutorials/getting-started/dash.md
+++ b/tutorials/getting-started/dash.md
@@ -46,7 +46,7 @@ services:
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
       CLUSTER_ID: MkU3OEVBNTcwNTJENDM2Qk
   pinot-controller:
-    image: apachepinot/pinot:latest
+    image: apachepinot/pinot:1.5.0
     command: "StartController -zkAddress zookeeper-wiki:2181 -dataDir /data"
     container_name: "pinot-controller-wiki"
     volumes:
@@ -58,7 +58,7 @@ services:
     depends_on:
       - zookeeper
   pinot-broker:
-    image: apachepinot/pinot:latest
+    image: apachepinot/pinot:1.5.0
     command: "StartBroker -zkAddress zookeeper-wiki:2181"
     restart: unless-stopped
     container_name: "pinot-broker-wiki"
@@ -69,7 +69,7 @@ services:
     depends_on:
       - pinot-controller
   pinot-server:
-    image: apachepinot/pinot:latest
+    image: apachepinot/pinot:1.5.0
     command: "StartServer -zkAddress zookeeper-wiki:2181"
     restart: unless-stopped
     container_name: "pinot-server-wiki"

--- a/tutorials/getting-started/redash.md
+++ b/tutorials/getting-started/redash.md
@@ -46,7 +46,7 @@ docker run \
   -p 2123:2123 \
   -p 9000:9000 \
   -p 8000:8000 \
-  apachepinot/pinot:latest QuickStart -type batch
+  apachepinot/pinot:1.5.0 QuickStart -type batch
 ```
 
 ## Run a query in Redash

--- a/tutorials/getting-started/streamlit.md
+++ b/tutorials/getting-started/streamlit.md
@@ -46,7 +46,7 @@ services:
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
       CLUSTER_ID: MkU3OEVBNTcwNTJENDM2Qk
   pinot-controller:
-    image: apachepinot/pinot:latest
+    image: apachepinot/pinot:1.5.0
     command: "StartController -zkAddress zookeeper-wiki:2181 -dataDir /data"
     container_name: "pinot-controller-wiki"
     volumes:
@@ -58,7 +58,7 @@ services:
     depends_on:
       - zookeeper
   pinot-broker:
-    image: apachepinot/pinot:latest
+    image: apachepinot/pinot:1.5.0
     command: "StartBroker -zkAddress zookeeper-wiki:2181"
     restart: unless-stopped
     container_name: "pinot-broker-wiki"
@@ -69,7 +69,7 @@ services:
     depends_on:
       - pinot-controller
   pinot-server:
-    image: apachepinot/pinot:latest
+    image: apachepinot/pinot:1.5.0
     command: "StartServer -zkAddress zookeeper-wiki:2181"
     restart: unless-stopped
     container_name: "pinot-server-wiki"


### PR DESCRIPTION
## Description

Pin Docker image tags from `apachepinot/pinot:latest` to `apachepinot/pinot:1.5.0` across tutorial pages to improve reproducibility, consistent with the guidance in the Getting Started version reference page (pinot-versions.md).

## Changes Made

- `tutorials/getting-started/dash.md` - 3 occurrences (docker-compose service images)
- `tutorials/getting-started/streamlit.md` - 3 occurrences (docker-compose service images)
- `tutorials/getting-started/redash.md` - 1 occurrence (docker run command)
- `tutorials/deep-storage/use-s3-and-pinot-in-docker.md` - 5 occurrences (docker run commands for controller, broker, server, AddTable, LaunchDataIngestionJob)

## Testing Done

- Verified all replacements are exact string substitutions with no surrounding changes
- Confirmed 1.5.0 is the current stable release referenced in pinot-versions.md