### PR TITLE
docs: document arraySliceLong (apache/pinot#18591)

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -278,6 +278,7 @@
   * [arrayReverseInt](functions/array/arrayreverseint.md)
   * [arrayReverseString](functions/array/arrayreversestring.md)
   * [arraySliceInt](functions/array/arraysliceint.md)
+  * [arraySliceLong](functions/array/arrayslicelong.md)
   * [arraySliceString](functions/array/arrayslicestring.md)
   * [arraySortInt](functions/array/arraysortint.md)
   * [arraySortString](functions/array/arraysortstring.md)

--- a/functions/array/README.md
+++ b/functions/array/README.md
@@ -509,6 +509,17 @@ SELECT arraySliceInt(ARRAY[10, 20, 30, 40], 1, 3);
 -- Result: [20, 30]
 ```
 
+### arraySliceLong
+
+**Description**: Extracts a LONG subarray (start inclusive, end exclusive).\
+**Syntax**: `arraySliceLong(long_array, start, end)`\
+**Example**:
+
+```sql
+SELECT arraySliceLong(ARRAY[10000000000, 20000000000, 30000000000, 40000000000], 1, 3);
+-- Result: [20000000000, 30000000000]
+```
+
 ### arraySliceString
 
 **Description**: Extracts a string subarray.\
@@ -904,6 +915,7 @@ SELECT arrayToString(ARRAY['foo', NULL, 'bar'], '|', 'NA');
 | [arrayToString](arraytostring.md) | [arrayRemoveInt](arrayremoveint.md) |
 | [arrayRemoveString](arrayremovestring.md) | [arrayReverseInt](arrayreverseint.md) |
 | [arrayReverseString](arrayreversestring.md) | [arraySliceInt](arraysliceint.md) |
-| [arraySliceString](arrayslicestring.md) | [arraySortInt](arraysortint.md) |
-| [arraySortString](arraysortstring.md) | [arrayUnionInt](arrayunionint.md) |
-| [arrayUnionString](arrayunionstring.md) | [isEqualSet](isequalset.md) |
+| [arraySliceLong](arrayslicelong.md) | [arraySliceString](arrayslicestring.md) |
+| [arraySortInt](arraysortint.md) | [arraySortString](arraysortstring.md) |
+| [arrayUnionInt](arrayunionint.md) | [arrayUnionString](arrayunionstring.md) |
+| [isEqualSet](isequalset.md) |  |

--- a/functions/array/arrayslicelong.md
+++ b/functions/array/arrayslicelong.md
@@ -1,0 +1,23 @@
+---
+description: This section contains reference documentation for the arraySliceLong function.
+---
+
+# arraySliceLong
+
+Returns the LONG values in the array between the start and end positions. The `start` index is inclusive and the `end` index is exclusive.
+
+## Signature
+
+> arraySliceLong('colName', start, end)
+
+## Usage Examples
+
+This example uses a LONG array literal.
+
+```sql
+select arraySliceLong(ARRAY[10000000000, 20000000000, 30000000000, 40000000000], 1, 3) AS slice
+```
+
+| slice                 |
+| --------------------- |
+| 20000000000,30000000000 |


### PR DESCRIPTION
## Summary

- document the new `arraySliceLong` scalar function added in `apache/pinot#18591`
- add a dedicated `functions/array/arrayslicelong.md` reference page and link it from the array function landing page
- update `SUMMARY.md` so the new page is discoverable in GitBook navigation

## Cross-checks against apache/pinot

- verified `pinot-common/src/main/java/org/apache/pinot/common/function/scalar/ArrayFunctions.java` now exposes `arraySliceLong(long[], int, int)`
- verified the implementation uses `Arrays.copyOfRange`, matching the existing start-inclusive/end-exclusive semantics used by `arraySliceInt`
- verified transform and integration coverage in `ScalarTransformFunctionWrapperTest` and `ArrayTest`

## Validation

- `git diff --check`
- lightweight link target check for the new `arrayslicelong.md` references from `functions/array/README.md` and `SUMMARY.md`
