### PR TITLE
docs: add controller periodic cron examples

### DIFF
--- a/basics/components/cluster/controller.md
+++ b/basics/components/cluster/controller.md
@@ -23,7 +23,7 @@ For redundancy, there can be multiple instances of Pinot controllers. Pinot expe
 
 ## Running the periodic task manually
 
-The controller runs several periodic tasks in the background, to perform activities such as management and validation. Each periodic task has [its own configuration](../../../reference/configuration-reference/controller.md#periodic-task-configuration) to define either a fixed `frequencyPeriod` or, for supported tasks, a Quartz `cronExpression`. If both are set for a task, Pinot uses the cron schedule. Each task can also be triggered manually if needed. The task runs on the lead controller for each table.
+The controller runs several periodic tasks in the background, to perform activities such as management and validation. Each periodic task has [its own configuration](../../../reference/configuration-reference/controller.md#periodic-task-configuration) to define either a fixed `frequencyPeriod` or, for supported tasks, a Quartz `cronExpression`. If both are set for a task, Pinot uses the cron schedule. See the configuration reference for cron syntax and copyable examples. Each task can also be triggered manually if needed. The task runs on the lead controller for each table.
 
 For period task configuration details, see [Controller configuration reference](../../../reference/configuration-reference/controller.md#periodic-task-configuration).
 

--- a/reference/configuration-reference/controller.md
+++ b/reference/configuration-reference/controller.md
@@ -83,6 +83,33 @@ The following controller periodic tasks can be tuned independently.
 
 When a task documents both `frequencyPeriod` and `cronExpression`, Pinot uses the Quartz `cronExpression` if it is set and falls back to the fixed-delay `frequencyPeriod` otherwise. Invalid cron expressions fail controller startup during periodic-task scheduler initialization. Tasks without a `cronExpression` entry remain fixed-delay only.
 
+### Cron expression examples
+
+Controller periodic-task cron schedules use Quartz syntax, with seconds as the first field: `second minute hour day-of-month month day-of-week [year]`. Use `?` in either the day-of-month or day-of-week field when that field does not constrain the schedule. Pinot evaluates the schedule in the controller JVM's time zone, so keep controller time zones consistent when using wall-clock schedules.
+
+| Schedule | Quartz cron expression |
+| --- | --- |
+| Every 5 minutes | `0 0/5 * * * ?` |
+| Every hour | `0 0 * * * ?` |
+| Every day at 02:30 | `0 30 2 * * ?` |
+| Every Sunday at 03:00 | `0 0 3 ? * SUN` |
+| Weekdays at 01:15 | `0 15 1 ? * MON-FRI` |
+
+Add the cron expression to `controller.conf` under the task-specific key:
+
+```properties
+# Run retention cleanup daily during an off-peak window.
+controller.retention.cronExpression=0 30 2 * * ?
+
+# Run segment relocation weekly on Sunday at 03:00.
+controller.segment.relocator.cronExpression=0 0 3 ? * SUN
+
+# Run realtime segment validation every 15 minutes.
+controller.realtime.segment.validation.cronExpression=0 0/15 * * * ?
+```
+
+Do not include quote characters in a Java properties `controller.conf` value. If the same config is rendered through YAML or another format where spaces are significant, quote the whole cron string in that outer format only. To return a task to fixed-delay scheduling, remove or clear its `*.cronExpression` value and set the corresponding `*.frequencyPeriod`.
+
 ### BrokerResourceValidationManager
 
 This task rebuilds the BrokerResource if the instance set has changed.
@@ -104,24 +131,34 @@ This task removes expired cursor response-store entries from brokers. Cursor exp
 
 ### StaleInstancesCleanupTask
 
-This task periodically cleans up stale Pinot broker/server/minion instances.
+This task periodically cleans up stale Pinot broker/server/minion instances. It is disabled by default.
 
 | Config | Default Value |
 | --- | --- |
-| controller.stale.instances.cleanup.task.frequencyPeriod | 1h |
+| controller.stale.instances.cleanup.task.frequencyPeriod | -1s |
 | controller.stale.instances.cleanup.task.cronExpression | unset |
 | controller.stale.instances.cleanup.task.initialDelaySeconds | between 2m-5m |
 | controller.stale.instances.cleanup.task.minOfflineTimeBeforeDeletionPeriod | 1h |
 
 ### OfflineSegmentIntervalChecker
 
-This task manages the segment ValidationMetrics (missingSegmentCount, offlineSegmentDelayHours, lastPushTimeDelayHours, TotalDocumentCount, NonConsumingPartitionCount, SegmentCount), to ensure that all offline segments are contiguous (no missing segments) and that the offline push delay isn't too high.
+This legacy interval controls how often `OfflineSegmentValidationManager` runs expensive segment-level validation, including missing-segment and offline-push-delay metrics. It does not have its own cron expression; use `controller.offline.segment.validation.cronExpression` to cron-schedule the offline validation task.
 
 | Config | Default Value |
 | --- | --- |
 | controller.offline.segment.interval.checker.frequencyPeriod | 24h |
 | controller.statuschecker.waitForPushTimePeriod | 10m |
 | controller.offlineSegmentIntervalChecker.initialDelayInSeconds | between 2m-5m |
+
+### OfflineSegmentValidationManager
+
+This task validates offline tables and updates offline segment validation metrics. Segment-level validation is throttled by `controller.segment.level.validation.intervalPeriod`; if `controller.offline.segment.interval.checker.frequencyPeriod` is also configured, Pinot uses the lower of the two intervals for segment-level validation.
+
+| Config | Default Value |
+| --- | --- |
+| controller.offline.segment.validation.frequencyPeriod | 1h |
+| controller.offline.segment.validation.cronExpression | unset |
+| controller.segment.level.validation.intervalPeriod | 24h |
 
 ### PinotTaskManager
 
@@ -175,6 +212,27 @@ This task does not fix consumption stalled due to
 When `controller.realtime.segment.partialOfflineReplicaRepairEnabled` is enabled, the controller's periodic validation task automatically resets OFFLINE replicas back to CONSUMING for IN_PROGRESS segments that have a mix of CONSUMING and OFFLINE replicas. This handles cases where a replica's startup fails (for example, due to Kafka consumer initialization errors) while other replicas continue normally. Enable only after verifying that OFFLINE replicas are caused by transient failures rather than persistent errors.
 
 `controller.segment.disaster.recovery.mode` sets the cluster-wide default disaster-recovery policy used by the controller's realtime segment validation task for pauseless ingestion. Supported values are `DEFAULT` and `ALWAYS`, matching the table-level `disasterRecoveryMode` setting in `streamIngestionConfig`. You can set this in `controller.conf`, or update the same key through cluster configs so the controller picks up the new mode without restart.
+
+### RealtimeOffsetAutoResetManager
+
+This task runs offset-auto-reset backfill work for real-time tables when realtime segment offset auto reset is enabled in the table ingestion config.
+
+| Config | Default Value |
+| --- | --- |
+| controller.realtime.offsetAutoReset.backfill.enabled | false |
+| controller.realtime.offsetAutoReset.backfill.frequencyPeriod | 1h |
+| controller.realtime.offsetAutoReset.backfill.cronExpression | unset |
+| controller.realtime.offsetAutoReset.backfill.initialDelayInSeconds | between 2m-5m |
+
+### RealtimeConsumerMonitor
+
+This task fetches consuming-segment information for real-time tables and emits per-partition records-lag and availability-lag controller gauges. It is disabled by default.
+
+| Config | Default Value |
+| --- | --- |
+| controller.realtimeConsumerMonitor.frequencyPeriod | -1s |
+| controller.realtimeConsumerMonitor.cronExpression | unset |
+| controller.realtimeConsumerMonitor.initialDelayInSeconds | between 2m-5m |
 
 ### RetentionManager
 
@@ -240,6 +298,16 @@ Currently, table rebalance triggered by user runs at best effort. It could fail 
 | controller.rebalance.checker.frequencyPeriod | 5m |
 | controller.rebalance.checker.cronExpression | unset |
 | controller.rebalanceChecker.initialDelayInSeconds | between 2m-5m |
+
+### TenantRebalanceChecker
+
+This task checks tenant rebalance jobs that may be stuck after a controller crash or restart and resumes unfinished table-rebalance work.
+
+| Config | Default Value |
+| --- | --- |
+| controller.tenant.rebalance.checker.frequencyPeriod | 5m |
+| controller.tenant.rebalance.checker.cronExpression | unset |
+| controller.tenant.rebalance.checker.initialDelayInSeconds | between 2m-5m |
 
 ### TaskMetricsEmitter
 


### PR DESCRIPTION
## Summary
- add Quartz cron syntax notes and copyable controller.conf examples for controller periodic tasks
- document additional cron-capable controller periodic task configs from apache/pinot#18256
- correct stale instance cleanup as disabled by default while documenting cron usage

## User manual
- Operators can use `reference/configuration-reference/controller.md#cron-expression-examples` to choose Quartz cron expressions for controller periodic tasks.
- Use `*.cronExpression` in `controller.conf`; remove or clear that key to return to `*.frequencyPeriod` fixed-delay scheduling.
- Keep controller JVM time zones consistent when using wall-clock schedules.

## Sample controller config
```properties
controller.retention.cronExpression=0 30 2 * * ?
controller.segment.relocator.cronExpression=0 0 3 ? * SUN
controller.realtime.segment.validation.cronExpression=0 0/15 * * * ?
```

## Validation
- `git diff --check`
- `python3 scripts/validate-docs.py --changed-only=<(printf '%s\\n' basics/components/cluster/controller.md reference/configuration-reference/controller.md)`\n\nFollow-up to #845.