### PR TITLE
docs: expand SQL table DDL guide

### DIFF
--- a/build-with-pinot/querying-and-sql/sql-ddl.md
+++ b/build-with-pinot/querying-and-sql/sql-ddl.md
@@ -6,7 +6,7 @@ description: Use controller-managed SQL DDL to create, inspect, list, and drop P
 
 Pinot supports a controller-managed SQL DDL surface for table metadata operations. Use it when you want a SQL alternative to the JSON-based `/schemas` and `/tables` workflows.
 
-The controller accepts these statements:
+The controller accepts one DDL statement per request:
 
 - `CREATE TABLE`
 - `DROP TABLE`
@@ -22,19 +22,20 @@ Run these statements through the controller endpoint `POST /sql/ddl`, not throug
 `POST /sql/ddl` compiles SQL into the same Pinot `Schema` and `TableConfig` model used by the existing controller APIs. That means:
 
 - DDL-created tables go through the same controller validation path as `POST /tables`.
-- `SHOW CREATE TABLE` renders a canonical SQL form of the stored schema and table config.
+- `SHOW CREATE TABLE` renders a canonical SQL form of the stored schema and table config that you can review, version, or replay.
 - `dryRun=true` lets you compile and validate without persisting any metadata.
+- Existing broker query APIs still handle `SELECT` statements. The controller endpoint handles metadata changes.
 
 ## Supported statement shapes
 
 | Statement | Notes |
 | --- | --- |
-| `CREATE TABLE [IF NOT EXISTS] [db.]table (...) TABLE_TYPE = OFFLINE|REALTIME [PROPERTIES (...)]` | Creates one table type at a time. Use `PROPERTIES` for table config settings such as replication, tenants, time column, stream configs, and nested config blobs. |
+| `CREATE TABLE [IF NOT EXISTS] [db.]table (...) [PRIMARY KEY (...)] TABLE_TYPE = OFFLINE|REALTIME [PROPERTIES (...)]` | Creates one table type at a time. Use `PROPERTIES` for table config settings such as replication, tenants, time column, indexes, stream configs, task configs, and nested config blobs. |
 | `DROP TABLE [IF EXISTS] [db.]table [TYPE OFFLINE|REALTIME]` | Omitting `TYPE` targets both table variants. |
 | `SHOW TABLES [FROM db]` | Lists tables in the selected database. |
 | `SHOW CREATE TABLE [db.]table [TYPE OFFLINE|REALTIME]` | Returns canonical DDL for the stored table metadata. |
 
-Use either a `db.table` qualifier or a `Database` header to target a database.
+Use either a `db.table` qualifier or a `Database` header to target a database. If both are present, they must refer to the same database; otherwise Pinot returns `400 Bad Request`.
 
 ## Endpoint contract
 
@@ -42,7 +43,18 @@ Send requests to the controller:
 
 ```bash
 curl -X POST "http://localhost:9000/sql/ddl" \
+  -H "accept: application/json" \
   -H "Content-Type: application/json" \
+  -d '{"sql":"SHOW TABLES"}'
+```
+
+To target a database with an HTTP header:
+
+```bash
+curl -X POST "http://localhost:9000/sql/ddl" \
+  -H "accept: application/json" \
+  -H "Content-Type: application/json" \
+  -H "Database: analytics" \
   -d '{"sql":"SHOW TABLES"}'
 ```
 
@@ -50,6 +62,7 @@ Use `dryRun=true` when you want validation without persistence:
 
 ```bash
 curl -X POST "http://localhost:9000/sql/ddl?dryRun=true" \
+  -H "accept: application/json" \
   -H "Content-Type: application/json" \
   -d '{"sql":"CREATE TABLE events (id INT DIMENSION) TABLE_TYPE = OFFLINE"}'
 ```
@@ -60,6 +73,94 @@ High-level response behavior:
 - `200 OK` for `DROP TABLE`, `SHOW TABLES`, `SHOW CREATE TABLE`, dry runs, and idempotent `IF EXISTS` or `IF NOT EXISTS` cases
 - `400 Bad Request` for parse errors, semantic validation errors, or oversized SQL
 - `404 Not Found` when a requested table or schema does not exist
+- `409 Conflict` for duplicate `CREATE TABLE` without `IF NOT EXISTS`, logical-table references that block a drop, or a race with another writer
+
+Response bodies include only fields that apply to the executed operation.
+
+| Field | Applies to | Notes |
+| --- | --- | --- |
+| `operation` | all responses | One of `CREATE_TABLE`, `DROP_TABLE`, `SHOW_TABLES`, or `SHOW_CREATE_TABLE`. |
+| `databaseName` | create, drop, show create | The database scope used for the operation when available. |
+| `tableName` | create, drop, show create | The resolved Pinot table name, often with `_OFFLINE` or `_REALTIME`. |
+| `tableType` | create, typed drop, show create | `OFFLINE` or `REALTIME`. |
+| `schema` | create | The compiled Pinot schema JSON. Returned for dry runs and persisted creates. |
+| `tableConfig` | create | The compiled Pinot table config JSON after table config tuner processing. Returned for dry runs and persisted creates. |
+| `warnings` | create | Non-fatal compile warnings, such as ignored `DECIMAL(p,s)` precision details. |
+| `dryRun` | create, drop | Whether the request validated without persisting or deleting metadata. |
+| `ifNotExists` | create | Whether the statement used `IF NOT EXISTS`. |
+| `ifExists` | drop | Whether the statement used `IF EXISTS`. |
+| `deletedTables` | drop | Typed table names removed by the drop. |
+| `tableNames` | show tables | Tables visible in the selected database. |
+| `ddl` | show create | Canonical `CREATE TABLE` SQL for the stored metadata. |
+| `message` | most responses | Human-readable operation summary. |
+
+## Columns, types, and defaults
+
+Every column has a Pinot data type and an optional role. If you omit the role, Pinot treats the column as a single-value dimension.
+
+| Column form | Result |
+| --- | --- |
+| `name STRING` | Single-value dimension. |
+| `name STRING DIMENSION` | Single-value dimension. |
+| `tags STRING DIMENSION ARRAY` | Multi-value dimension. |
+| `score DOUBLE METRIC` | Metric column. |
+| `ts TIMESTAMP DATETIME FORMAT 'TIMESTAMP' GRANULARITY '1:MILLISECONDS'` | Date-time column. |
+
+Supported data type names:
+
+| SQL type name | Pinot type |
+| --- | --- |
+| `INT`, `INTEGER` | `INT` |
+| `BIGINT`, `LONG` | `LONG` |
+| `FLOAT`, `REAL` | `FLOAT` |
+| `DOUBLE` | `DOUBLE` |
+| `DECIMAL`, `NUMERIC`, `BIG_DECIMAL` | `BIG_DECIMAL` |
+| `BOOLEAN` | `BOOLEAN` |
+| `TIMESTAMP` | `TIMESTAMP` |
+| `VARCHAR`, `CHAR`, `STRING` | `STRING` |
+| `VARBINARY`, `BINARY`, `BYTES` | `BYTES` |
+| `JSON` | `JSON` |
+
+`SMALLINT` and `TINYINT` are intentionally rejected. Use `INT` until Pinot exposes narrower integer types.
+
+Use `NOT NULL` to set a non-nullable field and `DEFAULT` to set Pinot's default null value:
+
+```sql
+CREATE TABLE users (
+  id INT NOT NULL DIMENSION,
+  name STRING NOT NULL DEFAULT 'unknown' DIMENSION,
+  score DOUBLE DEFAULT 0.0 METRIC,
+  active BOOLEAN DEFAULT TRUE DIMENSION
+)
+TABLE_TYPE = OFFLINE;
+```
+
+`DEFAULT NULL` is rejected. Default literals must be compatible with the declared column type. `TIMESTAMP` defaults are emitted by `SHOW CREATE TABLE` in UTC ISO-8601 form, and `BYTES` defaults are emitted as quoted hex strings.
+
+## Properties mapping
+
+Use the `PROPERTIES (...)` clause for table config values that are not part of the column list or `TABLE_TYPE` clause. Property keys and values are string literals.
+
+```sql
+PROPERTIES (
+  'timeColumnName' = 'ts',
+  'replication' = '3',
+  'brokerTenant' = 'DefaultTenant',
+  'serverTenant' = 'DefaultTenant'
+)
+```
+
+Pinot routes properties with these rules:
+
+| Property shape | Destination | Examples |
+| --- | --- | --- |
+| Promoted scalar table config keys | Dedicated `TableConfig` fields | `replication`, `brokerTenant`, `serverTenant`, `timeColumnName`, `retentionTimeUnit`, `retentionTimeValue`, `loadMode`, `sortedColumn`, `nullHandlingEnabled`, `aggregateMetrics`, `segmentVersion`, `tags`, `invertedIndexColumns`, `noDictionaryColumns`, `bloomFilterColumns`, `rangeIndexColumns`, `jsonIndexColumns` |
+| JSON blob table config keys | Nested `TableConfig` objects | `ingestionConfig`, `upsertConfig`, `dedupConfig`, `routingConfig`, `queryConfig`, `quotaConfig`, `tierConfigs`, `tunerConfigs`, `fieldConfigs`, `instanceAssignmentConfigMap`, `tagOverrideConfig`, `starTreeIndexConfigs`, `segmentPartitionConfig`, `jsonIndexConfigs` |
+| `streamType`, `stream.*`, `realtime.*` | Realtime stream configs | `stream.kafka.topic.name`, `stream.kafka.decoder.class.name`, `stream.kafka.consumer.factory.class.name`, `realtime.segment.flush.threshold.rows` |
+| `task.<taskType>.<key>` | Minion task config | `task.RealtimeToOfflineSegmentsTask.bucketTimePeriod` |
+| Any other key | Table custom config | `owner`, `team.pipeline`, `custom.flag` |
+
+List-valued promoted properties use comma-separated strings, for example `'invertedIndexColumns' = 'userId,country'`. Stream and realtime properties are valid only on `REALTIME` tables.
 
 ## Example: create an offline table
 
@@ -67,6 +168,7 @@ High-level response behavior:
 CREATE TABLE events (
   id INT NOT NULL DIMENSION,
   city STRING DIMENSION,
+  amount DOUBLE METRIC,
   ts TIMESTAMP DATETIME FORMAT 'TIMESTAMP' GRANULARITY '1:MILLISECONDS'
 )
 TABLE_TYPE = OFFLINE
@@ -82,21 +184,152 @@ Submit that statement with `POST /sql/ddl`:
 
 ```bash
 curl -X POST "http://localhost:9000/sql/ddl" \
+  -H "accept: application/json" \
   -H "Content-Type: application/json" \
   -d @- <<'EOF'
-{"sql":"CREATE TABLE events (id INT NOT NULL DIMENSION, city STRING DIMENSION, ts TIMESTAMP DATETIME FORMAT 'TIMESTAMP' GRANULARITY '1:MILLISECONDS') TABLE_TYPE = OFFLINE PROPERTIES ('timeColumnName' = 'ts', 'replication' = '3', 'brokerTenant' = 'DefaultTenant', 'serverTenant' = 'DefaultTenant')"}
+{"sql":"CREATE TABLE events (id INT NOT NULL DIMENSION, city STRING DIMENSION, amount DOUBLE METRIC, ts TIMESTAMP DATETIME FORMAT 'TIMESTAMP' GRANULARITY '1:MILLISECONDS') TABLE_TYPE = OFFLINE PROPERTIES ('timeColumnName' = 'ts', 'replication' = '3', 'brokerTenant' = 'DefaultTenant', 'serverTenant' = 'DefaultTenant')"}
 EOF
+```
+
+## Example: create a realtime Kafka table
+
+```sql
+CREATE TABLE clicks (
+  user_id STRING DIMENSION,
+  url STRING DIMENSION,
+  ts TIMESTAMP DATETIME FORMAT 'TIMESTAMP' GRANULARITY '1:MILLISECONDS'
+)
+TABLE_TYPE = REALTIME
+PROPERTIES (
+  'timeColumnName' = 'ts',
+  'replication' = '2',
+  'streamType' = 'kafka',
+  'stream.kafka.topic.name' = 'click_events',
+  'stream.kafka.decoder.class.name' = 'org.apache.pinot.plugin.stream.kafka.KafkaJSONMessageDecoder',
+  'stream.kafka.consumer.factory.class.name' = 'org.apache.pinot.plugin.stream.kafka30.KafkaConsumerFactory',
+  'stream.kafka.broker.list' = 'kafka-broker:9092',
+  'stream.kafka.consumer.prop.auto.offset.reset' = 'smallest',
+  'realtime.segment.flush.threshold.rows' = '500000'
+);
+```
+
+## Example: create an upsert table
+
+Use `PRIMARY KEY` with a realtime table and pass the upsert configuration as a JSON property:
+
+```sql
+CREATE TABLE upsertOrders (
+  orderId INT NOT NULL DIMENSION,
+  userId STRING NOT NULL DIMENSION,
+  amount DOUBLE METRIC,
+  ts TIMESTAMP DATETIME FORMAT 'TIMESTAMP' GRANULARITY '1:MILLISECONDS'
+)
+PRIMARY KEY (orderId)
+TABLE_TYPE = REALTIME
+PROPERTIES (
+  'timeColumnName' = 'ts',
+  'replication' = '2',
+  'streamType' = 'kafka',
+  'stream.kafka.topic.name' = 'orders',
+  'stream.kafka.decoder.class.name' = 'org.apache.pinot.plugin.stream.kafka.KafkaJSONMessageDecoder',
+  'stream.kafka.consumer.factory.class.name' = 'org.apache.pinot.plugin.stream.kafka30.KafkaConsumerFactory',
+  'stream.kafka.broker.list' = 'kafka-broker:9092',
+  'stream.kafka.consumer.prop.auto.offset.reset' = 'smallest',
+  'upsertConfig' = '{"mode":"FULL"}'
+);
+```
+
+## Example: multi-value dimension
+
+Use `DIMENSION ARRAY` for multi-value dimensions:
+
+```sql
+CREATE TABLE products (
+  id INT DIMENSION,
+  tags STRING DIMENSION ARRAY
+)
+TABLE_TYPE = OFFLINE;
+```
+
+## Example: indexes and ingestion config
+
+Promoted list properties use comma-separated strings. Nested table configs use JSON strings.
+
+```sql
+CREATE TABLE pageviews (
+  userId STRING DIMENSION,
+  country STRING DIMENSION,
+  payload JSON DIMENSION,
+  ts TIMESTAMP DATETIME FORMAT 'TIMESTAMP' GRANULARITY '1:MILLISECONDS'
+)
+TABLE_TYPE = OFFLINE
+PROPERTIES (
+  'timeColumnName' = 'ts',
+  'invertedIndexColumns' = 'userId,country',
+  'jsonIndexColumns' = 'payload',
+  'ingestionConfig' = '{"batchIngestionConfig":{"segmentIngestionType":"APPEND","segmentIngestionFrequency":"DAILY"}}'
+);
+```
+
+## Example: task config
+
+Use `task.<taskType>.<key>` properties for minion task configs:
+
+```sql
+CREATE TABLE events (
+  id INT DIMENSION,
+  ts TIMESTAMP DATETIME FORMAT 'TIMESTAMP' GRANULARITY '1:MILLISECONDS'
+)
+TABLE_TYPE = OFFLINE
+PROPERTIES (
+  'timeColumnName' = 'ts',
+  'task.RealtimeToOfflineSegmentsTask.bucketTimePeriod' = '1d',
+  'task.RealtimeToOfflineSegmentsTask.maxNumRecordsPerSegment' = '5000000',
+  'task.SegmentRefreshTask.tableMaxNumTasks' = '5'
+);
 ```
 
 ## Example: show the stored table definition
 
 ```bash
 curl -X POST "http://localhost:9000/sql/ddl" \
+  -H "accept: application/json" \
   -H "Content-Type: application/json" \
   -d '{"sql":"SHOW CREATE TABLE events TYPE OFFLINE"}'
 ```
 
-Pinot returns canonical SQL that you can review, version, or replay later.
+Example response:
+
+```json
+{
+  "operation": "SHOW_CREATE_TABLE",
+  "tableName": "events_OFFLINE",
+  "tableType": "OFFLINE",
+  "ddl": "CREATE TABLE events (\n  id INT NOT NULL DIMENSION,\n  city STRING DIMENSION,\n  amount DOUBLE METRIC,\n  ts TIMESTAMP DATETIME FORMAT 'TIMESTAMP' GRANULARITY '1:MILLISECONDS'\n)\nTABLE_TYPE = OFFLINE\nPROPERTIES (\n  'brokerTenant' = 'DefaultTenant',\n  'replication' = '3',\n  'serverTenant' = 'DefaultTenant',\n  'timeColumnName' = 'ts'\n)",
+  "message": "Rendered canonical CREATE TABLE for events_OFFLINE."
+}
+```
+
+Canonical DDL uses deterministic ordering for properties and normalizes values where Pinot stores a canonical form. For example, a `TIMESTAMP` date-time column emits `FORMAT 'TIMESTAMP'`, boolean defaults emit `TRUE` or `FALSE`, and identifiers that need quoting are double-quoted.
+
+## Example: list and drop tables
+
+```bash
+curl -X POST "http://localhost:9000/sql/ddl" \
+  -H "accept: application/json" \
+  -H "Content-Type: application/json" \
+  -H "Database: analytics" \
+  -d '{"sql":"SHOW TABLES"}'
+```
+
+```bash
+curl -X POST "http://localhost:9000/sql/ddl" \
+  -H "accept: application/json" \
+  -H "Content-Type: application/json" \
+  -d '{"sql":"DROP TABLE events TYPE OFFLINE"}'
+```
+
+Use `DROP TABLE events` without `TYPE` to drop both the offline and realtime variants when they exist. Use `DROP TABLE IF EXISTS events` when a missing table should be a successful no-op.
 
 ## When to keep using JSON APIs
 

--- a/reference/api-reference/controller-api.md
+++ b/reference/api-reference/controller-api.md
@@ -1,60 +1,4 @@
 ---
-description: Pinot controller API reference.
----
-
-# Controller API Examples
-
-The controller exposes the administrative API surface for cluster, schema, table, segment, tenant, database, and SQL DDL operations. The detailed request and response examples live here instead of in the user guide so the reference tree can act as the canonical endpoint index.
-
-## Endpoint Families
-
-| Family | Representative endpoints |
-| --- | --- |
-| Cluster | `GET /cluster/configs`, `POST /cluster/configs`, `DELETE /cluster/configs/{configName}`, `GET /cluster/configs/groovy/staticAnalyzerConfig`, `POST /cluster/configs/groovy/staticAnalyzerConfig`, `GET /cluster/configs/groovy/staticAnalyzerConfig/default`, `GET /cluster/info` |
-| Health and leadership | `GET /health`, `GET /leader/tables` |
-| Query validation | `POST /validateMultiStageQuery`, `POST /query/tableNames` |
-| SQL DDL | `POST /sql/ddl` |
-| Schema | `GET /schemas`, `GET /schemas/{schemaName}`, `POST /schemas`, `PUT /schemas/{schemaName}`, `DELETE /schemas/{schemaName}` |
-| Table | `GET /tables`, `POST /tables`, `PUT /tables/{tableName}`, `DELETE /tables/{tableName}`, `POST /tableConfigs/validate` |
-| Logical tables | `GET /logicalTables`, `POST /logicalTables`, `PUT /logicalTables/{tableName}`, `DELETE /logicalTables/{tableName}` |
-| Segments | `GET /segments/{tableName}/invalidPartitionMetadata`, `POST /segments/{tableName}/reload`, `POST /segments/{tableNameWithType}/uploadFromServerToDeepstore`, `POST /segments/reingested`, `DELETE /deleteSegmentsFromSequenceNum/{tableNameWithType}`, `GET /segments/segmentReloadStatus/{jobId}`, `GET /segments/{tableNameWithType}/needReload` |
-| Tenant and instance management | `GET /tenants`, `GET /tenants/{tenantName}`, `GET /instances`, `POST /instances` |
-
-## Swagger UI
-
-The controller hosts the interactive Swagger UI at `http://<controller-host>:<port>/help`. Use it to confirm exact request shapes before issuing destructive calls.
-
-## Operational Examples
-
-```bash
-curl -X GET "http://localhost:9000/cluster/configs" -H "accept: application/json"
-```
-
-```bash
-curl -X DELETE "http://localhost:9000/tables/baseballStats?retention=0d" -H "accept: application/json"
-```
-
-```bash
-curl -X GET "http://localhost:9000/schemas/baseballStats" -H "accept: application/json"
-```
-
-## What this page covered
-
-- The controller endpoint families and their top-level responsibilities.
-- The interactive Swagger UI location.
-- A few representative request examples for the most common admin flows.
-
-## Next step
-
-If you are about to modify cluster state, use the Swagger UI or the original controller examples page to confirm parameters before running the request.
-
-## Related pages
-
-- [API Reference](README.md)
-- [Controller Admin API](controller-admin-api.md)
-- [Broker Query API](query-api.md)
-- [Broker gRPC API](broker-grpc-api.md)
----
 description: Detailed curl examples for commonly used controller endpoints.
 ---
 
@@ -116,14 +60,22 @@ For static validation, you can also send `tableConfigs` and `schemas` so the con
 
 ### POST /sql/ddl
 
-Execute controller-managed SQL DDL statements for table metadata:
+Execute one controller-managed SQL DDL statement for table metadata:
 
 - `CREATE TABLE`
 - `DROP TABLE`
 - `SHOW TABLES`
 - `SHOW CREATE TABLE`
 
-Use this endpoint when you want a SQL alternative to the JSON `/schemas` and `/tables` APIs. The controller compiles DDL into the same stored `Schema` and `TableConfig` model, so `SHOW CREATE TABLE` reflects the metadata Pinot persists.
+Use this endpoint when you want a SQL alternative to the JSON `/schemas` and `/tables` APIs. The controller compiles DDL into the same stored `Schema` and `TableConfig` model, so `SHOW CREATE TABLE` reflects the metadata Pinot persists. Send the DDL in a JSON request body:
+
+```json
+{
+  "sql": "CREATE TABLE events (id INT DIMENSION) TABLE_TYPE = OFFLINE"
+}
+```
+
+Use a `Database` header or a SQL `db.table` qualifier to target a database. If both are present, they must agree.
 
 Use `dryRun=true` to validate without persisting:
 
@@ -134,32 +86,58 @@ curl -X POST "http://localhost:9000/sql/ddl?dryRun=true" \
   -d '{"sql":"CREATE TABLE events (id INT DIMENSION) TABLE_TYPE = OFFLINE"}'
 ```
 
-Use a regular request when you want Pinot to apply the DDL:
+Use a regular request when you want Pinot to apply the DDL. This example scopes the request with the `Database` header:
 
 ```bash
 curl -X POST "http://localhost:9000/sql/ddl" \
   -H "accept: application/json" \
   -H "Content-Type: application/json" \
+  -H "Database: analytics" \
   -d '{"sql":"SHOW CREATE TABLE events TYPE OFFLINE"}'
 ```
 
-**Response**
+**SHOW CREATE response**
 
 ```json
 {
   "operation": "SHOW_CREATE_TABLE",
-  "tableName": "events_OFFLINE",
+  "databaseName": "analytics",
+  "tableName": "analytics.events_OFFLINE",
   "tableType": "OFFLINE",
-  "ddl": "CREATE TABLE events (id INT DIMENSION) TABLE_TYPE = OFFLINE"
+  "ddl": "CREATE TABLE analytics.events (id INT DIMENSION) TABLE_TYPE = OFFLINE",
+  "message": "Rendered canonical CREATE TABLE for analytics.events_OFFLINE."
 }
 ```
+
+**CREATE dry-run response**
+
+```json
+{
+  "operation": "CREATE_TABLE",
+  "tableName": "events_OFFLINE",
+  "tableType": "OFFLINE",
+  "dryRun": true,
+  "ifNotExists": false,
+  "schema": {
+    "schemaName": "events"
+  },
+  "tableConfig": {
+    "tableName": "events_OFFLINE",
+    "tableType": "OFFLINE"
+  },
+  "message": "Dry-run succeeded for CREATE TABLE events_OFFLINE."
+}
+```
+
+The real response includes the fully resolved schema and table config objects. `warnings` appears when Pinot accepts the DDL but needs to report a non-fatal compile warning.
 
 High-level response semantics:
 
 - `201 Created` for a successful `CREATE TABLE`
-- `200 OK` for `DROP TABLE`, `SHOW TABLES`, `SHOW CREATE TABLE`, and dry runs
-- `400 Bad Request` for parse or semantic validation errors
+- `200 OK` for `DROP TABLE`, `SHOW TABLES`, `SHOW CREATE TABLE`, dry runs, and idempotent `IF EXISTS` or `IF NOT EXISTS` cases
+- `400 Bad Request` for parse errors, semantic validation errors, oversized SQL, type-incompatible defaults, or conflicting database references
 - `404 Not Found` for missing tables or schemas
+- `409 Conflict` for duplicate creates without `IF NOT EXISTS`, logical-table references that block a drop, or races with another writer
 
 See [SQL Table DDL](../../build-with-pinot/querying-and-sql/sql-ddl.md) for syntax details and end-to-end examples.
 


### PR DESCRIPTION
## Summary

- expand the SQL Table DDL user guide with detailed endpoint behavior, response fields, column roles, data types, defaults, and property routing
- add sample table DDL for OFFLINE, REALTIME Kafka, upsert, multi-value dimension, index/ingestion config, and minion task config workflows
- tighten the controller API `POST /sql/ddl` reference with request/response examples and precise response-code semantics
- remove the duplicated front matter/title block from the controller API examples page

## User manual

The updated `build-with-pinot/querying-and-sql/sql-ddl.md` now acts as the user manual for controller-managed SQL table DDL. It explains when to use `POST /sql/ddl`, how database scoping works, what fields appear in responses, which column forms and data types are supported, how defaults are handled, and how `PROPERTIES (...)` maps into Pinot table config sections.

## Sample table config and queries

The guide includes copyable SQL examples for:

- `CREATE TABLE events (...) TABLE_TYPE = OFFLINE`
- `CREATE TABLE clicks (...) TABLE_TYPE = REALTIME` with Kafka stream properties
- `CREATE TABLE upsertOrders (...) PRIMARY KEY (...) TABLE_TYPE = REALTIME` with `upsertConfig`
- `DIMENSION ARRAY` multi-value columns
- index and ingestion config properties such as `invertedIndexColumns`, `jsonIndexColumns`, and `ingestionConfig`
- minion task properties such as `task.RealtimeToOfflineSegmentsTask.bucketTimePeriod`
- `SHOW CREATE TABLE`, `SHOW TABLES`, and `DROP TABLE`

## Validation

- `git diff --check`
- `python3 scripts/validate-docs.py --changed-only=/tmp/pinot-docs-changed.txt --summary-only`
