### PR TITLE
docs: document TimeFieldSpec REST rejection

### DIFF
--- a/build-with-pinot/data-modeling/schema.md
+++ b/build-with-pinot/data-modeling/schema.md
@@ -23,6 +23,8 @@ Use column names that are stable and business-facing. Prefer simple types that m
 
 For time columns, keep one primary time field in mind for retention and hybrid-table boundary behavior. For null handling, decide early whether the table needs column-based or table-based semantics.
 
+For new schemas, model time columns with `dateTimeFieldSpecs` only. Pinot's REST schema submission paths now reject the deprecated `TimeFieldSpec` (`fieldType=TIME`) and require `DateTimeFieldSpec` instead. Legacy schemas that are already stored in the cluster can still load internally for backward compatibility.
+
 ## Example schema
 
 ```json

--- a/developers/plugin-architecture/write-custom-plugins/record-reader.md
+++ b/developers/plugin-architecture/write-custom-plugins/record-reader.md
@@ -28,7 +28,7 @@ There are several contracts for record readers that developers should follow whe
   * All the columns in the schema should be preserved (if column does not exist in the original record, put default value instead)
   * Columns not in the schema should not be included
   * Values for the column should follow the field spec from the schema (data type, single-valued/multi-valued)
-* For the time column (refer to [TimeFieldSpec](https://github.com/apache/pinot/blob/master/pinot-spi/src/main/java/org/apache/pinot/spi/data/TimeFieldSpec.java)), record reader should be able to read both incoming and outgoing time (we allow _incoming time - time value from the original data_ to _outgoing time - time value stored in Pinot_ conversion during index creation).
+* For the time column (usually defined with [DateTimeFieldSpec](https://github.com/apache/pinot/blob/master/pinot-spi/src/main/java/org/apache/pinot/spi/data/DateTimeFieldSpec.java); legacy schemas may still deserialize `TimeFieldSpec`), record reader should be able to read both incoming and outgoing time (we allow _incoming time - time value from the original data_ to _outgoing time - time value stored in Pinot_ conversion during index creation).
   * If incoming and outgoing time column name are the same, use incoming time field spec
   * If incoming and outgoing time column name are different, put both of them as time field spec
   * We keep both incoming and outgoing time column to handle cases where the input file contains time values that are already converted

--- a/operate-pinot/upgrade-notes.md
+++ b/operate-pinot/upgrade-notes.md
@@ -17,6 +17,29 @@ recommended component upgrade order, see
 
 ## Upcoming Release
 
+### REST schema APIs now reject deprecated `TimeFieldSpec`
+
+Apache Pinot now formally deprecates `TimeFieldSpec` and rejects schema payloads
+that use `fieldType=TIME` on the controller REST validation paths:
+
+- `POST /schemas`
+- `PUT /schemas/{schemaName}`
+- `/schemas/validate`
+
+Use `DateTimeFieldSpec` through `dateTimeFieldSpecs` for all new or updated
+schemas submitted through the controller. Pinot still allows older schemas that
+already exist in cluster metadata to load internally for backward compatibility,
+so the change affects submission and validation, not startup of existing legacy
+tables.
+
+**Action required.** Audit any schema-generation tooling, CI validation, or
+operator runbooks that still emit `TimeFieldSpec`, and migrate them to
+`DateTimeFieldSpec` before upgrading. If you maintain a record reader or other
+schema-aware plugin, treat `DateTimeFieldSpec` as the default contract and keep
+legacy `TimeFieldSpec` handling only where backward compatibility requires it.
+
+*Source: [PR #18502](https://github.com/apache/pinot/pull/18502)*
+
 ### Removal of deprecated PinotTaskManager scheduleTasks wrapper methods
 
 The following `@Deprecated(forRemoval = true)` wrapper methods in `PinotTaskManager` have been removed. These methods were deprecated since v1.4.0 (Feb 2025):

--- a/reference/configuration-reference/schema.md
+++ b/reference/configuration-reference/schema.md
@@ -28,7 +28,7 @@ Use a schema to define the column names, data types, null-handling behavior, and
 | `enableColumnBasedNullHandling` | 1.1.0 | `false` | When `true`, enables column-based null handling. When `false`, Pinot uses table-based null handling. See [Null value support](../../build-with-pinot/querying-and-sql/null-value-support.md). |
 | `dimensionFieldSpecs` | - | `[]` | Dimension-column definitions. See [DimensionFieldSpecs](#dimensionfieldspecs). |
 | `metricFieldSpecs` | - | `[]` | Metric-column definitions. See [MetricFieldSpecs](#metricfieldspecs). |
-| `dateTimeFieldSpecs` | - | `[]` | Time-column definitions. A schema can define multiple time columns. See [DateTimeFieldSpecs](#datetimefieldspecs). |
+| `dateTimeFieldSpecs` | - | `[]` | Time-column definitions. A schema can define multiple time columns. New schema submissions must use `dateTimeFieldSpecs`; controller REST validation rejects the deprecated `TimeFieldSpec` (`fieldType=TIME`). See [DateTimeFieldSpecs](#datetimefieldspecs). |
 | `complexFieldSpecs` | - | `[]` | Complex-column definitions. Pinot currently supports `MAP` and `OPEN_STRUCT` through this section. See [ComplexFieldSpecs](#complexfieldspecs). |
 
 ## Example Schema
@@ -198,6 +198,8 @@ Define one metric field spec for each metric column.
 ## DateTimeFieldSpecs
 
 Use date-time field specs to define time columns.
+
+Pinot accepts legacy `TimeFieldSpec` objects when loading older schemas that are already stored in the cluster, but controller REST schema submission paths (`POST /schemas`, `PUT /schemas/{schemaName}`, and `/schemas/validate`) now reject new payloads that use `fieldType=TIME`. Use `DateTimeFieldSpec` for all new schema work.
 
 | Property | Description |
 | --- | --- |


### PR DESCRIPTION
## Summary
- document that controller REST schema submission paths now reject deprecated `TimeFieldSpec` payloads
- update schema modeling and schema reference docs to point readers to `dateTimeFieldSpecs`
- refresh the record-reader plugin guidance and add an upgrade note for operators

## Cross-check
- verified the merged Apache Pinot behavior against `apache/pinot#18502`, using the merged `SchemaUtils` and schema REST tests as the source of truth
- documented only the shipped REST-validation change; did not describe the unmerged checker text from the PR description

## Validation
- `git diff --check`
