### PR TITLE
Document unary +/- SQL operators

### DIFF
--- a/build-with-pinot/querying-and-sql/function-index.md
+++ b/build-with-pinot/querying-and-sql/function-index.md
@@ -152,7 +152,7 @@ For full details, see [Math Functions](../../functions/math/).
 | `GCD` | `GCD(a, b)` | LONG | Greatest common divisor | Both |
 | `LCM` | `LCM(a, b)` | LONG | Least common multiple | Both |
 | `HYPOT` | `HYPOT(a, b)` | DOUBLE | Hypotenuse (sqrt(a^2 + b^2)) | Both |
-| `NEGATE` | `NEGATE(val)` | DOUBLE | Negates the value | Both |
+| `NEGATE` | `NEGATE(val)` | DOUBLE | Negates the value; equivalent to unary `-` operator | Both |
 | `SIGMOID` | `SIGMOID(val)` | DOUBLE | Logistic sigmoid `1 / (1 + e^(-val))` | Both |
 | `PI` | `PI()` | DOUBLE | Mathematical constant pi | Both |
 | `E` / `EULER` | `E()` | DOUBLE | Euler's number, base of the natural logarithm | Both |

--- a/build-with-pinot/querying-and-sql/sql-reference.md
+++ b/build-with-pinot/querying-and-sql/sql-reference.md
@@ -421,6 +421,39 @@ FROM line_items
 WHERE (price * quantity) > 1000
 ```
 
+### Unary Operators
+
+Unary `-` and `+` are prefix operators on numeric expressions. They can be used anywhere a scalar expression is valid: `SELECT` list, `WHERE`, `GROUP BY`, `HAVING`, `ORDER BY`, `JOIN` conditions, `CASE` branches, `CAST` inputs, `IN` lists, subqueries, and inside aggregates and window functions.
+
+| Operator | Description | Example |
+|---|---|---|
+| `-` (unary) | Negation (numeric) | `-price`, `ORDER BY -score` |
+| `+` (unary) | Identity (numeric) | `+price` |
+
+```sql
+SELECT order_id, -discount AS adjustment
+FROM line_items
+```
+
+```sql
+SELECT order_id
+FROM line_items
+WHERE -profit > 100
+```
+
+```sql
+SELECT order_id, score
+FROM line_items
+ORDER BY -score
+```
+
+Notes:
+
+- Supported on `INT`, `LONG`, `FLOAT`, `DOUBLE`, and `BIG_DECIMAL`. The result preserves the input type.
+- `NULL` input returns `NULL`.
+- `-col` is equivalent to [`negate(col)`](../../functions/math/negate.md).
+- Negation uses `Math.negateExact` semantics, so `-INT_MIN` and `-LONG_MIN` overflow at runtime.
+
 ---
 
 ## Type Casting

--- a/functions/math/negate.md
+++ b/functions/math/negate.md
@@ -7,6 +7,8 @@ description: >-
 
 Returns the negation of the input value. This is a polymorphic function that preserves the input numeric type.
 
+`negate(col)` is equivalent to the unary minus operator `-col`. See [Arithmetic Operators](../../build-with-pinot/querying-and-sql/sql-reference.md#arithmetic-operators) for operator syntax.
+
 ## Signature
 
 negate(col)


### PR DESCRIPTION
## Summary
  
  Documents the unary prefix `+` and `-` operators added to Pinot SQL in [apache/pinot#18444](https://github.com/apache/pinot/pull/18444).

  ## Changes
  
  - **`build-with-pinot/querying-and-sql/sql-reference.md`**: Added a "Unary Operators" subsection under "Arithmetic Operators" with an operator table, three SQL examples (SELECT / WHERE / ORDER BY), and notes covering supported types, NULL handling, the `negate(col)` equivalence, and `Math.negateExact` overflow on `INT_MIN` / `LONG_MIN`.
  - **`functions/math/negate.md`**: One-sentence cross-reference noting that `negate(col)` is equivalent to unary `-col`, linking to the operators page.
  - **`build-with-pinot/querying-and-sql/function-index.md`**:  Extended the `NEGATE` row description to mention the unary `-` equivalence.