### PR TITLE
docs: document mailbox backpressure controls (apache/pinot#18519)

### DIFF
--- a/operate-pinot/production-guides/run-multi-stage-engine-in-production.md
+++ b/operate-pinot/production-guides/run-multi-stage-engine-in-production.md
@@ -108,6 +108,19 @@ The broker and server controls protect different parts of the system:
 Changing the broker-side throttle from disabled to enabled, or from enabled to disabled, requires a broker restart to take effect. Updating the limit value while the throttle remains enabled is applied dynamically.
 {% endhint %}
 
+### Mailbox backpressure and gRPC memory bounds
+
+The MSE mailbox layer now exposes sender-side backpressure controls for clusters that hit gRPC direct-memory pressure during wide shuffles or slow-consumer scenarios:
+
+| Control | Default | Description |
+| --- | --- | --- |
+| `pinot.query.runner.grpc.sender.backpressure.enabled` | `false` | When `true`, mailbox senders wait for gRPC client writability before pushing the next chunk. Enable this first if you see `OutOfDirectMemoryError` from `GrpcSendingMailbox`. |
+| `pinot.query.runner.grpc.flow.control.window.bytes` | `67108864` (64 MiB) | Receiver-side HTTP/2 flow-control window per inbound stream. Larger values improve throughput but raise worst-case receiver direct-memory exposure for stalled streams. |
+| `pinot.query.runner.grpc.write.buffer.high.water.mark.bytes` | `67108864` (64 MiB) | Sender-side per-channel Netty write-buffer high watermark. This is the primary cap on outbound mailbox direct memory per peer. |
+| `pinot.query.runner.grpc.write.buffer.low.water.mark.bytes` | `33554432` (32 MiB) | Sender-side low watermark used to reopen the channel after backpressure engages. Keep it below the high watermark to avoid constant writable/unwritable flapping. |
+
+Monitor the corresponding `MAILBOX_CLIENT_USED_DIRECT_MEMORY` and `MAILBOX_CLIENT_USED_HEAP_MEMORY` gauges on brokers and servers to see how much outbound mailbox memory is currently pinned by gRPC clients.
+
 ### Broker pruning and routing
 
 The physical optimizer path supports broker-side segment pruning through `useBrokerPruning`, enabled by default through `pinot.broker.multistage.use.broker.pruning`. The logical planner path can also prune non-partitioned leaf stages, but it stays off by default unless you set `useBrokerPruning=true` for the query or enable `pinot.broker.multistage.logical.planner.use.broker.pruning` on the broker.

--- a/reference/configuration-reference/monitoring-metrics.md
+++ b/reference/configuration-reference/monitoring-metrics.md
@@ -61,6 +61,8 @@ Pinot provides metrics out of the box so that you can monitor every aspect of pe
 | NETTY_TOTAL_USED_DIRECT_MEMORY | Current direct memory allocated by the server's Netty query service |  |
 | GRPC_TOTAL_MAX_DIRECT_MEMORY | Maximum direct memory available to the shaded Netty runtime used by the server gRPC query service and MSE mailbox traffic |  |
 | GRPC_TOTAL_USED_DIRECT_MEMORY | Current direct memory allocated by the shaded Netty runtime used by the server gRPC query service and MSE mailbox traffic |  |
+| MAILBOX_CLIENT_USED_DIRECT_MEMORY | Current direct memory pinned by the server's outbound MSE mailbox gRPC clients |  |
+| MAILBOX_CLIENT_USED_HEAP_MEMORY | Current heap memory pinned by the server's outbound MSE mailbox gRPC clients |  |
 | STARTUP_SUCCESS_DURATION_MS | Time spent starting the server when startup finishes in a healthy state |  |
 | STARTUP_FAILURE_DURATION_MS | Time spent starting the server when startup finishes in an unhealthy state |  |
 | EXECUTION_THREAD_CPU_TIME_NS | time spent by all threads processing query and results (doesn't includes time spent in system activities) |  |
@@ -152,6 +154,8 @@ Pinot provides metrics out of the box so that you can monitor every aspect of pe
 | STARTUP_SUCCESS_DURATION_MS | Time spent starting the broker when startup completes successfully |  |
 | GRPC_TOTAL_MAX_DIRECT_MEMORY | Maximum direct memory available to the shaded Netty runtime used by broker gRPC services and MSE mailbox traffic |  |
 | GRPC_TOTAL_USED_DIRECT_MEMORY | Current direct memory allocated by the shaded Netty runtime used by broker gRPC services and MSE mailbox traffic |  |
+| MAILBOX_CLIENT_USED_DIRECT_MEMORY | Current direct memory pinned by the broker's outbound MSE mailbox gRPC clients |  |
+| MAILBOX_CLIENT_USED_HEAP_MEMORY | Current heap memory pinned by the broker's outbound MSE mailbox gRPC clients |  |
 
 #### Tracking time spent in various phases of Query execution in milliseconds
 


### PR DESCRIPTION
## Summary
- document the new MSE mailbox sender-backpressure and gRPC memory-bound controls
- add the outbound mailbox client direct/heap memory gauges to monitoring docs

## Validation
- `git diff --check`
