### PR TITLE
docs: document materialized view DDL (apache/pinot#18544)

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -92,7 +92,7 @@
 * [Querying & SQL](build-with-pinot/querying-and-sql/README.md)
   * [Querying Pinot](build-with-pinot/querying-and-sql/querying-pinot.md)
   * [SQL syntax](build-with-pinot/querying-and-sql/sql-syntax.md)
-    * [SQL Table DDL](build-with-pinot/querying-and-sql/sql-ddl.md)
+    * [SQL DDL](build-with-pinot/querying-and-sql/sql-ddl.md)
     * [SQL Reference](build-with-pinot/querying-and-sql/sql-reference.md)
     * [Query Syntax Overview](build-with-pinot/querying-and-sql/query-syntax-overview.md)
     * [Filtering with IdSet](build-with-pinot/querying-and-sql/filtering-with-idset.md)

--- a/build-with-pinot/querying-and-sql/README.md
+++ b/build-with-pinot/querying-and-sql/README.md
@@ -42,7 +42,7 @@ For explain plans, joins, optimizer behavior, and operator details, continue int
 
 ## What this page covered
 
-This page mapped the main query workflows in Pinot: learning the query path, understanding SQL behavior, finding functions, choosing between SSE and MSE, using SQL table DDL through the controller, working with materialized views, and tuning execution controls.
+This page mapped the main query workflows in Pinot: learning the query path, understanding SQL behavior, finding functions, choosing between SSE and MSE, using controller-managed SQL DDL for tables and materialized views, and tuning execution controls.
 
 ## Next step
 

--- a/build-with-pinot/querying-and-sql/materialized-views.md
+++ b/build-with-pinot/querying-and-sql/materialized-views.md
@@ -1,10 +1,10 @@
 ---
-description: Create offline Pinot materialized views for recurring time-windowed aggregations.
+description: Create and manage offline Pinot materialized views for recurring time-windowed aggregations.
 ---
 
 # Materialized Views
 
-Materialized views in Pinot are offline tables that store pre-aggregated results for a recurring query shape. Pinot validates the materialized view definition when you create the table, refreshes it with the `MaterializedViewTask` minion workflow, and exposes discovery and runtime state in the controller UI and REST API. Pinot can also transparently rewrite eligible single-stage base-table queries to a materialized view when the broker rewrite feature is enabled.
+Materialized views in Pinot are offline tables that store pre-aggregated results for a recurring query shape. Use controller-managed SQL DDL through `POST /sql/ddl` to create, inspect, list, and drop them. Pinot validates the materialized view definition when you create it, refreshes it with the `MaterializedViewTask` minion workflow, and exposes discovery and runtime state in the controller UI and REST API. Pinot can also transparently rewrite eligible single-stage base-table queries to a materialized view when the broker rewrite feature is enabled.
 
 {% hint style="info" %}
 Transparent materialized-view rewrite is available for eligible Single-Stage Engine (SSE) queries. Keep querying the MV table directly when you want explicit control over the table name or when broker rewrite is disabled.
@@ -14,9 +14,10 @@ Transparent materialized-view rewrite is available for eligible Single-Stage Eng
 
 - Time-windowed materialized views only.
 - The MV table itself must be `OFFLINE`.
+- Create and manage MVs through controller SQL DDL: `CREATE MATERIALIZED VIEW`, `SHOW MATERIALIZED VIEWS`, `SHOW CREATE MATERIALIZED VIEW`, and `DROP MATERIALIZED VIEW`.
 - Transparent rewrite applies to eligible SSE queries only.
 - Broker-side rewrite is off by default until you set `pinot.broker.query.enable.materialized.view.rewrite=true` on brokers.
-- Create the MV by posting a schema and an offline table config. The table config must set top-level `isMaterializedView: true` and include `task.taskTypeConfigsMap.MaterializedViewTask` with a non-empty `definedSQL`.
+- `CREATE MATERIALIZED VIEW` accepts either a full column list or no column list at all. If you omit the column list, Pinot infers the MV schema from the `AS SELECT` projection.
 - Use a flat `SELECT` over one source table. Pinot validates the SQL, schema mapping, bucket definition, and aggregation set when the MV table is created.
 - The source table must be append-only. Pinot rejects realtime, upsert, dedup, dimension, and `REFRESH`-push source tables.
 - The source table time column and the MV time column must both be `TIMESTAMP` `dateTimeFieldSpecs`.
@@ -30,87 +31,58 @@ Pinot also validates the expression that produces the MV time column. The suppor
 - Run at least one Minion.
 - Enable controller task scheduling with `controller.task.scheduler.enabled=true`.
 - Keep the base table on the validated append-only `OFFLINE` path described above.
+- Decide whether Pinot should infer the MV schema from the `SELECT` list or whether you need to provide a full explicit column list to override inferred types or roles.
 
-## Define the schema and MV table
+## Create an MV with SQL DDL
 
-Create the schema first, then create the MV table as an offline table with top-level `isMaterializedView: true` plus a `MaterializedViewTask` block.
+Run MV DDL through the controller endpoint `POST /sql/ddl`, not through the broker query API.
 
-Pinot uses `isMaterializedView` as the canonical MV identity bit. `MaterializedViewTask` still carries execution settings such as `definedSQL` and `bucketTimePeriod`, and Pinot rejects configs where only one side is present. If you manage tables through SQL DDL, the same flag round-trips as `PROPERTIES ('isMaterializedView' = 'true', ...)`.
+The controller accepts these MV statements:
 
-The task config needs at least these keys:
+- `CREATE MATERIALIZED VIEW [IF NOT EXISTS] [db.]name [(...)] [REFRESH [INTERVAL] EVERY ...] PROPERTIES (...) AS <select>`
+- `SHOW MATERIALIZED VIEWS [FROM db]`
+- `SHOW CREATE MATERIALIZED VIEW [db.]name`
+- `DROP MATERIALIZED VIEW [IF EXISTS] [db.]name`
 
-- `definedSQL`: the aggregation query Pinot runs for each time window.
-- `bucketTimePeriod`: the window size, such as `1h` or `1d`.
-- `stalenessThresholdMs`: optional freshness SLO for broker rewrite. `0` is the default and means Pinot can use any MV with a non-zero watermark.
+If you omit the column list, Pinot infers the MV schema from the `SELECT` projection. If you provide a column list, declare every projected column and alias every computed expression or aggregation so it matches the destination column name.
 
-The `SELECT` output must line up with the MV schema exactly. Bare column references keep their source names. Any expression or aggregation needs an `AS` alias that matches the destination schema column.
+The DDL needs at least these properties:
 
-Example schema:
+- `timeColumnName`: the MV column Pinot uses to track watermark progress.
+- `bucketTimePeriod`: the materialization window size, such as `1h` or `1d`.
+- `stalenessThresholdMs`: optional freshness SLO for broker rewrite. `0` disables the SLO check.
 
-```json
-{
-  "schemaName": "salesByHourMv",
-  "dimensionFieldSpecs": [
-    {
-      "name": "region",
-      "dataType": "STRING"
-    }
-  ],
-  "metricFieldSpecs": [
-    {
-      "name": "sum_revenue",
-      "dataType": "DOUBLE"
-    },
-    {
-      "name": "row_count",
-      "dataType": "LONG"
-    }
-  ],
-  "dateTimeFieldSpecs": [
-    {
-      "name": "bucket_start_ts",
-      "dataType": "TIMESTAMP",
-      "format": "1:MILLISECONDS:TIMESTAMP",
-      "granularity": "1:MILLISECONDS"
-    }
-  ]
-}
+`REFRESH EVERY` is optional. When you provide it, Pinot stores a per-MV schedule using minute, hour, or day units. When you omit it, the MV runs on the cluster-wide `MaterializedViewTask` schedule.
+
+Example DDL:
+
+```sql
+CREATE MATERIALIZED VIEW salesByHourMv
+REFRESH EVERY 1 HOUR
+PROPERTIES (
+  'timeColumnName' = 'bucket_start_ts',
+  'bucketTimePeriod' = '1h',
+  'stalenessThresholdMs' = '900000',
+  'replication' = '1'
+)
+AS
+SELECT DATETRUNC('HOUR', event_ts) AS bucket_start_ts,
+       region,
+       SUM(revenue) AS sum_revenue,
+       COUNT(*) AS row_count
+FROM sales
+GROUP BY DATETRUNC('HOUR', event_ts), region;
 ```
 
-Example table config:
-
-```json
-{
-  "tableName": "salesByHourMv",
-  "tableType": "OFFLINE",
-  "isMaterializedView": true,
-  "segmentsConfig": {
-    "timeColumnName": "bucket_start_ts",
-    "segmentPushType": "APPEND",
-    "replication": "1"
-  },
-  "task": {
-    "taskTypeConfigsMap": {
-      "MaterializedViewTask": {
-        "definedSQL": "SELECT DATETRUNC('HOUR', event_ts) AS bucket_start_ts, region, SUM(revenue) AS sum_revenue, COUNT(*) AS row_count FROM sales GROUP BY DATETRUNC('HOUR', event_ts), region",
-        "bucketTimePeriod": "1h",
-        "stalenessThresholdMs": "900000"
-      }
-    }
-  }
-}
-```
-
-Post the schema and table config through the controller:
+Submit the statement through the controller:
 
 ```bash
-curl -X POST "http://localhost:9000/schemas" \
+curl -X POST "http://localhost:9000/sql/ddl" \
+  -H "accept: application/json" \
   -H "Content-Type: application/json" \
-  -d @salesByHourMv_schema.json
-
-curl -X POST "http://localhost:9000/tables" \
-  -H "Content-Type: application/json" \
-  -d @salesByHourMv_offline_table_config.json
+  -d @- <<'EOF'
+{"sql":"CREATE MATERIALIZED VIEW salesByHourMv REFRESH EVERY 1 HOUR PROPERTIES ('timeColumnName' = 'bucket_start_ts', 'bucketTimePeriod' = '1h', 'stalenessThresholdMs' = '900000', 'replication' = '1') AS SELECT DATETRUNC('HOUR', event_ts) AS bucket_start_ts, region, SUM(revenue) AS sum_revenue, COUNT(*) AS row_count FROM sales GROUP BY DATETRUNC('HOUR', event_ts), region"}
+EOF
 ```
 
 Pinot generates MV segments through `MaterializedViewTask`. The controller task manager can schedule those tasks automatically, or you can trigger them manually:
@@ -118,6 +90,10 @@ Pinot generates MV segments through `MaterializedViewTask`. The controller task 
 ```text
 POST /tasks/schedule?taskType=MaterializedViewTask&tableName=<mvTable>_OFFLINE
 ```
+
+## When to keep using JSON APIs
+
+The existing `POST /schemas`, `POST /tables`, and `PUT /tables/{tableName}` APIs still work for materialized views. Keep using them when your automation already depends on raw Pinot metadata payloads, or when you need a hand-written `MaterializedViewTask` cron that cannot be expressed as `REFRESH EVERY <N> MINUTES|HOURS|DAYS` or `'<N>m|h|d'`.
 
 ## Enable transparent rewrite for SSE queries
 
@@ -186,6 +162,16 @@ In the Data Explorer, use **Data Sources** to discover both physical tables and 
 - **Materialized Views** lists each MV with its base tables, watermark, VALID and STALE partition counts, last refresh time, staleness SLO, and any metadata errors.
 - Clicking an MV opens a detail page with the stored `definedSQL`, split spec, partition state, raw runtime metadata, and controls to refresh the page data or drop the MV.
 
+The same controller DDL surface also lets you inspect and remove MVs from SQL:
+
+```sql
+SHOW MATERIALIZED VIEWS;
+SHOW CREATE MATERIALIZED VIEW salesByHourMv;
+DROP MATERIALIZED VIEW IF EXISTS salesByHourMv;
+```
+
+`SHOW MATERIALIZED VIEWS` returns raw MV names without the `_OFFLINE` suffix. `SHOW CREATE MATERIALIZED VIEW` emits canonical DDL for the stored MV definition, including an explicit column list even when the original `CREATE MATERIALIZED VIEW` used inferred columns.
+
 The controller also exposes dedicated MV endpoints:
 
 - `GET /materializedViews`
@@ -194,7 +180,7 @@ The controller also exposes dedicated MV endpoints:
 
 ## What this page covered
 
-This page covered the current materialized-view feature surface in Pinot: how to define the schema and offline table, which source tables and aggregations are supported, how broker-side SSE rewrite works, how to query the MV table directly, and where to inspect the MV in the UI and controller API.
+This page covered the current materialized-view feature surface in Pinot: how to create and manage an MV through controller SQL DDL, which source tables and aggregations are supported, how broker-side SSE rewrite works, how to query the MV table directly, and where to inspect the MV in the UI and controller API.
 
 ## Next step
 

--- a/build-with-pinot/querying-and-sql/sql-ddl.md
+++ b/build-with-pinot/querying-and-sql/sql-ddl.md
@@ -1,10 +1,10 @@
 ---
-description: Use controller-managed SQL DDL to create, inspect, list, and drop Pinot tables.
+description: Use controller-managed SQL DDL to create, inspect, list, and drop Pinot tables and materialized views.
 ---
 
-# SQL Table DDL
+# SQL DDL
 
-Pinot supports a controller-managed SQL DDL surface for table metadata operations. Use it when you want a SQL alternative to the JSON-based `/schemas` and `/tables` workflows.
+Pinot supports a controller-managed SQL DDL surface for table and materialized-view metadata operations. Use it when you want a SQL alternative to the JSON-based `/schemas` and `/tables` workflows.
 
 The controller accepts one DDL statement per request:
 
@@ -12,9 +12,13 @@ The controller accepts one DDL statement per request:
 - `DROP TABLE`
 - `SHOW TABLES`
 - `SHOW CREATE TABLE`
+- `CREATE MATERIALIZED VIEW`
+- `SHOW MATERIALIZED VIEWS`
+- `SHOW CREATE MATERIALIZED VIEW`
+- `DROP MATERIALIZED VIEW`
 
 {% hint style="info" %}
-Run these statements through the controller endpoint `POST /sql/ddl`, not through the broker query API. SSE and MSE still execute query statements; the controller owns table DDL.
+Run these statements through the controller endpoint `POST /sql/ddl`, not through the broker query API. SSE and MSE still execute query statements; the controller owns table and materialized-view DDL.
 {% endhint %}
 
 ## How it works
@@ -22,7 +26,9 @@ Run these statements through the controller endpoint `POST /sql/ddl`, not throug
 `POST /sql/ddl` compiles SQL into the same Pinot `Schema` and `TableConfig` model used by the existing controller APIs. That means:
 
 - DDL-created tables go through the same controller validation path as `POST /tables`.
+- DDL-created materialized views persist as regular `OFFLINE` tables plus the same MV task config the JSON APIs use.
 - `SHOW CREATE TABLE` renders a canonical SQL form of the stored schema and table config that you can review, version, or replay.
+- `SHOW CREATE MATERIALIZED VIEW` renders canonical MV DDL for the stored definition, including the `AS <query>` clause and MV-specific properties.
 - `dryRun=true` lets you compile and validate without persisting any metadata.
 - Existing broker query APIs still handle `SELECT` statements. The controller endpoint handles metadata changes.
 
@@ -34,6 +40,10 @@ Run these statements through the controller endpoint `POST /sql/ddl`, not throug
 | `DROP TABLE [IF EXISTS] [db.]table [TYPE OFFLINE|REALTIME]` | Omitting `TYPE` targets both table variants. |
 | `SHOW TABLES [FROM db]` | Lists tables in the selected database. |
 | `SHOW CREATE TABLE [db.]table [TYPE OFFLINE|REALTIME]` | Returns canonical DDL for the stored table metadata. |
+| `CREATE MATERIALIZED VIEW [IF NOT EXISTS] [db.]name [(...)] [REFRESH [INTERVAL] EVERY ...] PROPERTIES (...) AS <select>` | Creates an `OFFLINE` MV. Omit the column list to infer the MV schema from the `SELECT` projection, or provide a full column list to override inferred types or roles. |
+| `SHOW MATERIALIZED VIEWS [FROM db]` | Lists materialized views in the selected database using raw names without the `_OFFLINE` suffix. |
+| `SHOW CREATE MATERIALIZED VIEW [db.]name` | Returns canonical MV DDL for the stored metadata. |
+| `DROP MATERIALIZED VIEW [IF EXISTS] [db.]name` | Drops an MV. There is no `TYPE` clause because MVs are always backed by `OFFLINE` tables. |
 
 Use either a `db.table` qualifier or a `Database` header to target a database. If both are present, they must refer to the same database; otherwise Pinot returns `400 Bad Request`.
 
@@ -70,7 +80,8 @@ curl -X POST "http://localhost:9000/sql/ddl?dryRun=true" \
 High-level response behavior:
 
 - `201 Created` for a successful `CREATE TABLE`
-- `200 OK` for `DROP TABLE`, `SHOW TABLES`, `SHOW CREATE TABLE`, dry runs, and idempotent `IF EXISTS` or `IF NOT EXISTS` cases
+- `201 Created` for a successful `CREATE MATERIALIZED VIEW`
+- `200 OK` for `DROP TABLE`, `SHOW TABLES`, `SHOW CREATE TABLE`, `SHOW MATERIALIZED VIEWS`, `SHOW CREATE MATERIALIZED VIEW`, dry runs, and idempotent `IF EXISTS` or `IF NOT EXISTS` cases
 - `400 Bad Request` for parse errors, semantic validation errors, or oversized SQL
 - `404 Not Found` when a requested table or schema does not exist
 - `409 Conflict` for duplicate `CREATE TABLE` without `IF NOT EXISTS`, logical-table references that block a drop, or a race with another writer
@@ -79,19 +90,19 @@ Response bodies include only fields that apply to the executed operation.
 
 | Field | Applies to | Notes |
 | --- | --- | --- |
-| `operation` | all responses | One of `CREATE_TABLE`, `DROP_TABLE`, `SHOW_TABLES`, or `SHOW_CREATE_TABLE`. |
+| `operation` | all responses | One of `SHOW_TABLES`, `SHOW_MATERIALIZED_VIEWS`, `CREATE_TABLE`, `SHOW_CREATE_TABLE`, `DROP_TABLE`, `CREATE_MATERIALIZED_VIEW`, `SHOW_CREATE_MATERIALIZED_VIEW`, or `DROP_MATERIALIZED_VIEW`. |
 | `databaseName` | create, drop, show create | The database scope used for the operation when available. |
-| `tableName` | create, drop, show create | The resolved Pinot table name, often with `_OFFLINE` or `_REALTIME`. |
-| `tableType` | create, typed drop, show create | `OFFLINE` or `REALTIME`. |
-| `schema` | create | The compiled Pinot schema JSON. Returned for dry runs and persisted creates. |
-| `tableConfig` | create | The compiled Pinot table config JSON after table config tuner processing. Returned for dry runs and persisted creates. |
+| `tableName` | create, drop, show create | The resolved Pinot table name, often with `_OFFLINE` or `_REALTIME`. MV operations still target `OFFLINE` storage under the hood. |
+| `tableType` | table create, typed table drop, table show create | `OFFLINE` or `REALTIME`. MV-specific statements do not take a `TYPE` clause. |
+| `schema` | create | The compiled Pinot schema JSON. Returned for dry runs and persisted creates, including MV creates. |
+| `tableConfig` | create | The compiled Pinot table config JSON after table config tuner processing. Returned for dry runs and persisted creates, including MV creates. |
 | `warnings` | create | Non-fatal compile warnings, such as ignored `DECIMAL(p,s)` precision details. |
 | `dryRun` | create, drop | Whether the request validated without persisting or deleting metadata. |
 | `ifNotExists` | create | Whether the statement used `IF NOT EXISTS`. |
 | `ifExists` | drop | Whether the statement used `IF EXISTS`. |
 | `deletedTables` | drop | Typed table names removed by the drop. |
-| `tableNames` | show tables | Tables visible in the selected database. |
-| `ddl` | show create | Canonical `CREATE TABLE` SQL for the stored metadata. |
+| `tableNames` | catalog listings | Tables or materialized views visible in the selected database, depending on the statement. |
+| `ddl` | show create | Canonical `CREATE TABLE` or `CREATE MATERIALIZED VIEW` SQL for the stored metadata. |
 | `message` | most responses | Human-readable operation summary. |
 
 ## Columns, types, and defaults
@@ -289,6 +300,53 @@ PROPERTIES (
 );
 ```
 
+## Example: create and inspect a materialized view
+
+Use `CREATE MATERIALIZED VIEW` when you want the controller to persist an MV as an `OFFLINE` table plus `MaterializedViewTask` metadata. The column list is optional: omit it to infer the schema from the `SELECT` projection, or provide a full column list if you need to override inferred types or roles.
+
+```sql
+CREATE MATERIALIZED VIEW salesByHourMv
+REFRESH EVERY 1 HOUR
+PROPERTIES (
+  'timeColumnName' = 'bucket_start_ts',
+  'bucketTimePeriod' = '1h',
+  'stalenessThresholdMs' = '900000',
+  'replication' = '1'
+)
+AS
+SELECT DATETRUNC('HOUR', event_ts) AS bucket_start_ts,
+       region,
+       SUM(revenue) AS sum_revenue,
+       COUNT(*) AS row_count
+FROM sales
+GROUP BY DATETRUNC('HOUR', event_ts), region;
+```
+
+Use the same endpoint to list, inspect, and drop MVs:
+
+```bash
+curl -X POST "http://localhost:9000/sql/ddl" \
+  -H "accept: application/json" \
+  -H "Content-Type: application/json" \
+  -d '{"sql":"SHOW MATERIALIZED VIEWS"}'
+```
+
+```bash
+curl -X POST "http://localhost:9000/sql/ddl" \
+  -H "accept: application/json" \
+  -H "Content-Type: application/json" \
+  -d '{"sql":"SHOW CREATE MATERIALIZED VIEW salesByHourMv"}'
+```
+
+```bash
+curl -X POST "http://localhost:9000/sql/ddl" \
+  -H "accept: application/json" \
+  -H "Content-Type: application/json" \
+  -d '{"sql":"DROP MATERIALIZED VIEW IF EXISTS salesByHourMv"}'
+```
+
+`SHOW CREATE MATERIALIZED VIEW` emits canonical DDL for the stored MV definition, including an explicit column list even if the original create statement relied on inferred columns.
+
 ## Example: show the stored table definition
 
 ```bash
@@ -333,7 +391,7 @@ Use `DROP TABLE events` without `TYPE` to drop both the offline and realtime var
 
 ## When to keep using JSON APIs
 
-If you already manage table metadata through `POST /schemas`, `POST /tables`, or `PUT /tables/{tableName}`, those APIs still work. SQL DDL is an additional interface, not a replacement for the existing controller metadata APIs.
+If you already manage table metadata through `POST /schemas`, `POST /tables`, or `PUT /tables/{tableName}`, those APIs still work. SQL DDL is an additional interface, not a replacement for the existing controller metadata APIs. For materialized views, keep using raw JSON metadata if you need a `MaterializedViewTask` schedule that is not expressible as `REFRESH EVERY <N> MINUTES|HOURS|DAYS` or `'<N>m|h|d'`.
 
 ## Related pages
 

--- a/build-with-pinot/querying-and-sql/sql-reference.md
+++ b/build-with-pinot/querying-and-sql/sql-reference.md
@@ -696,8 +696,8 @@ The following table summarizes feature support across the single-stage engine (S
 | Window functions (OVER, PARTITION BY) | No | Yes |
 | Correlated subqueries | No | No |
 | INSERT INTO (from file) | No | Yes |
-| CREATE TABLE / DROP TABLE DDL | No | No |
+| Controller DDL (tables and materialized views) | No | No |
 | DISTINCT with * | No | No |
 | DISTINCT with GROUP BY | No | No |
 
-`CREATE TABLE / DROP TABLE DDL` stays `No` in this matrix because broker-routed SSE and MSE queries do not execute table DDL. Pinot exposes SQL table DDL through the controller endpoint `POST /sql/ddl`; see [SQL Table DDL](sql-ddl.md).
+`Controller DDL (tables and materialized views)` stays `No` in this matrix because broker-routed SSE and MSE queries do not execute controller metadata DDL. Pinot exposes SQL DDL through the controller endpoint `POST /sql/ddl`; see [SQL DDL](sql-ddl.md) and [Materialized Views](materialized-views.md).

--- a/build-with-pinot/querying-and-sql/sql-syntax.md
+++ b/build-with-pinot/querying-and-sql/sql-syntax.md
@@ -44,15 +44,15 @@ Some SQL features depend on the engine:
 
 If you are working on a query and do not know whether a feature is supported, check the engine-specific guidance before you assume the syntax is invalid.
 
-## Table DDL runs on the controller
+## DDL runs on the controller
 
-Pinot also supports SQL table DDL, but it is exposed through the controller rather than the broker query path. Use `POST /sql/ddl` for `CREATE TABLE`, `DROP TABLE`, `SHOW TABLES`, and `SHOW CREATE TABLE`.
+Pinot also supports controller-managed SQL DDL, but it is exposed through the controller rather than the broker query path. Use `POST /sql/ddl` for table statements such as `CREATE TABLE`, `DROP TABLE`, `SHOW TABLES`, and `SHOW CREATE TABLE`, and for materialized-view statements such as `CREATE MATERIALIZED VIEW`, `SHOW MATERIALIZED VIEWS`, `SHOW CREATE MATERIALIZED VIEW`, and `DROP MATERIALIZED VIEW`.
 
-This distinction matters because the SSE and MSE engines still execute query statements, not controller metadata changes. If you want the syntax and examples for controller-managed DDL, use [SQL Table DDL](sql-ddl.md).
+This distinction matters because the SSE and MSE engines still execute query statements, not controller metadata changes. If you want the syntax and examples for controller-managed DDL, use [SQL DDL](sql-ddl.md) and [Materialized Views](materialized-views.md).
 
 ## Where the details live
 
-This page intentionally stays light. For the full statement-by-statement reference, use the detailed [SQL syntax and operators reference](sql-reference.md). For controller-managed table DDL, use [SQL Table DDL](sql-ddl.md). For query controls and diagnostics, use the pages under `query-execution-controls/`.
+This page intentionally stays light. For the full statement-by-statement reference, use the detailed [SQL syntax and operators reference](sql-reference.md). For controller-managed DDL, use [SQL DDL](sql-ddl.md). For MV-specific workflow guidance, use [Materialized Views](materialized-views.md). For query controls and diagnostics, use the pages under `query-execution-controls/`.
 
 ## What this page covered
 
@@ -65,6 +65,7 @@ Read [Querying Pinot](querying-pinot.md) for the broader query workflow, or jump
 ## Related pages
 
 - [Querying Pinot](querying-pinot.md)
-- [SQL Table DDL](sql-ddl.md)
+- [SQL DDL](sql-ddl.md)
+- [Materialized Views](materialized-views.md)
 - [Query options](query-execution-controls/query-options.md)
 - [Explain plan](query-execution-controls/explain-plan.md)


### PR DESCRIPTION
## What changed for readers
- document `CREATE MATERIALIZED VIEW`, `SHOW MATERIALIZED VIEWS`, `SHOW CREATE MATERIALIZED VIEW`, and `DROP MATERIALIZED VIEW` as the primary controller-managed workflow for Pinot materialized views
- replace the old JSON-first MV creation guidance with SQL DDL examples, while keeping the JSON APIs documented for raw metadata automation and non-standard schedules
- update the nearby SQL overview/reference pages so `POST /sql/ddl` is described as the controller DDL surface for both tables and materialized views

## Structural updates
- rename the query-nav entry from `SQL Table DDL` to `SQL DDL`
- keep the existing GitBook page structure and update the query landing/overview pages to point readers toward the new MV DDL path

## Cross-checked against apache/pinot
- `apache/pinot#18544` merged source for the new MV DDL grammar and controller flow in `pinot-common`, `pinot-sql-ddl`, and `pinot-controller`
- inferred-column support, optional `REFRESH EVERY`, raw-name `SHOW MATERIALIZED VIEWS`, canonical `SHOW CREATE MATERIALIZED VIEW`, and `DROP MATERIALIZED VIEW` type-partitioning behavior
- JSON-API fallback for non-round-trippable schedules, based on the merged reverse-DDL and property-routing behavior

## Validation
- `git diff --check`
- internal markdown/content-ref link resolution on the changed docs pages
