### PR TITLE
docs: document MSE adaptive routing metric (apache/pinot#18553)

### DIFF
--- a/operate-pinot/tuning/query-routing-using-adaptive-server-selection.md
+++ b/operate-pinot/tuning/query-routing-using-adaptive-server-selection.md
@@ -80,17 +80,18 @@ To enable adaptive routing metrics export:
 
 #### Available Metrics
 
-Three metrics are exported for each broker × server pair:
+Single-stage adaptive routing exports three metrics for each broker × server pair, and multi-stage adaptive routing now exports its own in-flight gauge:
 
 | Metric Name | Type | Description |
 | --- | --- | --- |
 | `adaptiveServerNumInFlightRequests` | Gauge | Number of in-flight (pending) requests currently being processed on this server |
 | `adaptiveServerLatencyEma` | Gauge | Exponential moving average of query latency (in milliseconds) observed on this server |
 | `adaptiveServerHybridScore` | Gauge | Combined score balancing in-flight requests and latency to indicate server health; higher scores indicate less healthy servers |
+| `adaptiveServerMseNumInFlightRequests` | Gauge | Number of in-flight multi-stage requests currently being processed on this server. Pinot exports only the MSE in-flight gauge today; MSE latency and hybrid-score series are not emitted yet. |
 
 #### Metric Format
 
-Metric names follow the pattern: `pinot.broker.adaptiveServer<MetricName>.<tenant>.<server>`
+Metric names follow the pattern `pinot.broker.adaptiveServer<MetricName>.<tenant>.<server>` for SSE metrics and `pinot.broker.adaptiveServerMseNumInFlightRequests.<tenant>.<server>` for the MSE in-flight series.
 
 Example: `pinot.broker.adaptiveServerLatencyEma.server.Server_pinotdb1_8098`
 

--- a/reference/configuration-reference/monitoring-metrics.md
+++ b/reference/configuration-reference/monitoring-metrics.md
@@ -230,9 +230,9 @@ Pinot provides metrics out of the box so that you can monitor every aspect of pe
 | TASK_EXECUTION | Time spent by tasks in execution |  |
 | STARTUP_SUCCESS_DURATION_MS | Time spent starting the minion when startup completes successfully |  |
 
-#### Adaptive Server Routing Metrics (Multi-stage)
+#### Adaptive Server Routing Metrics
 
-Broker tracks per-server adaptive routing statistics when `pinot.broker.adaptive.server.selector.enable.stats.collection=true`. These stats can be exported as broker metrics by enabling `pinot.broker.adaptive.server.selector.enable.stats.metric.export=true` (disabled by default to avoid cardinality concerns). When enabled, metrics are emitted in the form `pinot.broker.adaptiveServer<MetricName>.<tenant>.<server>`.
+Broker tracks per-server adaptive routing statistics when `pinot.broker.adaptive.server.selector.enable.stats.collection=true`. These stats can be exported as broker metrics by enabling `pinot.broker.adaptive.server.selector.enable.stats.metric.export=true` (disabled by default to avoid cardinality concerns). Pinot exports the SSE metrics as `pinot.broker.adaptiveServer<MetricName>.<tenant>.<server>` and the MSE in-flight gauge as `pinot.broker.adaptiveServerMseNumInFlightRequests.<tenant>.<server>`.
 
 **Configuration:**
 - `pinot.broker.adaptive.server.selector.enable.stats.collection`: Enable/disable stats collection (default: `false`)
@@ -246,3 +246,4 @@ Broker tracks per-server adaptive routing statistics when `pinot.broker.adaptive
 | adaptiveServerNumInFlightRequests | Number of in-flight requests to a specific server | Gauge |
 | adaptiveServerLatencyEma | Exponential moving average of latency (ms) for a specific server | Gauge |
 | adaptiveServerHybridScore | Hybrid score for a specific server (combines in-flight requests and latency) | Gauge |
+| adaptiveServerMseNumInFlightRequests | Number of in-flight multi-stage requests to a specific server | Gauge |


### PR DESCRIPTION
## Summary
- document the new `adaptiveServerMseNumInFlightRequests` broker metric
- clarify that SSE and MSE adaptive-routing metrics are exported as separate series

## Validation
- `git diff --check`
