### PR TITLE
resolves apache/pinot#14371  Documentation on index availability

### DIFF
--- a/build-with-pinot/indexing/README.md
+++ b/build-with-pinot/indexing/README.md
@@ -55,6 +55,7 @@ Indexes available in Realtime Segments are updated during insertion of the consu
 
 Indexes available only in Offline segments are calculated during segment load. That means, that for offline tables indexes
 become available when segment was loaded. For realtime tables, those indexes are available only for completed (not consuming) segments.
+
 ## How Pinot applies indexes
 
 Most index choices are defined in the table config, usually under `fieldConfigList` or `tableIndexConfig`, depending on the index and the configuration style you are using. The canonical table-level reference is [Table](../../reference/configuration-reference/table.md).

--- a/build-with-pinot/indexing/README.md
+++ b/build-with-pinot/indexing/README.md
@@ -36,20 +36,20 @@ Use the decision guide when you know the query shape but not the best index yet.
 
 ### Index availability
 
-| Index Type          | Availability       |
+| Index Type          | Segment Type       |
 |:--------------------|:-------------------|
-| Bloom filter        | tbd                |
+| Bloom filter        | Offline            |
 | Forward index       | Realtime & Offline |
 | FST index           | Offline            |
 | Inverted index      | Realtime & Offline | 
-| Timestamp index     | tbd                |
-| Range index         | tbd                |
+| Timestamp index     | Offline            | 
+| Sorted index        | Offline            | 
+| Range index         | Offline            |
 | Text search support | Realtime & Offline |
 | JSON index          | Realtime & Offline |
 | Geospatial support  | Realtime & Offline |
 | Star-tree index     | Offline            |
 | Vector index        | Realtime & Offline |
-
 
 ## How Pinot applies indexes
 

--- a/build-with-pinot/indexing/README.md
+++ b/build-with-pinot/indexing/README.md
@@ -43,7 +43,7 @@ Use the decision guide when you know the query shape but not the best index yet.
 | FST index           | Offline            |
 | Inverted index      | Realtime & Offline | 
 | Timestamp index     | Offline            | 
-| Sorted index        | Offline            | 
+| Sorted index        | Realtime & Offline | 
 | Range index         | Offline            |
 | Text search support | Realtime & Offline |
 | JSON index          | Realtime & Offline |

--- a/build-with-pinot/indexing/README.md
+++ b/build-with-pinot/indexing/README.md
@@ -51,6 +51,10 @@ Use the decision guide when you know the query shape but not the best index yet.
 | Star-tree index     | Offline            |
 | Vector index        | Realtime & Offline |
 
+Indexes available in Realtime Segments are updated during insertion of the consumed row to the segment, so data are indexed as they become queryable.
+
+Indexes available only in Offline segments are calculated during segment load. That means, that for offline tables indexes
+become available when segment was loaded. For realtime tables, those indexes are available only for completed (not consuming) segments.
 ## How Pinot applies indexes
 
 Most index choices are defined in the table config, usually under `fieldConfigList` or `tableIndexConfig`, depending on the index and the configuration style you are using. The canonical table-level reference is [Table](../../reference/configuration-reference/table.md).

--- a/build-with-pinot/indexing/README.md
+++ b/build-with-pinot/indexing/README.md
@@ -34,6 +34,23 @@ Use the decision guide when you know the query shape but not the best index yet.
 * [Star-tree index](star-tree-index.md) for repeatable aggregation and group-by workloads.
 * [Vector index](vector-index.md) for similarity search on embeddings.
 
+### Index availability
+
+| Index Type          | Availability       |
+|:--------------------|:-------------------|
+| Bloom filter        | tbd                |
+| Forward index       | Realtime & Offline |
+| FST index           | Offline            |
+| Inverted index      | Realtime & Offline | 
+| Timestamp index     | tbd                |
+| Range index         | tbd                |
+| Text search support | Realtime & Offline |
+| JSON index          | Realtime & Offline |
+| Geospatial support  | Realtime & Offline |
+| Star-tree index     | Offline            |
+| Vector index        | Realtime & Offline |
+
+
 ## How Pinot applies indexes
 
 Most index choices are defined in the table config, usually under `fieldConfigList` or `tableIndexConfig`, depending on the index and the configuration style you are using. The canonical table-level reference is [Table](../../reference/configuration-reference/table.md).


### PR DESCRIPTION
Short table which classifies indexes by their availability by segment type.
Includes short clarification on between offline and realtime segments.