### PR TITLE
Update segment assignment config docs for dimension tables

### DIFF
--- a/build-with-pinot/ingestion/batch-ingestion/dim-table.md
+++ b/build-with-pinot/ingestion/batch-ingestion/dim-table.md
@@ -58,7 +58,7 @@ Mark a table as a dimension table by setting the following properties in the tab
 | --- | --- | --- |
 | `isDimTable` | Yes | Set to `true` to designate the table as a dimension table. |
 | `ingestionConfig.batchIngestionConfig.segmentIngestionType` | Yes | Must be set to `REFRESH`. Dimension tables use segment replacement rather than append semantics so that the in-memory hash map is rebuilt with the latest data. |
-| `validationConfig.segmentAssignmentStrategy` | No | If set, must be `allservers`. Leaving it unset also works because Pinot automatically uses all-servers assignment for dimension tables. |
+| `segmentAssignmentConfigMap.OFFLINE.segmentAssignmentStrategy` | No | If set, must be `allservers`. Leaving it unset also works because Pinot automatically uses all-servers assignment for dimension tables. |
 | `quota.storage` | Recommended | Storage quota for the table. Must not exceed the cluster-level `controller.dimTable.maxSize` (default 200 MB). |
 | `dimensionTableConfig.disablePreload` | No | Set to `true` to use memory-optimized mode (store only primary key and segment reference instead of full rows). Defaults to `false` (fast lookup). |
 | `dimensionTableConfig.errorOnDuplicatePrimaryKey` | No | Set to `true` to fail segment loading if duplicate primary keys are detected across segments. Defaults to `false` (last-loaded segment wins). |
@@ -68,7 +68,7 @@ Mark a table as a dimension table by setting the following properties in the tab
 Dimension table schemas use `dimensionFieldSpecs` instead of `metricFieldSpecs`. A `primaryKeyColumns` array is **required** -- it defines the key used for lookups.
 
 {% hint style="warning" %}
-Dimension tables always use the `allservers` segment assignment strategy so every segment is replicated to every server in the tenant. Do not configure balanced, replica-group, or round-robin segment assignment for a dimension table. Pinot now rejects those values during table validation.
+Dimension tables always use the `allservers` segment assignment strategy so every segment is replicated to every server in the tenant. If you set the strategy explicitly, do so under `segmentAssignmentConfigMap.OFFLINE.segmentAssignmentStrategy`. Do not configure balanced, replica-group, or round-robin segment assignment for a dimension table. Pinot now rejects those values during table validation.
 {% endhint %}
 
 ### Example table configuration
@@ -80,8 +80,10 @@ Dimension tables always use the `allservers` segment assignment strategy so ever
     "tableType": "OFFLINE",
     "segmentsConfig": {
     },
-    "validationConfig": {
-      "segmentAssignmentStrategy": "allservers"
+    "segmentAssignmentConfigMap": {
+      "OFFLINE": {
+        "segmentAssignmentStrategy": "allservers"
+      }
     },
     "ingestionConfig": {
       "batchIngestionConfig": {

--- a/operate-pinot/segment-assignment.md
+++ b/operate-pinot/segment-assignment.md
@@ -10,13 +10,23 @@ Segment assignment refers to the strategy of assigning each segment from a table
 
 ## Dimension Tables
 
-Dimension tables are a special case: Pinot always assigns their segments to all servers in the tenant so lookup queries can run locally on every server. If you set `validationConfig.segmentAssignmentStrategy` on a dimension table, the only supported value is `allservers`; leaving it unset also works. Balanced, replica-group, and round-robin strategies do not apply to dimension tables.
+Dimension tables are a special case: Pinot always assigns their segments to all servers in the tenant so lookup queries can run locally on every server. If you want to make that default explicit, configure `segmentAssignmentConfigMap` at the top level of the table config with an `OFFLINE` entry whose `segmentAssignmentStrategy` is `allservers`. Leaving it unset also works. Balanced, replica-group, and round-robin strategies do not apply to dimension tables.
+
+```json
+{
+  "segmentAssignmentConfigMap": {
+    "OFFLINE": {
+      "segmentAssignmentStrategy": "allservers"
+    }
+  }
+}
+```
 
 ## Balanced Segment Assignment
 
 Balanced Segment Assignment is the default assignment strategy, where each segment is assigned to the server with the least segments already assigned. With this strategy, each server will have balanced query load, and each query will be routed to all the servers. It requires minimum configuration, and works well for small use cases.
 
-![](<../../.gitbook/assets/balanced-segment-assignment (1).png>)
+![](<../.gitbook/assets/balanced-segment-assignment (1).png>)
 
 ## Replica-Group Segment Assignment
 


### PR DESCRIPTION
## Summary
- replace stale `validationConfig.segmentAssignmentStrategy` references with the supported top-level `segmentAssignmentConfigMap.OFFLINE.segmentAssignmentStrategy` path for dimension tables
- update the dimension-table example JSON to show the supported `segmentAssignmentConfigMap` shape
- fix the in-page balanced segment assignment image path while validating the edited page

## Cross-checks
- verified the `apache/pinot#18398` change removed `segmentAssignmentStrategy` from `SegmentsValidationAndRetentionConfig`
- verified `TableConfig` still exposes top-level `segmentAssignmentConfigMap`
- verified dimension-table validation now checks only `segmentAssignmentConfigMap["OFFLINE"].segmentAssignmentStrategy` and only allows `allservers`

## Validation
- `git diff --check`
- lightweight relative link and asset sanity check for the edited docs files
