### PR TITLE
docs: document pipeline breaker stageStats default (apache/pinot#18601)

### DIFF
--- a/build-with-pinot/querying-and-sql/multi-stage-query/understanding-stage-stats.md
+++ b/build-with-pinot/querying-and-sql/multi-stage-query/understanding-stage-stats.md
@@ -8,6 +8,8 @@ description: >-
 
 Multi-stage stats (MSE) are more complex but also more expressive than single-stage stats. While in single-stage stats Apache Pinot returns a single set of statistics for the query, in multi-stage stats Apache Pinot returns a set of statistics for each operator of the query execution. These stats are collected by default and included in the response of any MSE query.
 
+Starting in Pinot 1.6.0, the `stageStats` tree also includes leaf-stage pipeline-breaker subtrees by default. If an existing consumer needs the pre-1.6 shape, set `pinot.query.mse.skip.pipeline.breaker.stats=true` on the cluster to suppress those nodes again.
+
 Each operator has its own set of statistics, which are collected during the execution of the query. See the [Operator Types](../../../build-with-pinot/querying-and-sql/multi-stage-query/operator-types) section to learn more about the different operator types and their statistics.
 
 ### Multi-stage stats visualizer [](#multi-stage-stats-visualizer)

--- a/operate-pinot/production-guides/run-multi-stage-engine-in-production.md
+++ b/operate-pinot/production-guides/run-multi-stage-engine-in-production.md
@@ -132,6 +132,8 @@ If a rolling upgrade still includes any server older than Pinot 1.4.0, set `pino
 `SAFE` is intentionally conservative: it only sends stats when all brokers and servers advertise the same Pinot version. During a Pinot 1.4-to-1.5 rolling upgrade, that can temporarily suppress stage stats even though `ALWAYS` remains the recommended setting once all servers are on Pinot 1.4.0 or later.
 {% endhint %}
 
+Starting in Pinot 1.6.0, stage stats also include pipeline-breaker child operators by default. That richer tree is usually preferable for debugging joins and semi-joins, but if an existing downstream parser expects the 1.5-era shape you can temporarily restore it with `pinot.query.mse.skip.pipeline.breaker.stats=true`.
+
 ## Choosing between standard MSE and Lite Mode
 
 MSE supports two execution modes:


### PR DESCRIPTION
## Summary
- document that Pinot 1.6.0 includes pipeline-breaker child nodes in `stageStats` by default
- note the `pinot.query.mse.skip.pipeline.breaker.stats=true` opt-out for old consumers

## Validation
- `git diff --check`
