### PR TITLE
docs: document offline upsert upload validation

### DIFF
--- a/build-with-pinot/ingestion/segment-upload.md
+++ b/build-with-pinot/ingestion/segment-upload.md
@@ -67,6 +67,14 @@ POST /v2/segments?tableName=myTable&tableType=OFFLINE&enableParallelPushProtecti
 | `COPY_SEGMENT_TO_DEEP_STORE` | No | Metadata push | If `true`, controller copies the segment from the source URI into Pinot deep store and rewrites the stored download URI |
 | `CRYPTER` | No | All uploads | Crypter class name if the uploaded payload is encrypted |
 
+### Offline upsert upload validation
+
+For offline upsert tables, Pinot applies an extra upload-time validation when it can resolve a partition column from the table config. Pinot checks `instanceAssignmentConfigMap.OFFLINE` first, then legacy `replicaGroupStrategyConfig.partitionColumn`, and finally a single-column `segmentPartitionConfig`.
+
+When one of those configs identifies the partition column, every uploaded segment must expose exactly one partition id for that column in segment metadata. This applies to both single-segment upload endpoints and `POST /segments/batchUpload`.
+
+For example, if Pinot resolves `playerId` as the partition column, the segment metadata must include one value such as `column.playerId.partitionValues=2`. Uploads are rejected with `400 BAD_REQUEST` when the partition metadata is missing for that column or lists multiple partition ids such as `2,3`.
+
 ## Push modes
 
 ### Tar push


### PR DESCRIPTION
## What changed for readers
- documents the offline upsert upload-time validation in the segment upload guide
- explains which table config fields Pinot uses to resolve the partition column
- calls out that uploads are rejected when segment metadata is missing that partition id or advertises more than one id

## Structural changes
- none; updated the existing `build-with-pinot/ingestion/segment-upload.md` guide in place

## Cross-check against apache/pinot
- verified `SegmentValidationUtils.validateUpsertSegmentPartitionMetadata()` in `apache/pinot` merged commit `2de43845254a9d20bb27a7c249c2e9c6154a3145`
- verified the controller upload paths in `PinotSegmentUploadDownloadRestletResource`

## Validation
- `git diff --check`
