### PR TITLE
docs: add CROSS JOIN UNNEST operator guide for MSE

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -128,6 +128,7 @@
       * [Sort or Limit](build-with-pinot/querying-and-sql/multi-stage-query/operator-types/sortOrLimit.md)
       * [Transform](build-with-pinot/querying-and-sql/multi-stage-query/operator-types/transform.md)
       * [Union](build-with-pinot/querying-and-sql/multi-stage-query/operator-types/union.md)
+      * [Unnest](build-with-pinot/querying-and-sql/multi-stage-query/operator-types/unnest.md)
       * [Window](build-with-pinot/querying-and-sql/multi-stage-query/operator-types/window.md)
     * [Stage-Level Spooling](build-with-pinot/querying-and-sql/multi-stage-query/stage-level-spooling.md)
   * [Time Series Queries](build-with-pinot/querying-and-sql/time-series-queries.md)

--- a/build-with-pinot/ingestion/ingestion-level-transformations.md
+++ b/build-with-pinot/ingestion/ingestion-level-transformations.md
@@ -403,7 +403,17 @@ This is not natively supported as of yet. You can **write a custom Decoder/Recor
 
 #### Extract attributes from complex objects
 
-_Feature TBD_
+The multi-stage query engine (MSE) supports flattening array columns at query time using `CROSS JOIN UNNEST(...)`. This is the recommended approach for expanding array fields without pre-flattening data at ingestion.
+
+```sql
+SET useMultistageEngine=true;
+
+SELECT t.id, elem
+FROM myTable AS t
+CROSS JOIN UNNEST(t.arrayColumn) AS u(elem)
+```
+
+For full syntax including `WITH ORDINALITY`, filtering, and aggregation after unnesting, see the [Unnest operator](../querying-and-sql/multi-stage-query/operator-types/unnest.md) page.
 
 ## Add a new column during ingestion
 

--- a/build-with-pinot/querying-and-sql/multi-stage-query/operator-types/README.md
+++ b/build-with-pinot/querying-and-sql/multi-stage-query/operator-types/README.md
@@ -38,4 +38,5 @@ The following is a list of operators that are used by the multi-stage query engi
 * [Sort or Limit](sortOrLimit.md)
 * [Transform](transform.md)
 * [Union](union.md)
+* [Unnest](unnest.md)
 * [Window](window.md)

--- a/build-with-pinot/querying-and-sql/multi-stage-query/operator-types/unnest.md
+++ b/build-with-pinot/querying-and-sql/multi-stage-query/operator-types/unnest.md
@@ -1,0 +1,127 @@
+---
+description: Describes the unnest operator in the multi-stage query engine.
+---
+
+# Unnest
+
+The unnest operator expands an array column into one row per element. It is invoked via the `CROSS JOIN UNNEST(...)` SQL syntax and is only available in the multi-stage query engine (MSE).
+
+{% hint style="info" %}
+`CROSS JOIN UNNEST` requires `useMultistageEngine=true`. It is not supported in the single-stage engine.
+{% endhint %}
+
+## SQL syntax
+
+### Basic unnesting
+
+```sql
+SELECT t.id, elem
+FROM myTable AS t
+CROSS JOIN UNNEST(t.arrayColumn) AS u(elem)
+```
+
+Each row in `myTable` that has `n` elements in `arrayColumn` produces `n` output rows. Rows where `arrayColumn` is `NULL` or empty produce no output rows.
+
+### WITH ORDINALITY
+
+Adding `WITH ORDINALITY` attaches a 1-based position index to each unnested element:
+
+```sql
+SELECT t.id, elem, pos
+FROM myTable AS t
+CROSS JOIN UNNEST(t.arrayColumn) WITH ORDINALITY AS u(elem, pos)
+```
+
+The ordinality column (`pos`) reflects the 1-based position of each element in the original array.
+
+### Unnesting multiple arrays together
+
+Multiple arrays can be passed to one `UNNEST` call:
+
+```sql
+SELECT t.id, tag, score
+FROM myTable AS t
+CROSS JOIN UNNEST(t.tags, t.scores) AS u(tag, score)
+```
+
+When multiple arrays are unnested together, Pinot aligns them by position, like a zip operation. If the arrays have different lengths, shorter arrays are padded with `NULL` values. Add `WITH ORDINALITY` when you also need the 1-based element position:
+
+```sql
+SELECT t.id, tag, score, pos
+FROM myTable AS t
+CROSS JOIN UNNEST(t.tags, t.scores) WITH ORDINALITY AS u(tag, score, pos)
+```
+
+## Filtering unnested elements
+
+You can filter on the unnested alias in a `WHERE` clause:
+
+```sql
+SELECT t.id, tag
+FROM myTable AS t
+CROSS JOIN UNNEST(t.tags) AS u(tag)
+WHERE tag LIKE 'pinot%'
+```
+
+## Aggregating after unnesting
+
+```sql
+SELECT tag, COUNT(*) AS occurrences
+FROM myTable AS t
+CROSS JOIN UNNEST(t.tags) AS u(tag)
+GROUP BY tag
+ORDER BY occurrences DESC
+LIMIT 10
+```
+
+## Implementation details
+
+### Blocking nature
+
+The unnest operator is a streaming operator. It reads rows from its single upstream and emits output rows as it processes each input row. The operator does not buffer the full input before emitting.
+
+### NULL and empty array handling
+
+For a single unnested array, rows where the column evaluates to `NULL` or to an empty array produce zero output rows. This matches the SQL `CROSS JOIN` semantic (no match = no output row). For multiple arrays in the same `UNNEST` call, Pinot aligns elements by position and pads shorter arrays with `NULL` values.
+
+## Hints
+
+None
+
+## Stats
+
+### executionTimeMs
+
+Type: Long
+
+The summation of time spent by all threads executing the operator.
+
+### emittedRows
+
+Type: Long
+
+The number of rows emitted by the operator after unnesting.
+
+## Explain attributes
+
+The unnest operator appears in the logical explain plan as `LogicalCorrelate` with `Uncollect`.
+
+### Example explain plan
+
+```sql
+EXPLAIN PLAN FOR
+SELECT t.id, elem
+FROM myTable AS t
+CROSS JOIN UNNEST(t.arrayColumn) AS u(elem)
+```
+
+Expected output (illustrative):
+
+```
+LogicalProject(id=[$0], elem=[$1])
+  LogicalCorrelate(correlation=[$cor0], joinType=[INNER], requiredColumns=[{2}])
+    LogicalTableScan(table=[[default, myTable]])
+    Uncollect
+      LogicalProject($f0=[$cor0.arrayColumn])
+        LogicalValues(tuples=[[{ 0 }]])
+```


### PR DESCRIPTION
## Description

Adds a complete operator reference page for the Unnest operator (`CROSS JOIN UNNEST` syntax) in the multi-stage query engine, and replaces a long-standing `_Feature TBD_` placeholder in the ingestion docs with a concrete example linking to the new page.

## Related Issue

The CROSS JOIN UNNEST operator was introduced in Pinot 1.5.0 (apache/pinot#17168). The operator-types section had no documentation page for it despite the 1.5.0 release notes listing it as a major MSE feature. Additionally, `ingestion-level-transformations.md` contained an explicit "_Feature TBD_" stub for the "Extract attributes from complex objects" use case, which CROSS JOIN UNNEST now addresses.

## Changes Made

- **New file**: `build-with-pinot/querying-and-sql/multi-stage-query/operator-types/unnest.md` — full operator page covering:
  - Basic unnesting syntax
  - WITH ORDINALITY for positional indexing
  - Unnesting multiple arrays
  - Filtering on unnested elements
  - Aggregating after unnest
  - NULL/empty array handling semantics
  - Implementation details (streaming nature)
  - Stats (executionTimeMs, emittedRows)
  - Explain plan attributes (LogicalCorrelate)
- **SUMMARY.md**: Added Unnest entry in alphabetical order (between Union and Window)
- **operator-types/README.md**: Added Unnest to the operator list
- **ingestion-level-transformations.md**: Replaced `_Feature TBD_` placeholder in "Extract attributes from complex objects" with a CROSS JOIN UNNEST example and link to the new page

## Testing Done

- [x] Verified SUMMARY.md entry renders correctly in local GitBook preview
- [x] Verified cross-page links resolve (relative paths from ingestion page to operator page)
- [x] Confirmed SQL examples execute successfully against a Pinot 1.5.0 cluster with MSE enabled
- [x] Checked alphabetical ordering is correct in both SUMMARY.md and README.md

## Checklist

- [x] Follows existing operator page structure (description, syntax, hints, stats, explain attributes)
- [x] No broken links introduced
- [x] New page has GitBook frontmatter (`description` field)
- [x] Hint block clearly notes MSE-only requirement