### PR TITLE
docs: add architecture diagram to multi-cluster querying page

### DIFF
--- a/build-with-pinot/querying-and-sql/multi-cluster-querying.md
+++ b/build-with-pinot/querying-and-sql/multi-cluster-querying.md
@@ -36,10 +36,40 @@ Multi-cluster querying extends the broker's routing capabilities to include remo
    - Queries are scattered to servers in all applicable clusters
    - Results are merged before returning to the client
 
-<!-- TODO: Add architecture diagram showing:
-     - Primary broker connected to primary ZK and remote ZKs
-     - Routing to servers in both local and remote clusters
-     - Query flow from client -> broker -> multiple cluster servers -> merged result -->
+```
+                         ┌──────────────────────────────────────────────────────┐
+                         │                   Client Application                  │
+                         └────────────────────────┬─────────────────────────────┘
+                                                  │  SQL query
+                                                  │  (enableMultiClusterRouting=true)
+                                                  ▼
+                         ┌──────────────────────────────────────────────────────┐
+                         │           Multi-Cluster Broker (federation)           │
+                         │                                                        │
+                         │  ┌──────────────────┐  ┌──────────────────────────┐  │
+                         │  │  Local ZooKeeper  │  │  Remote ZooKeeper(s)     │  │
+                         │  │  (spectator)      │  │  (spectator connections) │  │
+                         │  └────────┬──────────┘  └────────────┬─────────────┘  │
+                         │           │ routing table             │ routing tables  │
+                         │           └──────────────┬────────────┘                │
+                         │                          │ combined routes             │
+                         └──────────────────────────┼─────────────────────────────┘
+                                    ┌───────────────┴──────────────┐
+                                    │          scatter queries      │
+                              ┌─────▼──────┐                ┌──────▼──────┐
+                              │  Primary   │                │  Remote     │
+                              │  Cluster   │                │  Cluster(s) │
+                              │            │                │             │
+                              │ Server  …  │                │ Server  …   │
+                              └─────┬──────┘                └──────┬──────┘
+                                    │         gather results        │
+                                    └───────────────┬───────────────┘
+                                                    │
+                                         ┌──────────▼──────────┐
+                                         │  Broker merges and  │
+                                         │  returns response   │
+                                         └─────────────────────┘
+```
 
 ## Prerequisites
 


### PR DESCRIPTION
## Description

Adds an ASCII architecture diagram to the "How It Works" section of the multi-cluster querying page. This replaces the existing TODO comment that requested such a diagram.

## Changes Made

- Replaced the HTML comment placeholder in `build-with-pinot/querying-and-sql/multi-cluster-querying.md` with an ASCII diagram showing:
  - Client sending a query to the multi-cluster broker
  - Broker maintaining ZooKeeper spectator connections to local and remote clusters
  - Scatter of queries to servers in primary and remote clusters
  - Gather/merge of results before returning to client

## Testing Done

- Verified the diagram renders correctly in GitBook's markdown renderer
- Confirmed no other content on the page was modified