### PR TITLE
docs: clarify RAW shared dictionary index configs

### DIFF
--- a/build-with-pinot/indexing/dictionary-index.md
+++ b/build-with-pinot/indexing/dictionary-index.md
@@ -19,11 +19,11 @@ In Pinot, dictionaries serve as both an index and actual encoding. Consequently,
 | Index                                       | Conditional               | Description                                                         |
 | ------------------------------------------- | ------------------------- | ------------------------------------------------------------------- |
 | [forward](forward-index.md)                 |                           | Implementation depends on whether the dictionary is enabled or not. |
-| [range](range-index.md)                     |                           | Implementation depends on whether the dictionary is enabled or not. |
-| [inverted](inverted-index.md)               |                           | Uses dictionary IDs. Pinot can materialize a standalone dictionary for RAW columns when the index is enabled. |
+| [range](range-index.md)                     |                           | Uses dictionary IDs when a dictionary is enabled, or raw values for numeric RAW columns without a dictionary. RAW + dictionary range indexes must use range index version 2. |
+| [inverted](inverted-index.md)               |                           | Uses dictionary IDs. Pinot can materialize a standalone dictionary for RAW columns when the dictionary is not disabled by legacy config. |
 | [json](json-index.md)                       | when `optimizeDictionary` | Disables dictionary.                                                |
 | [text](text-search-support.md)              | when `optimizeDictionary` | Disables dictionary.                                                |
-| FST                                         |                           | Uses dictionary values. Pinot can materialize a standalone dictionary for RAW STRING columns when FST is enabled. |
+| FST and IFST                                |                           | Use dictionary values. Pinot can materialize a standalone dictionary for RAW STRING columns when the dictionary is not disabled by legacy config. |
 | [H3 (or geospatial)](geospatial-support.md) |                           | Incompatible with dictionary.                                       |
 
 ## Configuration
@@ -70,9 +70,43 @@ Alternatively, the `encodingType` property can be changed. For example:
 
 You may choose the option you prefer, but it's essential to maintain consistency, as Pinot will reject table configurations where the same column and index are defined in different locations.
 
-Even when a column keeps a RAW forward index, Pinot may still materialize a standalone dictionary when another enabled
-index needs dictionary IDs or dictionary values. This lets a RAW column back features such as bitmap inverted indexes
-or FST/IFST without changing the forward-index encoding.
+Even when a column keeps a RAW forward index, Pinot may still materialize a standalone dictionary when another enabled index needs dictionary IDs or dictionary values. This lets a RAW column back features such as bitmap inverted indexes or FST/IFST without changing the forward-index encoding.
+
+For table config updates, prefer an explicit dictionary entry in `fieldConfigList`:
+
+{% code title="RAW forward index with standalone dictionary" %}
+```json
+{
+  "fieldConfigList": [
+    {
+      "name": "myColumn",
+      "encodingType": "RAW",
+      "indexes": {
+        "dictionary": {},
+        "inverted": {}
+      }
+    }
+  ]
+}
+```
+{% endcode %}
+
+A field-level `encodingType: RAW` configuration can also leave the dictionary enabled when an index configured on that same `FieldConfig` requires a dictionary. Legacy no-dictionary settings are different: `tableIndexConfig.noDictionaryColumns` and `tableIndexConfig.noDictionaryConfig` still disable the dictionary before secondary-index validation runs.
+
+The following legacy shape is rejected when a dictionary-backed secondary index is enabled on the same column:
+
+{% code title="Rejected legacy no-dictionary shape" %}
+```json
+{
+  "tableIndexConfig": {
+    "noDictionaryColumns": ["myColumn"],
+    "invertedIndexColumns": ["myColumn"]
+  }
+}
+```
+{% endcode %}
+
+To migrate that table, remove the column from the legacy no-dictionary config, keep `encodingType: RAW`, and add `indexes.dictionary` plus the secondary index in `fieldConfigList`.
 
 ### Heuristically enable dictionaries
 

--- a/build-with-pinot/indexing/forward-index.md
+++ b/build-with-pinot/indexing/forward-index.md
@@ -16,12 +16,12 @@ The `DICTIONARY` encoding can be even more efficient if the segment is sorted by
 
 When working out whether a column should use dictionary encoded or raw value encoding, the following comparison table may help:
 
-| Dictionary                                                                  | Raw Value                                                                             |
-| --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
-| Provides compression when low to medium cardinality.                        | Eliminates padding overhead                                                           |
-| Allows for indexing (esp inv index).                                        | No inv index (only JSON/Text/FST index)                                               |
-| Adds one level of dereferencing, so can increase disk seeks                 | Eliminates additional dereferencing, so good when all docs of interest are contiguous |
-| For Strings, adds padding to make all values equal length in the dictionary | Chunk de-compression overhead with docs selected don't have spatial locality          |
+| Dictionary                                                                  | Raw Value                                                                                                           |
+| --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| Provides compression when low to medium cardinality.                        | Eliminates padding overhead                                                                                         |
+| Serves dictionary-backed indexes directly, such as inverted and FST/IFST.   | Can keep the forward index RAW while a standalone dictionary serves dictionary-backed secondary indexes.             |
+| Adds one level of dereferencing, so can increase disk seeks                 | Eliminates additional dereferencing, so good when all docs of interest are contiguous                               |
+| For Strings, adds padding to make all values equal length in the dictionary | Chunk de-compression overhead with docs selected don't have spatial locality                                        |
 
 ### Dictionary-encoded forward index with bit compression (default)
 
@@ -116,18 +116,15 @@ The raw value forward index stores actual values instead of IDs. This means that
 
 As shown in the diagram below, dictionary encoding can lead to numerous random memory accesses for dictionary lookups. In contrast, the raw value forward index allows for sequential value scanning, which can enhance query performance when applied appropriately.
 
-Note: A RAW forward index can still be paired with secondary indexes that need dictionary IDs. When you enable a
-dictionary-backed index such as bitmap inverted index or FST/IFST on a RAW column, Pinot keeps the forward index RAW
-and materializes a standalone dictionary for the secondary index. Since reading a value from this index requires
-reading the entire chunk in memory and decompressing, it is not suitable for heavy random reads.&#x20;
+Note: A RAW forward index can still be paired with secondary indexes that need dictionary IDs or dictionary values. When you enable a dictionary-backed index such as bitmap inverted index or FST/IFST on a RAW column, Pinot keeps the forward index RAW and materializes a standalone dictionary for the secondary index. For existing table config updates, remove the column from legacy `tableIndexConfig.noDictionaryColumns` or `tableIndexConfig.noDictionaryConfig` and declare the dictionary under `fieldConfigList.indexes.dictionary`; otherwise validation still treats the dictionary as disabled. Since reading a value from the RAW forward index requires reading the entire chunk in memory and decompressing, it is not suitable for heavy random reads.&#x20;
 
 **Sorted raw columns:** As of Pinot 1.3.0, raw columns can now be configured as sorted columns without forcing an inverted index. Previously, configuring a column as both sorted and no-dictionary would cause Pinot to force-add an inverted index, which negated the storage benefits of raw encoding. Now, you can have a time-sorted raw column (e.g., a timestamp column) without dictionary encoding or inverted index, allowing for efficient storage while maintaining sort order metadata.
 
 ![](../../.gitbook/assets/no-dictionary.png)
 
-The raw format is applied when the dictionary is disabled for a column and the encoding is explicitly set to `RAW`. For more details, refer to the [dictionary documentation](dictionary-index.md) and the [field config list](../../reference/configuration-reference/table.md#field-config-list).
+The RAW forward-index encoding is selected by setting `encodingType` to `RAW`. If the dictionary is disabled, the column is a traditional no-dictionary RAW column. If a dictionary is enabled explicitly, or retained because a secondary index needs it, Pinot stores RAW forward values alongside a standalone dictionary. For more details, refer to the [dictionary documentation](dictionary-index.md) and the [field config list](../../reference/configuration-reference/table.md#field-config-list).
 
-**Note:** Both configurations must be enabled together for the raw format to take effect. Setting only the `encodingType` to `RAW` in the field config is not sufficient.
+**Note:** Do not combine legacy no-dictionary config with dictionary-backed secondary indexes on the same RAW column. `noDictionaryColumns` and `noDictionaryConfig` still disable the dictionary and cause validation to reject indexes that require dictionary IDs or dictionary values.
 
 When using the raw format, you can configure the following parameters:
 
@@ -199,6 +196,31 @@ The recommended way to configure the forward index using raw format is by includ
           "compressionCodec": "PASS_THROUGH", // or "SNAPPY", "ZSTANDARD", "LZ4" or "GZIP"
           "deriveNumDocsPerChunk": false,
           "rawIndexWriterVersion": 4
+        }
+      }
+    },
+    ...
+  ],
+...
+}
+```
+{% endcode %}
+
+To keep the forward index RAW while also enabling a dictionary-backed secondary index, declare both the dictionary and the secondary index in `fieldConfigList`:
+
+{% code title="RAW forward index with standalone dictionary" %}
+```javascript
+{
+  "tableName": "somePinotTable",
+  "fieldConfigList": [
+    {
+      "name": "playerID",
+      "encodingType": "RAW",
+      "indexes": {
+        "dictionary": {},
+        "inverted": {},
+        "forward": {
+          "compressionCodec": "LZ4"
         }
       }
     },

--- a/build-with-pinot/indexing/fst-index.md
+++ b/build-with-pinot/indexing/fst-index.md
@@ -11,8 +11,8 @@ Use an FST index when your queries use `LIKE` or `REGEXP_LIKE` predicates on str
 
 - STRING columns only
 - Must be single-valued
-- Must have dictionary values available. This can come from a dictionary-encoded forward index, or Pinot can
-  materialize a standalone dictionary while keeping the forward index RAW.
+- Must have dictionary values available. This can come from a dictionary-encoded forward index, or from a standalone
+  dictionary paired with a RAW forward index.
 
 ## Limitations
 
@@ -45,9 +45,26 @@ To enable the FST index on a column:
 ```
 {% endcode %}
 
-The FST index generates one index file (`.lucene.fst`). If you keep the forward index RAW, Pinot materializes a
-standalone dictionary for the FST automatically. If an inverted index is also enabled on the column, FST can take
-advantage of it for faster lookups.
+The FST index generates one index file (`.lucene.fst`). If you keep the forward index RAW, declare a dictionary for the column so Pinot can build the FST from dictionary values:
+
+{% code title="RAW forward index with FST" %}
+```json
+{
+  "fieldConfigList": [
+    {
+      "name": "text_col_1",
+      "encodingType": "RAW",
+      "indexTypes": ["FST"],
+      "indexes": {
+        "dictionary": {}
+      }
+    }
+  ]
+}
+```
+{% endcode %}
+
+Do not keep the column in legacy `tableIndexConfig.noDictionaryColumns` or `tableIndexConfig.noDictionaryConfig` when enabling FST or IFST. Those settings disable the dictionary and Pinot rejects the table config. If an inverted index is also enabled on the column, FST can take advantage of it for faster lookups.
 
 ## Query examples
 

--- a/build-with-pinot/indexing/inverted-index.md
+++ b/build-with-pinot/indexing/inverted-index.md
@@ -42,9 +42,28 @@ The recommended way to enable a bitmap inverted index:
 ```
 {% endcode %}
 
-If the column uses a RAW forward index, you do not need to add a separate dictionary configuration just to make the
-bitmap inverted index work. Pinot keeps the forward index RAW and materializes a standalone dictionary for the
-inverted index automatically.
+Bitmap inverted indexes require dictionary IDs. If you want the column's forward index to stay RAW, configure the RAW forward index and the standalone dictionary together in `fieldConfigList`:
+
+{% code title="RAW forward index with bitmap inverted index" %}
+```json
+{
+  "fieldConfigList": [
+    {
+      "name": "playerName",
+      "encodingType": "RAW",
+      "indexes": {
+        "dictionary": {},
+        "inverted": {}
+      }
+    }
+  ]
+}
+```
+{% endcode %}
+
+Pinot keeps the forward index RAW and uses the standalone dictionary for the inverted index. A field-level RAW config can also resolve with dictionary enabled when the field-level index requires it and no legacy no-dictionary setting overrides it, but the explicit `dictionary` block is the safe migration form for existing table configs.
+
+Do not keep the column in legacy `tableIndexConfig.noDictionaryColumns` or `tableIndexConfig.noDictionaryConfig` while enabling an inverted index. Those settings still disable the dictionary, so Pinot rejects the table config instead of building a shared dictionary.
 
 <details>
 
@@ -117,7 +136,8 @@ LIMIT 10
 ## Limitations
 
 - Bitmap inverted indexes require dictionary IDs, but Pinot can satisfy that either with a dictionary-encoded forward
-  index or with a standalone dictionary materialized for a RAW forward index.
+  index or with a standalone dictionary materialized for a RAW forward index. Legacy no-dictionary config must not
+  disable the dictionary for that column.
 - Sorted inverted indexes (on dictionary-encoded columns) only work on columns whose data is physically sorted within each segment.
 - Sorted raw columns (no-dictionary) also support sort metadata without requiring an inverted index.
 - MAP columns are not supported.

--- a/build-with-pinot/indexing/range-index.md
+++ b/build-with-pinot/indexing/range-index.md
@@ -22,8 +22,8 @@ A range index is a variant of an [inverted index](inverted-index.md). Instead of
 
 Range index is supported on:
 
-- Dictionary-encoded columns of any data type (INT, LONG, FLOAT, DOUBLE, STRING, BIG_DECIMAL, BYTES, BOOLEAN, TIMESTAMP).
-- Raw-encoded columns of numeric types (INT, LONG, FLOAT, DOUBLE, BIG_DECIMAL).
+- Dictionary-enabled columns of any data type except MAP (INT, LONG, FLOAT, DOUBLE, STRING, BIG_DECIMAL, BYTES, BOOLEAN, TIMESTAMP). The dictionary can be paired with either a dictionary-encoded forward index or a RAW forward index with a standalone dictionary.
+- Raw-encoded columns without a dictionary for numeric types (INT, LONG, FLOAT, DOUBLE, BIG_DECIMAL).
 
 {% hint style="info" %}
 A range index can also be used on a dictionary-encoded time column using `STRING` type, because Pinot only supports datetime formats that are in lexicographical order.
@@ -66,6 +66,29 @@ You can also specify the range index version (default is `2`):
 }
 ```
 {% endcode %}
+
+If the column keeps a RAW forward index but also needs a dictionary for the range index, configure the standalone dictionary explicitly and use range index version `2`:
+
+{% code title="RAW forward index with dictionary-backed range index" %}
+```json
+{
+  "fieldConfigList": [
+    {
+      "name": "eventDate",
+      "encodingType": "RAW",
+      "indexes": {
+        "dictionary": {},
+        "range": {
+          "version": 2
+        }
+      }
+    }
+  ]
+}
+```
+{% endcode %}
+
+Range index version `1` is rejected for the combination of RAW forward index plus dictionary, because version `1` can fall back to scans that compare raw forward values with dictionary-ID evaluators. Version `2` uses the BitSliced range index and is the required form for RAW + dictionary.
 
 <details>
 
@@ -115,3 +138,4 @@ ORDER BY avgHits DESC
 
 - The range index does not support MAP columns.
 - When the forward index is disabled for a column, the column must be single-valued and use range index version 2 for range queries to work.
+- Numeric RAW columns can use a range index without a dictionary. Non-numeric RAW columns need a dictionary, and RAW + dictionary range indexes must use version 2.

--- a/operate-pinot/upgrade-notes.md
+++ b/operate-pinot/upgrade-notes.md
@@ -88,8 +88,20 @@ define:
 Pinot uses these hooks during segment creation and reload to decide whether it
 must materialize a shared standalone dictionary for RAW forward-index columns
 and whether existing index files can be reused safely. Built-in inverted, FST,
-and IFST indexes require a dictionary; the built-in range index works with or
-without a dictionary but must be rebuilt when dictionary state changes.
+and IFST indexes require a dictionary. The built-in range index can still work
+without a dictionary for numeric RAW columns, but any RAW forward index with a
+dictionary-backed range index must use range index version 2; range index
+version 1 is rejected for RAW + dictionary.
+
+[PR #17269](https://github.com/apache/pinot/pull/17269) adds the related column
+shape where a RAW forward index can share a standalone dictionary with
+dictionary-backed secondary indexes. Existing configs that combine legacy
+`tableIndexConfig.noDictionaryColumns` or `tableIndexConfig.noDictionaryConfig`
+with dictionary-backed secondary indexes still need a config migration before
+validation succeeds. Move the column to `fieldConfigList`, keep
+`encodingType: RAW`, remove the legacy no-dictionary entry, and declare
+`indexes.dictionary` with the secondary index, for example `indexes.inverted`,
+`indexTypes: ["FST"]`, or `indexTypes: ["IFST"]`.
 
 **Action required for custom index authors.** Recompile any external
 `IndexType` plugin against Pinot 1.6.0 and implement both methods before

--- a/reference/configuration-reference/table.md
+++ b/reference/configuration-reference/table.md
@@ -201,6 +201,25 @@ Specify the columns and the type of indices to be created on those columns.
 | timestampConfig | An object that defines the granularities used in [timestamp](../../build-with-pinot/indexing/timestamp-index.md) indexes                                        |
 | properties      | JSON of key-value pairs containing additional properties associated with the index.                                                                |
 
+When `encodingType` is `RAW`, the forward index stores raw values. The column can still have a dictionary if another field-level index requires dictionary IDs or dictionary values. For config updates, make that dictionary explicit in `indexes.dictionary` and keep the column out of legacy `tableIndexConfig.noDictionaryColumns` and `tableIndexConfig.noDictionaryConfig`; those legacy settings still disable the dictionary and can cause validation to reject dictionary-backed secondary indexes such as inverted, FST, or IFST.
+
+Example RAW forward index with a standalone dictionary:
+
+```json
+{
+  "fieldConfigList": [
+    {
+      "name": "myColumn",
+      "encodingType": "RAW",
+      "indexes": {
+        "dictionary": {},
+        "inverted": {}
+      }
+    }
+  ]
+}
+```
+
 #### Deprecated configuration options
 
 There are several deprecated configuration options in Pinot that are still supported but recommended for migration to newer ways of configuration. Here's a summary of these options:


### PR DESCRIPTION
## Summary

- Clarify the Apache Pinot #17269 docs contract for RAW forward indexes with shared standalone dictionaries.
- Add valid `fieldConfigList` examples for RAW forward + dictionary-backed inverted, FST/IFST, and range indexes.
- Call out the rejected legacy `noDictionaryColumns` / `noDictionaryConfig` shape and the required migration path.
- Document that RAW + dictionary-backed range indexes must use range index version 2.

## User manual

When a column should keep a RAW forward index but also use a dictionary-backed secondary index, configure the column in `fieldConfigList`, keep `encodingType: RAW`, and declare `indexes.dictionary` with the secondary index.

Do not keep that column in legacy `tableIndexConfig.noDictionaryColumns` or `tableIndexConfig.noDictionaryConfig`. Those settings still disable the dictionary and Pinot rejects dictionary-backed secondary indexes such as inverted, FST, and IFST.

For range indexes, numeric RAW columns can still use a range index without a dictionary. If the RAW column has a standalone dictionary and a range index, use range index version 2.

## Sample table config

```json
{
  "fieldConfigList": [
    {
      "name": "myColumn",
      "encodingType": "RAW",
      "indexes": {
        "dictionary": {},
        "inverted": {},
        "forward": {
          "compressionCodec": "LZ4"
        }
      }
    }
  ]
}
```

Sample query served by the dictionary-backed inverted index while the forward index remains RAW:

```sql
SELECT COUNT(*)
FROM myTable
WHERE myColumn = 'some-value';
```

## Validation

- `git diff --check`
- `python3 scripts/validate-docs.py`

The docs validator passes; it reports existing warning-only broken-anchor warnings unrelated to this change.
