### PR TITLE
docs: document SQL table DDL endpoint (apache/pinot#18241)

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -92,6 +92,7 @@
 * [Querying & SQL](build-with-pinot/querying-and-sql/README.md)
   * [Querying Pinot](build-with-pinot/querying-and-sql/querying-pinot.md)
   * [SQL syntax](build-with-pinot/querying-and-sql/sql-syntax.md)
+    * [SQL Table DDL](build-with-pinot/querying-and-sql/sql-ddl.md)
     * [SQL Reference](build-with-pinot/querying-and-sql/sql-reference.md)
     * [Query Syntax Overview](build-with-pinot/querying-and-sql/query-syntax-overview.md)
     * [Filtering with IdSet](build-with-pinot/querying-and-sql/filtering-with-idset.md)

--- a/build-with-pinot/querying-and-sql/README.md
+++ b/build-with-pinot/querying-and-sql/README.md
@@ -16,6 +16,10 @@ Use this section to decide how to query Pinot, how much SQL support you need, wh
 [sql-syntax.md](sql-syntax.md)
 {% endcontent-ref %}
 
+{% content-ref url="sql-ddl.md" %}
+[sql-ddl.md](sql-ddl.md)
+{% endcontent-ref %}
+
 {% content-ref url="../../functions/README.md" %}
 [Functions](../../functions/README.md)
 {% endcontent-ref %}
@@ -34,7 +38,7 @@ For explain plans, joins, optimizer behavior, and operator details, continue int
 
 ## What this page covered
 
-This page mapped the main query workflows in Pinot: learning the query path, understanding SQL behavior, finding functions, choosing between SSE and MSE, and tuning execution controls.
+This page mapped the main query workflows in Pinot: learning the query path, understanding SQL behavior, finding functions, choosing between SSE and MSE, using SQL table DDL through the controller, and tuning execution controls.
 
 ## Next step
 

--- a/build-with-pinot/querying-and-sql/sql-ddl.md
+++ b/build-with-pinot/querying-and-sql/sql-ddl.md
@@ -1,0 +1,110 @@
+---
+description: Use controller-managed SQL DDL to create, inspect, list, and drop Pinot tables.
+---
+
+# SQL Table DDL
+
+Pinot supports a controller-managed SQL DDL surface for table metadata operations. Use it when you want a SQL alternative to the JSON-based `/schemas` and `/tables` workflows.
+
+The controller accepts these statements:
+
+- `CREATE TABLE`
+- `DROP TABLE`
+- `SHOW TABLES`
+- `SHOW CREATE TABLE`
+
+{% hint style="info" %}
+Run these statements through the controller endpoint `POST /sql/ddl`, not through the broker query API. SSE and MSE still execute query statements; the controller owns table DDL.
+{% endhint %}
+
+## How it works
+
+`POST /sql/ddl` compiles SQL into the same Pinot `Schema` and `TableConfig` model used by the existing controller APIs. That means:
+
+- DDL-created tables go through the same controller validation path as `POST /tables`.
+- `SHOW CREATE TABLE` renders a canonical SQL form of the stored schema and table config.
+- `dryRun=true` lets you compile and validate without persisting any metadata.
+
+## Supported statement shapes
+
+| Statement | Notes |
+| --- | --- |
+| `CREATE TABLE [IF NOT EXISTS] [db.]table (...) TABLE_TYPE = OFFLINE|REALTIME [PROPERTIES (...)]` | Creates one table type at a time. Use `PROPERTIES` for table config settings such as replication, tenants, time column, stream configs, and nested config blobs. |
+| `DROP TABLE [IF EXISTS] [db.]table [TYPE OFFLINE|REALTIME]` | Omitting `TYPE` targets both table variants. |
+| `SHOW TABLES [FROM db]` | Lists tables in the selected database. |
+| `SHOW CREATE TABLE [db.]table [TYPE OFFLINE|REALTIME]` | Returns canonical DDL for the stored table metadata. |
+
+Use either a `db.table` qualifier or a `Database` header to target a database.
+
+## Endpoint contract
+
+Send requests to the controller:
+
+```bash
+curl -X POST "http://localhost:9000/sql/ddl" \
+  -H "Content-Type: application/json" \
+  -d '{"sql":"SHOW TABLES"}'
+```
+
+Use `dryRun=true` when you want validation without persistence:
+
+```bash
+curl -X POST "http://localhost:9000/sql/ddl?dryRun=true" \
+  -H "Content-Type: application/json" \
+  -d '{"sql":"CREATE TABLE events (id INT DIMENSION) TABLE_TYPE = OFFLINE"}'
+```
+
+High-level response behavior:
+
+- `201 Created` for a successful `CREATE TABLE`
+- `200 OK` for `DROP TABLE`, `SHOW TABLES`, `SHOW CREATE TABLE`, dry runs, and idempotent `IF EXISTS` or `IF NOT EXISTS` cases
+- `400 Bad Request` for parse errors, semantic validation errors, or oversized SQL
+- `404 Not Found` when a requested table or schema does not exist
+
+## Example: create an offline table
+
+```sql
+CREATE TABLE events (
+  id INT NOT NULL DIMENSION,
+  city STRING DIMENSION,
+  ts TIMESTAMP DATETIME FORMAT 'TIMESTAMP' GRANULARITY '1:MILLISECONDS'
+)
+TABLE_TYPE = OFFLINE
+PROPERTIES (
+  'timeColumnName' = 'ts',
+  'replication' = '3',
+  'brokerTenant' = 'DefaultTenant',
+  'serverTenant' = 'DefaultTenant'
+);
+```
+
+Submit that statement with `POST /sql/ddl`:
+
+```bash
+curl -X POST "http://localhost:9000/sql/ddl" \
+  -H "Content-Type: application/json" \
+  -d @- <<'EOF'
+{"sql":"CREATE TABLE events (id INT NOT NULL DIMENSION, city STRING DIMENSION, ts TIMESTAMP DATETIME FORMAT 'TIMESTAMP' GRANULARITY '1:MILLISECONDS') TABLE_TYPE = OFFLINE PROPERTIES ('timeColumnName' = 'ts', 'replication' = '3', 'brokerTenant' = 'DefaultTenant', 'serverTenant' = 'DefaultTenant')"}
+EOF
+```
+
+## Example: show the stored table definition
+
+```bash
+curl -X POST "http://localhost:9000/sql/ddl" \
+  -H "Content-Type: application/json" \
+  -d '{"sql":"SHOW CREATE TABLE events TYPE OFFLINE"}'
+```
+
+Pinot returns canonical SQL that you can review, version, or replay later.
+
+## When to keep using JSON APIs
+
+If you already manage table metadata through `POST /schemas`, `POST /tables`, or `PUT /tables/{tableName}`, those APIs still work. SQL DDL is an additional interface, not a replacement for the existing controller metadata APIs.
+
+## Related pages
+
+- [SQL syntax](sql-syntax.md)
+- [SQL Reference](sql-reference.md)
+- [Controller API Examples](../../reference/api-reference/controller-api.md)
+- [Schema and Table Shape](../data-modeling/schema.md)

--- a/build-with-pinot/querying-and-sql/sql-reference.md
+++ b/build-with-pinot/querying-and-sql/sql-reference.md
@@ -666,3 +666,5 @@ The following table summarizes feature support across the single-stage engine (S
 | CREATE TABLE / DROP TABLE DDL | No | No |
 | DISTINCT with * | No | No |
 | DISTINCT with GROUP BY | No | No |
+
+`CREATE TABLE / DROP TABLE DDL` stays `No` in this matrix because broker-routed SSE and MSE queries do not execute table DDL. Pinot exposes SQL table DDL through the controller endpoint `POST /sql/ddl`; see [SQL Table DDL](sql-ddl.md).

--- a/build-with-pinot/querying-and-sql/sql-syntax.md
+++ b/build-with-pinot/querying-and-sql/sql-syntax.md
@@ -44,9 +44,15 @@ Some SQL features depend on the engine:
 
 If you are working on a query and do not know whether a feature is supported, check the engine-specific guidance before you assume the syntax is invalid.
 
+## Table DDL runs on the controller
+
+Pinot also supports SQL table DDL, but it is exposed through the controller rather than the broker query path. Use `POST /sql/ddl` for `CREATE TABLE`, `DROP TABLE`, `SHOW TABLES`, and `SHOW CREATE TABLE`.
+
+This distinction matters because the SSE and MSE engines still execute query statements, not controller metadata changes. If you want the syntax and examples for controller-managed DDL, use [SQL Table DDL](sql-ddl.md).
+
 ## Where the details live
 
-This page intentionally stays light. For the full statement-by-statement reference, use the detailed [SQL syntax and operators reference](sql-reference.md). For query controls and diagnostics, use the pages under `query-execution-controls/`.
+This page intentionally stays light. For the full statement-by-statement reference, use the detailed [SQL syntax and operators reference](sql-reference.md). For controller-managed table DDL, use [SQL Table DDL](sql-ddl.md). For query controls and diagnostics, use the pages under `query-execution-controls/`.
 
 ## What this page covered
 
@@ -59,5 +65,6 @@ Read [Querying Pinot](querying-pinot.md) for the broader query workflow, or jump
 ## Related pages
 
 - [Querying Pinot](querying-pinot.md)
+- [SQL Table DDL](sql-ddl.md)
 - [Query options](query-execution-controls/query-options.md)
 - [Explain plan](query-execution-controls/explain-plan.md)

--- a/reference/api-reference/controller-api.md
+++ b/reference/api-reference/controller-api.md
@@ -4,7 +4,7 @@ description: Pinot controller API reference.
 
 # Controller API Examples
 
-The controller exposes the administrative API surface for cluster, schema, table, segment, tenant, and database operations. The detailed request and response examples live here instead of in the user guide so the reference tree can act as the canonical endpoint index.
+The controller exposes the administrative API surface for cluster, schema, table, segment, tenant, database, and SQL DDL operations. The detailed request and response examples live here instead of in the user guide so the reference tree can act as the canonical endpoint index.
 
 ## Endpoint Families
 
@@ -13,6 +13,7 @@ The controller exposes the administrative API surface for cluster, schema, table
 | Cluster | `GET /cluster/configs`, `POST /cluster/configs`, `DELETE /cluster/configs/{configName}`, `GET /cluster/configs/groovy/staticAnalyzerConfig`, `POST /cluster/configs/groovy/staticAnalyzerConfig`, `GET /cluster/configs/groovy/staticAnalyzerConfig/default`, `GET /cluster/info` |
 | Health and leadership | `GET /health`, `GET /leader/tables` |
 | Query validation | `POST /validateMultiStageQuery`, `POST /query/tableNames` |
+| SQL DDL | `POST /sql/ddl` |
 | Schema | `GET /schemas`, `GET /schemas/{schemaName}`, `POST /schemas`, `PUT /schemas/{schemaName}`, `DELETE /schemas/{schemaName}` |
 | Table | `GET /tables`, `POST /tables`, `PUT /tables/{tableName}`, `DELETE /tables/{tableName}`, `POST /tableConfigs/validate` |
 | Logical tables | `GET /logicalTables`, `POST /logicalTables`, `PUT /logicalTables/{tableName}`, `DELETE /logicalTables/{tableName}` |
@@ -110,6 +111,57 @@ Each response object contains:
 - `sql`: the input SQL string for that result
 
 For static validation, you can also send `tableConfigs` and `schemas` so the controller compiles against the provided table metadata instead of the controller's ZooKeeper-backed table cache. `logicalTableConfigs` and `ignoreCase` are also accepted for this static-cache path. When populating `tableConfigs` and `schemas`, use the same JSON objects returned by `GET /tables/{tableName}` and `GET /schemas/{schemaName}`.
+
+## SQL DDL
+
+### POST /sql/ddl
+
+Execute controller-managed SQL DDL statements for table metadata:
+
+- `CREATE TABLE`
+- `DROP TABLE`
+- `SHOW TABLES`
+- `SHOW CREATE TABLE`
+
+Use this endpoint when you want a SQL alternative to the JSON `/schemas` and `/tables` APIs. The controller compiles DDL into the same stored `Schema` and `TableConfig` model, so `SHOW CREATE TABLE` reflects the metadata Pinot persists.
+
+Use `dryRun=true` to validate without persisting:
+
+```bash
+curl -X POST "http://localhost:9000/sql/ddl?dryRun=true" \
+  -H "accept: application/json" \
+  -H "Content-Type: application/json" \
+  -d '{"sql":"CREATE TABLE events (id INT DIMENSION) TABLE_TYPE = OFFLINE"}'
+```
+
+Use a regular request when you want Pinot to apply the DDL:
+
+```bash
+curl -X POST "http://localhost:9000/sql/ddl" \
+  -H "accept: application/json" \
+  -H "Content-Type: application/json" \
+  -d '{"sql":"SHOW CREATE TABLE events TYPE OFFLINE"}'
+```
+
+**Response**
+
+```json
+{
+  "operation": "SHOW_CREATE_TABLE",
+  "tableName": "events_OFFLINE",
+  "tableType": "OFFLINE",
+  "ddl": "CREATE TABLE events (id INT DIMENSION) TABLE_TYPE = OFFLINE"
+}
+```
+
+High-level response semantics:
+
+- `201 Created` for a successful `CREATE TABLE`
+- `200 OK` for `DROP TABLE`, `SHOW TABLES`, `SHOW CREATE TABLE`, and dry runs
+- `400 Bad Request` for parse or semantic validation errors
+- `404 Not Found` for missing tables or schemas
+
+See [SQL Table DDL](../../build-with-pinot/querying-and-sql/sql-ddl.md) for syntax details and end-to-end examples.
 
 ## Cluster
 


### PR DESCRIPTION
## Summary

- add a dedicated Querying & SQL page for controller-managed SQL table DDL
- wire the new page into Querying & SQL navigation and clarify the SQL syntax/reference pages
- document `POST /sql/ddl` in the controller API examples page

## What changed for readers

Readers now have a single docs path for `CREATE TABLE`, `DROP TABLE`, `SHOW TABLES`, and `SHOW CREATE TABLE`, including the controller endpoint contract and the distinction between controller DDL and broker query execution.

## Structural changes

- added `build-with-pinot/querying-and-sql/sql-ddl.md`
- added navigation links from `SUMMARY.md` and `build-with-pinot/querying-and-sql/README.md`
- added discoverability notes in `sql-syntax.md` and `sql-reference.md`
- added `POST /sql/ddl` coverage in `reference/api-reference/controller-api.md`

## Cross-checks against apache/pinot

- verified the controller endpoint contract in `pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotDdlRestletResource.java`
- verified supported statement shapes in `pinot-common/src/test/java/org/apache/pinot/sql/parsers/PinotDdlParserTest.java`
- verified create/show/dry-run behavior in `pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotDdlRestletResourceTest.java`

## Validation

- `git diff --check`
- resolved relative links and `content-ref` targets for all edited docs files
