### PR TITLE
docs: document MSE metrics emission modes

### DIFF
--- a/operate-pinot/production-guides/run-multi-stage-engine-in-production.md
+++ b/operate-pinot/production-guides/run-multi-stage-engine-in-production.md
@@ -108,6 +108,18 @@ The broker and server controls protect different parts of the system:
 Changing the broker-side throttle from disabled to enabled, or from enabled to disabled, requires a broker restart to take effect. Updating the limit value while the throttle remains enabled is applied dynamically.
 {% endhint %}
 
+### Metrics emission mode
+
+Use the cluster config `pinot.metrics.mse.mode` to control where Pinot publishes multi-stage engine metrics:
+
+| Value | What Pinot emits |
+| --- | --- |
+| `SERVER` | Existing `pinot.server.mse*` / `pinot.server.multiStage*` metrics only. This is the default for backward compatibility. |
+| `MSE` | New `pinot.mse.*` metrics only. Use this after dashboards and alerts have fully moved to the new namespace. |
+| `DUAL` | Both the legacy `pinot.server.*` series and the new `pinot.mse.*` series. Use this during migration windows. |
+
+Pinot reads this setting when brokers and servers start. Changing the mode requires a restart of those roles. In `MSE` or `DUAL` mode, the new `pinot.mse.*` metrics can surface from whichever JVM ran the multi-stage work, including broker JVMs for broker-owned stages.
+
 ### Mailbox backpressure and gRPC memory bounds
 
 The MSE mailbox layer now exposes sender-side backpressure controls for clusters that hit gRPC direct-memory pressure during wide shuffles or slow-consumer scenarios:

--- a/reference/configuration-reference/cluster.md
+++ b/reference/configuration-reference/cluster.md
@@ -42,6 +42,7 @@ These settings control broker-side query protection, query-console exposure, and
 | pinot.multistage.engine.enabled | true | Enables the multi-stage query engine for the cluster. When set to `false`, all queries use the single-stage engine. |
 | pinot.beta.multistage.engine.max.server.query.threads | -1 | Cluster-wide fallback for multi-stage query concurrency controls. Brokers use this value when `pinot.broker.mse.max.server.query.threads` is not set to a positive number. Servers also use it as the base value for deriving a hard limit when `pinot.server.query.executor.mse.max.execution.threads` is not set to a positive number. |
 | pinot.beta.multistage.engine.max.server.query.threads.hardlimit.factor | 4 | Multiplier used by servers to derive a hard limit for multi-stage executor tasks when no server-local limit is configured. The derived hard limit is `pinot.beta.multistage.engine.max.server.query.threads * pinot.beta.multistage.engine.max.server.query.threads.hardlimit.factor`. If either value is non-positive, server hard limiting is disabled. |
+| pinot.metrics.mse.mode | SERVER | Controls where multi-stage engine metrics are emitted. `SERVER` preserves the existing `pinot.server.mse*` / `pinot.server.multiStage*` series, `MSE` emits only `pinot.mse.*`, and `DUAL` emits both during dashboard migration. Brokers and servers read this at startup, so changing it requires a restart. |
 
 ## Resource Accounting
 


### PR DESCRIPTION
## What changed for readers
- documented the new cluster config `pinot.metrics.mse.mode`
- explained when to use `SERVER`, `DUAL`, and `MSE` during MSE dashboard migration

## Structural changes
- no navigation changes
- updated the cluster config reference and the MSE production guide only

## Cross-check against apache/pinot
- verified `pinot.metrics.mse.mode` and its default in `pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java`
- verified the mode semantics in `pinot-common/src/main/java/org/apache/pinot/common/metrics/MseMetricsMode.java`

## Validation
- `git diff --check`
