### PR TITLE
docs: document Arrow extractor config

### DIFF
--- a/build-with-pinot/ingestion/pinot-input-formats.md
+++ b/build-with-pinot/ingestion/pinot-input-formats.md
@@ -254,6 +254,17 @@ className: 'org.apache.pinot.plugin.inputformat.arrow.ArrowRecordReader'
 
 The `ArrowRecordReader` reads Arrow IPC files for batch ingestion. Note that Arrow IPC files require seekable channels, so **gzip compression is not supported**.
 
+To preserve raw Arrow temporal values instead of Pinot's default converted values, set `extractRawTimeValues` on `ArrowRecordReader`:
+
+```yaml
+dataFormat: 'arrow'
+className: 'org.apache.pinot.plugin.inputformat.arrow.ArrowRecordReader'
+configs:
+  extractRawTimeValues: true
+```
+
+When `extractRawTimeValues` is `false` (the default), Pinot converts Arrow `Date`, `Time`, and `Timestamp` values during extraction. Set it to `true` to keep raw integers instead: `Date` stays as days since epoch, while `Time` and `Timestamp` stay in the schema's declared Arrow unit.
+
 #### Stream ingestion
 
 For stream ingestion, the Arrow decoder converts Arrow columnar batches to Pinot rows:
@@ -267,5 +278,8 @@ stream.kafka.decoder.class.name=org.apache.pinot.plugin.inputformat.arrow.ArrowM
 | Property | Default | Description |
 |----------|---------|-------------|
 | `arrow.allocator.limit` | 268435456 (256 MB) | Memory limit for Arrow's off-heap allocator in bytes |
+| `extractRawTimeValues` | `false` | Keep Arrow `Date`, `Time`, and `Timestamp` values as raw integers instead of Pinot's default converted values |
 
-Arrow type conversions are handled automatically: `Text` → `String`, `LocalDateTime` → `Timestamp`, Arrow Maps → flattened `Map<String, Object>`, and Arrow Lists → `List<Object>`. Dictionary-encoded columns are also supported.
+Arrow type conversions are handled automatically: UTF-8 text becomes `String`, `Date` becomes `LocalDate`, `Time` becomes `LocalTime`, `Timestamp` becomes `Timestamp`, Arrow Maps become flattened `Map<String, Object>`, and Arrow Lists become `Object[]`. Dictionary-encoded columns are decoded against their logical type before extraction.
+
+Each Arrow Kafka message should contain a complete IPC stream. Empty batches are skipped, single-row batches ingest as one Pinot row, and multi-row batches fan out into multiple Pinot rows.

--- a/build-with-pinot/ingestion/stream-ingestion/import-from-apache-kafka.md
+++ b/build-with-pinot/ingestion/stream-ingestion/import-from-apache-kafka.md
@@ -731,6 +731,7 @@ Optional stream config properties:
 | Property | Description |
 |---|---|
 | `stream.kafka.decoder.prop.arrow.allocator.limit` | Maximum memory (in bytes) for the Arrow allocator. Default: `268435456` (256 MB). |
+| `stream.kafka.decoder.prop.extractRawTimeValues` | Keep Arrow `Date`, `Time`, and `Timestamp` values as raw integers instead of Pinot's default converted values. Default: `false`. |
 
 Example `streamConfigs`:
 
@@ -741,13 +742,18 @@ Example `streamConfigs`:
   "stream.kafka.decoder.class.name": "org.apache.pinot.plugin.inputformat.arrow.ArrowMessageDecoder",
   "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka30.KafkaConsumerFactory",
   "stream.kafka.broker.list": "kafka:9092",
-  "stream.kafka.decoder.prop.arrow.allocator.limit": "536870912"
+  "stream.kafka.decoder.prop.arrow.allocator.limit": "536870912",
+  "stream.kafka.decoder.prop.extractRawTimeValues": "true"
 }
 ```
 
 {% hint style="info" %}
 The Arrow decoder expects each Kafka message to contain a complete Arrow IPC stream (schema + record batch). Ensure your producer serializes Arrow data in the IPC streaming format.
 {% endhint %}
+
+When `stream.kafka.decoder.prop.extractRawTimeValues` is `false` (the default), Pinot converts Arrow `Date`, `Time`, and `Timestamp` values during extraction. Set it to `true` to keep raw integers instead: `Date` stays as days since epoch, while `Time` and `Timestamp` stay in the schema's declared Arrow unit.
+
+Each Arrow Kafka message can yield zero, one, or many Pinot rows. Empty batches are ignored, single-row batches ingest as one Pinot row, and multi-row batches fan out into multiple Pinot rows.
 
 ## Consuming a Subset of Kafka Partitions
 


### PR DESCRIPTION
## Summary
- document Arrow `extractRawTimeValues` for batch and Kafka stream ingestion
- clarify Arrow type conversion behavior and multi-row stream decode behavior

## What changed for readers
- added the batch-ingestion `configs.extractRawTimeValues` example for `ArrowRecordReader`
- added the Kafka stream property `stream.kafka.decoder.prop.extractRawTimeValues`
- documented that empty Arrow batches are skipped, single-row batches ingest as one row, and multi-row batches fan out into multiple rows

## Cross-checks against apache/pinot
- verified `ArrowRecordReaderConfig` and `ArrowRecordExtractorConfig` in `apache/pinot`
- verified `ArrowMessageDecoder` behavior for empty, single-row, and multi-row batches

## Validation
- `git diff --check`
- lightweight manual review of the edited markdown pages
