### PR TITLE
docs: add PostgreSQL-style scalar functions (apache/pinot#18420)

### DIFF
--- a/build-with-pinot/querying-and-sql/function-index.md
+++ b/build-with-pinot/querying-and-sql/function-index.md
@@ -88,6 +88,9 @@ For full details, see [String Functions](../../functions/string/).
 | [`LPAD`](../../functions/string/lpad.md) | `LPAD(str, size, pad)` | STRING | Left-pads string to specified size | Both |
 | [`RPAD`](../../functions/string/rpad.md) | `RPAD(str, size, pad)` | STRING | Right-pads string to specified size | Both |
 | [`LENGTH`](../../functions/string/length.md) | `LENGTH(str)` | INT | Returns the length of the string | Both |
+| `OCTETLENGTH` / `OCTET_LENGTH` | `OCTETLENGTH(str)` | INT | Returns the number of UTF-8 bytes in a string | Both |
+| `BITLENGTH` / `BIT_LENGTH` | `BITLENGTH(str)` | INT | Returns the number of UTF-8 bits in a string | Both |
+| `CHARLENGTH` / `CHAR_LENGTH` / `CHARACTERLENGTH` / `CHARACTER_LENGTH` | `CHARLENGTH(str)` | INT | Returns the number of Unicode code points in a string | Both |
 | [`STRPOS`](../../functions/string/strpos.md) | `STRPOS(str, find [, instance])` | INT | Returns position of substring | Both |
 | `STRRPOS` | `STRRPOS(str, find [, instance])` | INT | Returns last position of substring | Both |
 | [`STARTSWITH`](../../functions/string/startswith.md) | `STARTSWITH(str, prefix)` | BOOLEAN | Checks if string starts with prefix | Both |
@@ -101,6 +104,8 @@ For full details, see [String Functions](../../functions/string/).
 | `SUBSTRINGINDEX` / `SUBSTRING_INDEX` | `SUBSTRINGINDEX(str, delimiter, count)` | STRING | Returns text before the Nth delimiter, or after it when count is negative | Both |
 | `FIRSTLINE` | `FIRSTLINE(str)` | STRING | Returns the first line using `\n`, `\r\n`, or `\r` as delimiters | Both |
 | `REPEAT` | `REPEAT(str, times)` | STRING | Repeats string N times | Both |
+| `REGEXPCOUNT` / `REGEXP_COUNT` | `REGEXPCOUNT(str, pattern)` | INT | Counts non-overlapping regex matches | Both |
+| `REGEXPSUBSTR` / `REGEXP_SUBSTR` | `REGEXPSUBSTR(str, pattern)` | STRING | Returns the first regex match, or null if none | Both |
 | [`REGEXP_EXTRACT`](../../functions/string/regexpextract.md) | `REGEXP_EXTRACT(str, pattern [, group])` | STRING | Extracts regex match from string | Both |
 | [`CHR`](../../functions/string/chr.md) | `CHR(codepoint)` | STRING | Returns character for Unicode code point | Both |
 | [`CODEPOINT`](../../functions/string/codepoint.md) | `CODEPOINT(str)` | INT | Returns Unicode code point of first character | Both |
@@ -152,6 +157,8 @@ For full details, see [Math Functions](../../functions/math/).
 | `PI` | `PI()` | DOUBLE | Mathematical constant pi | Both |
 | `E` / `EULER` | `E()` | DOUBLE | Euler's number, base of the natural logarithm | Both |
 | `BITCOUNT` | `BITCOUNT(val)` | INT | Number of set bits in a long value | Both |
+| `FACTORIAL` | `FACTORIAL(val)` | LONG | Returns the factorial of an integer from 0 to 20 | Both |
+| `WIDTHBUCKET` / `WIDTH_BUCKET` | `WIDTHBUCKET(value, lo, hi, numBuckets)` | INT | Assigns a value to a histogram bucket using SQL-standard semantics | Both |
 | `RAND` | `RAND([seed])` | DOUBLE | Random number between 0 and 1 | Both |
 | `SIN` | `SIN(val)` | DOUBLE | Sine | Both |
 | `COS` | `COS(val)` | DOUBLE | Cosine | Both |
@@ -161,6 +168,9 @@ For full details, see [Math Functions](../../functions/math/).
 | `ACOS` | `ACOS(val)` | DOUBLE | Inverse cosine | Both |
 | `ATAN` | `ATAN(val)` | DOUBLE | Inverse tangent | Both |
 | `ATAN2` | `ATAN2(y, x)` | DOUBLE | Two-argument inverse tangent | Both |
+| `ASINH` | `ASINH(val)` | DOUBLE | Inverse hyperbolic sine | Both |
+| `ACOSH` | `ACOSH(val)` | DOUBLE | Inverse hyperbolic cosine | Both |
+| `ATANH` | `ATANH(val)` | DOUBLE | Inverse hyperbolic tangent | Both |
 | `DEGREES` | `DEGREES(radians)` | DOUBLE | Converts radians to degrees | Both |
 | `RADIANS` | `RADIANS(degrees)` | DOUBLE | Converts degrees to radians | Both |
 
@@ -406,11 +416,15 @@ For full details, see [IP Address Functions](../../functions/ip-address/).
 | `IPSUBNETMAX` | `IPSUBNETMAX(prefix)` | STRING | Returns highest IP in subnet | Both |
 | `ISIPV4STRING` | `ISIPV4STRING(ip)` | BOOLEAN | Checks whether the input is a plain IPv4 address string | Both |
 | `ISIPV6STRING` | `ISIPV6STRING(ip)` | BOOLEAN | Checks whether the input is a plain IPv6 address string | Both |
+| `IPFAMILY` / `IP_FAMILY` | `IPFAMILY(ip)` | INT | Returns 4 for IPv4 and 6 for IPv6 | Both |
 | `IPV4TOLONG` | `IPV4TOLONG(ip)` | LONG | Converts an IPv4 string to an unsigned 32-bit long | Both |
 | `LONGTOIPV4` | `LONGTOIPV4(value)` | STRING | Converts an unsigned 32-bit long to IPv4 text | Both |
 | `IPV6TOBYTES` | `IPV6TOBYTES(ip)` | BYTES | Converts an IPv6 string to a 16-byte value | Both |
 | `BYTESTOIPV6` | `BYTESTOIPV6(bytes)` | STRING | Converts a 16-byte IPv6 value to canonical text | Both |
 | `IPV4TOIPV6` | `IPV4TOIPV6(ip)` | STRING | Converts an IPv4 string to its IPv4-mapped IPv6 form | Both |
+| `IPMASKLEN` / `IP_MASK_LEN` | `IPMASKLEN(cidr)` | INT | Returns the prefix length from a CIDR string | Both |
+| `IPNETMASK` / `IP_NETMASK` | `IPNETMASK(cidr)` | STRING | Returns the network mask for a CIDR prefix | Both |
+| `IPHOSTMASK` / `IP_HOSTMASK` | `IPHOSTMASK(cidr)` | STRING | Returns the host mask for a CIDR prefix | Both |
 | `IPV4CIDRTORANGE` | `IPV4CIDRTORANGE(cidr)` | STRING[] | Returns the lower and upper IPv4 addresses for a CIDR range | Both |
 
 ---

--- a/functions/ip-address/README.md
+++ b/functions/ip-address/README.md
@@ -88,6 +88,19 @@ SELECT isIPv6String('2001:db8::1') AS valid_v6
 -- Returns true
 ```
 
+## ipFamily / ip_family
+
+```sql
+ipFamily(ipString)
+```
+
+Returns the address family for a plain IP address string: `4` for IPv4 and `6` for IPv6.
+
+```sql
+SELECT ipFamily('2001:db8::1') AS ip_version
+-- Returns 6
+```
+
 ## ipv4ToLong
 
 ```sql
@@ -152,6 +165,45 @@ Maps an IPv4 address to its IPv4-mapped IPv6 representation.
 ```sql
 SELECT ipv4ToIpv6('192.168.1.1') AS mapped_ip
 -- Returns '::ffff:c0a8:101'
+```
+
+## ipMaskLen / ip_mask_len
+
+```sql
+ipMaskLen(cidr)
+```
+
+Returns the prefix length from a CIDR string.
+
+```sql
+SELECT ipMaskLen('192.168.1.0/24') AS prefix_len
+-- Returns 24
+```
+
+## ipNetmask / ip_netmask
+
+```sql
+ipNetmask(cidr)
+```
+
+Returns the network mask for a CIDR prefix as an IP address string.
+
+```sql
+SELECT ipNetmask('192.168.1.0/24') AS netmask
+-- Returns '255.255.255.0'
+```
+
+## ipHostmask / ip_hostmask
+
+```sql
+ipHostmask(cidr)
+```
+
+Returns the host mask for a CIDR prefix as an IP address string.
+
+```sql
+SELECT ipHostmask('192.168.1.0/24') AS hostmask
+-- Returns '0.0.0.255'
 ```
 
 ## ipv4CIDRToRange

--- a/functions/math/README.md
+++ b/functions/math/README.md
@@ -208,6 +208,18 @@ Returns the number of set bits in the binary representation of a `LONG` value.
 Usage: `bitCount(col)`\
 Example: `SELECT bitCount(255)` returns `8`
 
+**factorial(col)**\
+Returns the factorial of a non-negative integer from `0` to `20`. Values outside that range raise an error.
+
+Usage: `factorial(col)`\
+Example: `SELECT factorial(5) FROM myTable` returns `120`
+
+**widthBucket(value, lo, hi, numBuckets)** / **width_bucket(value, lo, hi, numBuckets)**\
+Returns a histogram bucket number using SQL-standard semantics: `0` when `value < lo`, `numBuckets + 1` when `value >= hi`, otherwise a bucket from `1` to `numBuckets`.
+
+Usage: `widthBucket(value, lo, hi, numBuckets)` or `width_bucket(value, lo, hi, numBuckets)`\
+Example: `SELECT widthBucket(5.0, 0.0, 10.0, 5) FROM myTable` returns `3`
+
 ## Bitwise Functions
 
 [**bitAnd(a, b)** / **bit_and(a, b)**](bitwise.md)\

--- a/functions/string/README.md
+++ b/functions/string/README.md
@@ -43,6 +43,24 @@ trim spaces from right side of the string
 [**LENGTH(col)**](length.md)\
 calculate length of the string
 
+**octetLength(col)** / **octet_length(col)**\
+Returns the number of bytes in the UTF-8 representation of the input string.
+
+Usage: `octetLength(col)` or `octet_length(col)`\
+Example: `SELECT octetLength('é') FROM myTable` returns `2`
+
+**bitLength(col)** / **bit_length(col)**\
+Returns the number of bits in the UTF-8 representation of the input string.
+
+Usage: `bitLength(col)` or `bit_length(col)`\
+Example: `SELECT bitLength('é') FROM myTable` returns `16`
+
+**charLength(col)** / **char_length(col)** / **characterLength(col)** / **character_length(col)**\
+Returns the number of Unicode code points in the input string. Unlike `LENGTH`, supplementary characters such as emoji count as a single character.
+
+Usage: `charLength(col)` or `char_length(col)`\
+Example: `SELECT charLength('😀') FROM myTable` returns `1`
+
 [**levenshtein_distance(string1, string2)**](levenshtein_distance.md)\
 Returns the Levenshtein edit distance between two strings
 
@@ -215,6 +233,18 @@ Encodes binary data (byte array) to a Base64 encoded string.
 
 Usage: `toBase64(col)`\
 Example: `SELECT toBase64(byteCol) FROM myTable`
+
+**regexpCount(input, regexp)** / **regexp_count(input, regexp)**\
+Returns the number of non-overlapping matches for the regular expression.
+
+Usage: `regexpCount(input, regexp)` or `regexp_count(input, regexp)`\
+Example: `SELECT regexpCount('abc123def456', '\\d+') FROM myTable` returns `2`
+
+**regexpSubstr(input, regexp)** / **regexp_substr(input, regexp)**\
+Returns the first substring that matches the regular expression, or `null` if there is no match.
+
+Usage: `regexpSubstr(input, regexp)` or `regexp_substr(input, regexp)`\
+Example: `SELECT regexpSubstr('abc123def456', '\\d+') FROM myTable` returns `'123'`
 
 [**regexpExtract(value, regexp)**](regexpextract.md)\
 Extracts values that match the provided regular expression

--- a/functions/trigonometric/README.md
+++ b/functions/trigonometric/README.md
@@ -156,6 +156,48 @@ FROM myTable
 -- Returns 0.7615941559557649
 ```
 
+## asinh
+
+```sql
+asinh(col)
+```
+
+Returns the inverse hyperbolic sine of the given value.
+
+```sql
+SELECT asinh(0)
+FROM myTable
+-- Returns 0.0
+```
+
+## acosh
+
+```sql
+acosh(col)
+```
+
+Returns the inverse hyperbolic cosine of the given value. The input must be greater than or equal to `1`.
+
+```sql
+SELECT acosh(1)
+FROM myTable
+-- Returns 0.0
+```
+
+## atanh
+
+```sql
+atanh(col)
+```
+
+Returns the inverse hyperbolic tangent of the given value. The input must be between `-1` and `1`.
+
+```sql
+SELECT atanh(0.46211715726000974)
+FROM myTable
+-- Returns approximately 0.5
+```
+
 ## degrees
 
 ```sql


### PR DESCRIPTION
## What changed for readers
- document the PostgreSQL-style scalar functions added in `apache/pinot#18420` across the trigonometric, math, string, and IP-address function docs
- add the new functions and aliases to the SQL function index so they are discoverable from the A-Z reference

## Structural changes
- updated the existing category pages instead of creating new standalone docs pages
- kept the scope to the five function docs/index files that cover the new scalar functions

## Source cross-check
- verified exact function names and aliases against the merged Pinot source in `pinot-common/src/main/java/org/apache/pinot/common/function/scalar/{ArithmeticFunctions,IpAddressFunctions,StringFunctions,TrigonometricFunctions}.java`

## Validation
- `git diff --check`
- relative-link sanity check across the five touched docs files
