### PR TITLE
docs: document pauseStatus inactive topics (apache/pinot#18624)

### DIFF
--- a/build-with-pinot/ingestion/stream-ingestion/README.md
+++ b/build-with-pinot/ingestion/stream-ingestion/README.md
@@ -490,7 +490,7 @@ When a `Pause` request is issued, the controller instructs the real-time servers
 $ curl -X GET {controllerHost}/tables/{tableName}/pauseStatus
 ```
 
-The pause status response includes the current `pauseFlag`, the set of `consumingSegments`, the stored `reasonCode`, any persisted `comment`, and the controller-side `timestamp` for the current pause state. When no explicit comment was stored, Pinot returns a default paused or unpaused message.
+The pause status response includes the current `pauseFlag`, the set of `consumingSegments`, the stored `reasonCode`, any persisted `comment`, and the controller-side `timestamp` for the current pause state. When topic-level pause APIs have paused only some stream topics, Pinot also returns `indexOfInactiveTopics` with the zero-based topic indexes that remain inactive. When no explicit comment was stored, Pinot returns a default paused or unpaused message.
 
 It's worth noting that consuming segments on real-time servers are stored in volatile memory, and their resources are allocated when the consuming segments are first created. These resources cannot be altered if consumption parameters are changed midway through consumption. It may take hours before these changes take effect. Furthermore, if the parameters are changed in an incompatible way (for example, changing the underlying stream with a completely new set of offsets, or changing the stream endpoint from which to consume messages), it will result in the table getting into an error state.
 

--- a/reference/api-reference/controller-api.md
+++ b/reference/api-reference/controller-api.md
@@ -1422,6 +1422,7 @@ curl -X GET "http://localhost:9000/tables/myTable/pauseStatus" -H "accept: appli
 | `reasonCode` | string | Pause reason code, such as `ADMINISTRATIVE` for operator-driven pauses or `STORAGE_QUOTA_EXCEEDED` for automatic storage-quota pauses. |
 | `comment` | string | Stored administrative or automatic pause comment. If no explicit comment was stored, Pinot returns a default paused or unpaused message. |
 | `timestamp` | string | Stored pause-state timestamp from the controller metadata. |
+| `indexOfInactiveTopics` | array of integers | Zero-based topic indexes that remain paused after topic-level pause operations. Pinot omits this field when no individual topics are paused. |
 
 **Example response**
 
@@ -1434,7 +1435,8 @@ curl -X GET "http://localhost:9000/tables/myTable/pauseStatus" -H "accept: appli
   ],
   "reasonCode": "ADMINISTRATIVE",
   "comment": "maintenance",
-  "timestamp": "<stored pause-state timestamp>"
+  "timestamp": "<stored pause-state timestamp>",
+  "indexOfInactiveTopics": [0, 1]
 }
 ```
 


### PR DESCRIPTION
## Summary
- document the new `indexOfInactiveTopics` field on `GET /tables/{tableName}/pauseStatus`
- note topic-level pause visibility in the stream-ingestion guide

## Validation
- `git diff --check`
