### PR TITLE
docs: document pluggable MV DDL handlers

### DIFF
--- a/build-with-pinot/querying-and-sql/materialized-views.md
+++ b/build-with-pinot/querying-and-sql/materialized-views.md
@@ -24,6 +24,8 @@ Transparent materialized-view rewrite is available for eligible Single-Stage Eng
 - The MV time column must be a `TIMESTAMP` `dateTimeFieldSpec`.
 - Supported MV aggregations in `definedSQL` today are `SUM`, `COUNT`, `MIN`, `MAX`, `DISTINCTCOUNTRAWHLL`, `DISTINCTCOUNTRAWHLLPLUS`, and `DISTINCTCOUNTRAWTHETASKETCH`.
 
+These limits describe the built-in OSS materialized-view path. Pinot registers a default `MaterializedViewDdlHandler` that still validates a single-source SSE definition and still routes the table under `MaterializedViewTask`. Downstream distributions can replace that handler at controller startup to target a different engine or task type, but that is an extension point rather than a change to the default OSS behavior.
+
 Pinot also validates the expression that produces the MV time column. The supported shapes today are a direct `TIMESTAMP` passthrough or a `DATETRUNC(...)` whose unit matches `bucketTimePeriod`.
 
 ## Before you create one
@@ -45,6 +47,8 @@ The controller accepts these MV statements:
 - `DROP MATERIALIZED VIEW [IF EXISTS] [db.]name`
 
 If you omit the column list, Pinot infers the MV schema from the `SELECT` projection. If you provide a column list, declare every projected column and alias every computed expression or aggregation so it matches the destination column name.
+
+Schema inference is part of the built-in single-source handler. A custom handler can require an explicit column list instead.
 
 The DDL needs at least these properties:
 
@@ -94,6 +98,8 @@ POST /tasks/schedule?taskType=MaterializedViewTask&tableName=<mvTable>_OFFLINE
 ## When to keep using JSON APIs
 
 The existing `POST /schemas`, `POST /tables`, and `PUT /tables/{tableName}` APIs still work for materialized views. Keep using them when your automation already depends on raw Pinot metadata payloads, or when you need a hand-written `MaterializedViewTask` cron that cannot be expressed as `REFRESH EVERY <N> MINUTES|HOURS|DAYS` or `'<N>m|h|d'`.
+
+If you are building a downstream extension that needs a different MV task type or query-engine contract, see [Plugins](../../developers/plugin-architecture/README.md). Custom `MaterializedViewDdlHandler` implementations own that alternate task wiring and any engine-specific validation.
 
 ## Enable transparent rewrite for SSE queries
 

--- a/developers/plugin-architecture/README.md
+++ b/developers/plugin-architecture/README.md
@@ -134,6 +134,22 @@ Initialization is one-time. `PinotRuleSet.defaultInstance()` builds the broker p
 
 This SPI is more upgrade-sensitive than the stable ingestion, filesystem, and metrics plugin families. Pinot keeps `Phase` append-only for binary compatibility, but new phases can be added and the built-in rule ordering can change between releases. Revalidate customizers on every Pinot upgrade, especially if they depend on a specific built-in rule name or order.
 
+### Materialized view DDL handlers
+
+Controller-managed `CREATE MATERIALIZED VIEW ... AS <query>` also has an advanced extension point. Implement `org.apache.pinot.sql.ddl.compile.MaterializedViewDdlHandler` from `pinot-sql-ddl` when a downstream distribution needs a different materialized-view engine contract than the built-in single-source `MaterializedViewTask` path.
+
+The handler owns three decisions:
+
+- `validateDefinedQuery(...)` decides whether the `AS <query>` shape is valid for the target engine.
+- `supportsSchemaInference(...)` decides whether Pinot may infer MV columns from the `SELECT` projection when the DDL omits an explicit column list.
+- `applyTaskConfig(...)` routes the MV properties onto the `TableConfigBuilder` and returns the task type stamped onto the table.
+
+Register the handler once at controller startup through `DdlCompiler.setMaterializedViewDdlHandler(...)`. If no handler is registered, Pinot keeps the default behavior: JOINs are rejected, schema inference is allowed for the single-source path, and the MV runs under `MaterializedViewTask`.
+
+If a custom handler stamps a task type other than the built-in `MaterializedViewTask`, it also owns that task type's runtime contract. In practice that means the custom task generator/executor, its validation rules, and any definition-metadata persistence or consistency tracking required by that alternate MV implementation.
+
+For the default OSS materialized-view surface, see [Materialized Views](../../build-with-pinot/querying-and-sql/materialized-views.md).
+
 Custom segment or index extensions that depend on `pinot-segment-spi` are a
 separate, more upgrade-sensitive path than the stable plugin families listed
 above. Revalidate these extensions on every Pinot upgrade. For example, Pinot


### PR DESCRIPTION
## Summary
- document that the built-in OSS materialized-view path is still the single-source `MaterializedViewTask` flow by default
- add plugin-architecture guidance for the new `MaterializedViewDdlHandler` extension point
- clarify that custom handlers can require explicit MV column lists and own alternate task/runtime wiring

## Cross-check
- verified the merged Apache Pinot behavior against `apache/pinot#18639`, including `MaterializedViewDdlHandler`, `DdlCompiler`, and the default built-in behavior

## Validation
- `git diff --check`
