### PR TITLE
docs: document minion task wait/runtime gauges (apache/pinot#18517)

### DIFF
--- a/basics/components/cluster/minion.md
+++ b/basics/components/cluster/minion.md
@@ -480,7 +480,7 @@ Clicking into this subtask shows more details such as the input task config, pro
 
 ## Task-related metrics
 
-There is a controller job that runs every 5 minutes by default and emits metrics about Minion tasks scheduled in Pinot. The following metrics are emitted for each task type:
+There is a controller job that runs every 5 minutes by default, controlled by `controller.minion.task.metrics.emitter.frequencyPeriod`, and emits metrics about Minion tasks scheduled in Pinot. The following metrics are emitted for each task type:
 
 * _**NumMinionTasksInProgress**_: Number of running tasks
 * _**NumMinionSubtasksRunning**_: Number of running sub-tasks
@@ -488,6 +488,8 @@ There is a controller job that runs every 5 minutes by default and emits metrics
 * _**NumMinionSubtasksError**_: Number of error sub-tasks (completed with an error/exception)
 * _**PercentMinionSubtasksInQueue**_: Percent of sub-tasks in waiting or running states
 * _**PercentMinionSubtasksInError**_: Percent of sub-tasks in error
+* _**MaxSubtaskWaitTimeMs**_: Per-table, per-task-type controller gauge for the longest current wait time across subtasks in `WAITING`. Pinot emits `0` when no subtasks are waiting, so alerts can self-resolve after the queue drains.
+* _**MaxSubtaskRunningTimeMs**_: Per-table, per-task-type controller gauge for the longest current runtime across subtasks in `RUNNING`. Pinot emits `0` when no subtasks are running.
 
 The controller also emits metrics about how tasks are cron scheduled:
 

--- a/operate-pinot/metrics-and-monitoring.md
+++ b/operate-pinot/metrics-and-monitoring.md
@@ -164,6 +164,8 @@ The controller manages cluster metadata, segment assignments, and periodic maint
 | `HEALTHCHECK_BAD_CALLS` | Meter | Failed health check requests. | > 0 sustained |
 | `TABLE_STORAGE_QUOTA_UTILIZATION` | Gauge | Percentage of table storage quota in use. | > 85% |
 | `MISSING_CONSUMING_SEGMENT_TOTAL_COUNT` | Gauge | Partitions with missing consuming segments. | > 0 |
+| `MAX_SUBTASK_WAIT_TIME_MS` | Gauge | Maximum current wait time, in milliseconds, across `WAITING` minion subtasks for a table and task type. The controller rewrites the gauge every emit cycle and resets it to `0` when the queue drains. | Above your table-specific queue SLA |
+| `MAX_SUBTASK_RUNNING_TIME_MS` | Gauge | Maximum current runtime, in milliseconds, across `RUNNING` minion subtasks for a table and task type. The controller rewrites the gauge every emit cycle and resets it to `0` when no subtasks are running. | Above your table-specific runtime SLA |
 
 ### Controller Diagnosis Patterns
 
@@ -199,6 +201,8 @@ The controller manages cluster metadata, segment assignments, and periodic maint
 ## Minion Metrics
 
 Minions run background tasks such as segment compaction, purge, and merge. These metrics help track task health.
+
+For table-specific queue alerts, prefer the controller gauges `MAX_SUBTASK_WAIT_TIME_MS` and `MAX_SUBTASK_RUNNING_TIME_MS` listed above. They are emitted per table and task type and self-resolve to `0` after the queue clears.
 
 | Metric | Type | Description | Alert Threshold |
 |--------|------|-------------|-----------------|

--- a/reference/configuration-reference/controller.md
+++ b/reference/configuration-reference/controller.md
@@ -234,11 +234,11 @@ Currently, table rebalance triggered by user runs at best effort. It could fail 
 
 ### TaskMetricsEmitter
 
-This task periodically emits metrics about minion tasks, including task counts by state (RUNNING, WAITING, ERROR, COMPLETED) and task latencies. These metrics are useful for monitoring the health and throughput of the minion task system.
+This task periodically emits controller metrics about minion tasks, including task counts by state. It also publishes the per-table, per-task-type gauges `MAX_SUBTASK_WAIT_TIME_MS` and `MAX_SUBTASK_RUNNING_TIME_MS`. Pinot rewrites both gauges every emit cycle and sets them to `0` when no matching subtasks are in `WAITING` or `RUNNING`, so alerts based on these gauges self-resolve after the queue drains.
 
 | Config | Default Value |
 | --- | --- |
-| controller.task.metrics.emitter.frequencyPeriod | 5m |
+| controller.minion.task.metrics.emitter.frequencyPeriod | 5m |
 
 ### ResourceUtilizationChecker
 

--- a/reference/configuration-reference/monitoring-metrics.md
+++ b/reference/configuration-reference/monitoring-metrics.md
@@ -196,6 +196,8 @@ Pinot provides metrics out of the box so that you can monitor every aspect of pe
 | CONTROLLER_PERIODIC_TASK_ERROR | Number of Periodic tasks that failed due to error |  |
 | NUMBER_TIMES_SCHEDULE_TASKS_CALLED | Minion tasks schedule request sent to controller |  |
 | NUMBER_TASKS_SUBMITTED | Number of minion tasks submitted to the controller. |  |
+| MAX_SUBTASK_WAIT_TIME_MS | Per-table, per-task-type gauge for the maximum current wait time in milliseconds across subtasks in `WAITING`. The controller emits `0` when no subtasks are waiting. | Gauge |
+| MAX_SUBTASK_RUNNING_TIME_MS | Per-table, per-task-type gauge for the maximum current runtime in milliseconds across subtasks in `RUNNING`. The controller emits `0` when no subtasks are running. | Gauge |
 | NUMBER_SEGMENT_UPLOAD_TIMEOUT_EXCEEDED | Number of segments uploads failed due to timeout. Segments are re-uploaded in this case by controller itself. |  |
 | CRON_SCHEDULER_JOB_TRIGGERED | Number of minion tasks triggered that use cron |  |
 | NUMBER_ADHOC_TASKS_SUBMITTED | Number of minion ad hoc tasks submitted |  |


### PR DESCRIPTION
## Summary
- document the controller-side minion task gauges `MAX_SUBTASK_WAIT_TIME_MS` and `MAX_SUBTASK_RUNNING_TIME_MS` as per-table, per-task-type metrics that reset to `0` when queues clear
- correct the TaskMetricsEmitter config key to `controller.minion.task.metrics.emitter.frequencyPeriod`
- update the monitoring guide/reference so minion queue alerting points at the new self-resolving gauges

## Reader impact
- operators get the correct config key and metric names for minion wait-time and runtime alerting
- the docs now explain why these controller gauges clear automatically after waiting or running subtasks disappear

## Structure
- updated the Minion component page, controller config reference, monitoring guide, and monitoring metrics reference
- no navigation or URL changes

## Source cross-check
- verified metric names and scope against `pinot/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java`
- verified emission/reset behavior against `pinot/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/TaskMetricsEmitter.java`
- verified the config key against `pinot/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java`

## Validation
- `git diff --check`
- `rg -n "controller.minion.task.metrics.emitter.frequencyPeriod|MAX_SUBTASK_WAIT_TIME_MS|MAX_SUBTASK_RUNNING_TIME_MS"` across the local `pinot` source and edited docs files