### PR TITLE
docs: document LaunchBackfillIngestionJob for complete backfill

### DIFF
--- a/build-with-pinot/ingestion/batch-ingestion.md
+++ b/build-with-pinot/ingestion/batch-ingestion.md
@@ -14,7 +14,7 @@ Spark-based ingestion.
 
 Hadoop-style distributed ingestion.
 
-Backfill jobs for historical ranges.
+Backfill jobs for historical ranges. Pinot ships `LaunchBackfillIngestionJob` for the case where the backfilled input may have fewer files than the original ingestion — see [Backfill Data](batch-ingestion/backfill-data.md).
 
 Dimension tables and other specialized offline loads.
 

--- a/build-with-pinot/ingestion/batch-ingestion/backfill-data.md
+++ b/build-with-pinot/ingestion/batch-ingestion/backfill-data.md
@@ -39,3 +39,60 @@ Backfill jobs expect the same number of (or more) data files on the backfill dat
 For example, assuming table airlineStats has 2 segments(airlineStats\_2014-01-01\_2014-01-01\_0, airlineStats\_2014-01-01\_2014-01-01\_1) on date 2014/01/01 and the backfill input directory contains only 1 input file. Then the segment generation job will create just one segment: airlineStats\_2014-01-01\_2014-01-01\_0. After the segment push job, only segment airlineStats\_2014-01-01\_2014-01-01\_0 got replaced and stale data in segment airlineStats\_2014-01-01\_2014-01-01\_1 are still there.
 
 **If the raw data is modified in such a way that the original time bucket has fewer input files than the first ingestion run, backfill will fail.**
+
+### Complete backfill with LaunchBackfillIngestionJob
+
+To safely handle the case described above — where the backfill input may have fewer files than the original ingestion — Pinot ships a dedicated CLI command, `LaunchBackfillIngestionJob`. Instead of relying on segment-name collision to replace stale data, it uses Pinot's segment-lineage machinery to atomically replace the existing segments in a date range with the newly generated ones. See [Consistent Data Push and Rollback](../../../operate-pinot/consistent-push-and-rollback.md) for the underlying lineage semantics.
+
+#### How it works
+
+`LaunchBackfillIngestionJob` reuses the same `ingestionJobSpec.yaml` as `LaunchDataIngestionJob` and runs in four steps:
+
+| Step | Description |
+|------|-------------|
+| 1. Fetch existing segments | Calls the controller's `selectSegments` API to list every OFFLINE-table segment that overlaps `[startDate, endDate)`. These are the segments that will be replaced. |
+| 2. Generate new segments | Runs a local `SegmentCreation` pass over the input directory. The segment-name generator is forced to `simple` with a unique `_<currentTimeMs>` postfix, so newly generated segment names never collide with the existing ones (and the lineage replace can therefore reference both sets unambiguously). |
+| 3. Create a lineage entry | Calls `startReplaceSegments` with `segmentsFrom = <existing>` and `segmentsTo = <newly generated>`. The old segments continue to serve queries until the lineage entry is finalized. |
+| 4. Push and finalize | Uploads the new segments via `SegmentTarPush`, then calls `endReplaceSegments`, which atomically switches brokers onto the new segment set and retires the old one. If the push fails, the lineage entry is rolled back and any partially uploaded segments are cleaned up. |
+
+Because the old segment set is recorded explicitly in step 3 — rather than inferred from name collisions — the failure mode described in [Edge case example](#edge-case-example), where a shrunken backfill input leaves stale segments behind, cannot occur.
+
+`LaunchBackfillIngestionJob` currently supports **OFFLINE tables only**.
+
+#### Running the command
+
+```bash
+bin/pinot-admin.sh LaunchBackfillIngestionJob \
+    -jobSpecFile /path/to/ingestionJobSpec.yaml \
+    -startDate 2014-01-01 \
+    -endDate 2014-01-02
+```
+
+| Option | Required | Description |
+|--------|----------|-------------|
+| `-jobSpecFile` | yes | Same job-spec YAML used by `LaunchDataIngestionJob`. |
+| `-startDate` | yes | Backfill start date, **inclusive**. Format `yyyy-MM-dd`, parsed as **UTC**. |
+| `-endDate` | yes | Backfill end date, **exclusive**. Format `yyyy-MM-dd`, parsed as **UTC**. |
+| `-partitionColumn` | no | Column on which segments were partitioned via `BoundedColumnValue`. Used together with `-partitionColumnValue` to scope which segments are replaced. |
+| `-partitionColumnValue` | no | Only segments whose `BoundedColumnValue` partition contains this value are eligible for replacement. |
+
+All authentication options inherited from `LaunchDataIngestionJob` (`-authToken`, `-user`, `-password`, `-authProvider`, `-authTokenUrl`) are supported.
+
+{% hint style="info" %}
+Because dates are parsed as UTC day boundaries, callers in non-UTC time zones should account for the offset when building `-startDate` / `-endDate`. A "January 1st" backfill local to `America/Los_Angeles`, for example, spans `2014-01-01T08:00Z` to `2014-01-02T08:00Z`, which does not align with the UTC-day boundaries the command uses.
+{% endhint %}
+
+#### Filtering by partition column
+
+For tables whose offline segments are partitioned by `BoundedColumnValue`, the backfill can be scoped to a subset of partitions using `-partitionColumn` and `-partitionColumnValue`:
+
+```bash
+bin/pinot-admin.sh LaunchBackfillIngestionJob \
+    -jobSpecFile /path/to/ingestionJobSpec.yaml \
+    -startDate 2014-01-01 \
+    -endDate 2014-01-02 \
+    -partitionColumn region \
+    -partitionColumnValue us-east-1
+```
+
+The command computes the partition ID for `us-east-1` using the column's recorded partition function, then keeps only segments whose partition metadata contains that ID. Segments with no `BoundedColumnValue` partition metadata, or those covering more than one partition, are skipped.

--- a/tutorials/data-ingestion/batch-data-ingestion-in-practice.md
+++ b/tutorials/data-ingestion/batch-data-ingestion-in-practice.md
@@ -573,6 +573,23 @@ hadoop jar  \
         -jobSpecFile ${PINOT_DISTRIBUTION_DIR}/examples/batch/airlineStats/hadoopIngestionJobSpec.yaml
 ```
 
+## Executing a backfill ingestion job
+
+When the backfill input directory for a given date may contain fewer files than the original ingestion, `LaunchDataIngestionJob` cannot fully replace the existing segments — see the [Edge case example](../../build-with-pinot/ingestion/batch-ingestion/backfill-data.md#edge-case-example) in the backfill docs. For that case, use `LaunchBackfillIngestionJob`, which reuses the same `ingestionJobSpec.yaml` and replaces the existing segments in a date range via Pinot's segment-lineage machinery.
+
+```
+bin/pinot-admin.sh LaunchBackfillIngestionJob \
+    -jobSpecFile examples/batch/airlineStats/ingestionJobSpec.yaml \
+    -startDate 2014-01-01 \
+    -endDate 2014-01-02
+```
+
+The `-startDate` (inclusive) and `-endDate` (exclusive) arguments use `yyyy-MM-dd` format and are parsed as UTC day boundaries.
+
+{% hint style="info" %}
+For the full step-by-step workflow, supported options (including `-partitionColumn` / `-partitionColumnValue` for partition-scoped backfills), and OFFLINE-only constraints, see [Backfill Data](../../build-with-pinot/ingestion/batch-ingestion/backfill-data.md#complete-backfill-with-launchbackfillingestionjob).
+{% endhint %}
+
 ## Tuning
 
 You can set Environment Variable: `JAVA_OPTS` to modify:


### PR DESCRIPTION
## Title

docs: document LaunchBackfillIngestionJob for complete backfill (apache/pinot#16890)

## Summary

Documents the new `LaunchBackfillIngestionJob` admin command introduced by [apache/pinot#16890](https://github.com/apache/pinot/pull/16890). This command uses Pinot's segment-lineage machinery to atomically replace the existing segments in a date range with newly generated ones, fixing the long-standing edge case where `LaunchDataIngestionJob` leaves stale segments behind when the backfill input directory has fewer files than the original ingestion (the "Edge case example" already documented on the [Backfill Data](https://docs.pinot.apache.org/build-with-pinot/ingestion/batch-ingestion/backfill-data) page, which previously ended with "backfill will fail").

## Changes

Three pages updated, with [`backfill-data.md`](build-with-pinot/ingestion/batch-ingestion/backfill-data.md) being the primary delivery and the other two acting as discoverability pointers into it:

| File | Change |
|------|--------|
| `build-with-pinot/ingestion/batch-ingestion/backfill-data.md` | New section `### Complete backfill with LaunchBackfillIngestionJob` immediately after the Edge case. Covers the four-step lineage workflow (fetch existing → generate new with `_<currentTimeMs>` postfix → start lineage entry → push & finalize), the CLI invocation, the full option table (with `-startDate` / `-endDate` explicitly tagged as **UTC** `yyyy-MM-dd`), a hint block illustrating the UTC-vs-local-tz off-by-one with an `America/Los_Angeles` example, and a partition-scoped backfill sub-section using `-partitionColumn` / `-partitionColumnValue`. |
| `tutorials/data-ingestion/batch-data-ingestion-in-practice.md` | New `## Executing a backfill ingestion job` section between Hadoop and Tuning. Short, copy-paste-ready CLI example reusing the same `ingestionJobSpec.yaml`, plus a hint block linking to the deep-dive in `backfill-data.md`. |
| `build-with-pinot/ingestion/batch-ingestion.md` | Entry-page bullet "Backfill jobs for historical ranges." now names the tool and links to `backfill-data.md`. |

Total: **3 files, +75 / −1**.

## Related
- Source PR: [apache/pinot#16890 — \[Feature\] Develop LaunchBackfillIngestionJob to support complete backfill](https://github.com/apache/pinot/pull/16890)
- Related issue: [apache/pinot#16889](https://github.com/apache/pinot/issues/16889)
