### PR TITLE
docs: clarify Java client scheme precedence

### DIFF
--- a/build-with-pinot/connectors-clients-apis/clients/java.md
+++ b/build-with-pinot/connectors-clients-apis/clients/java.md
@@ -288,6 +288,8 @@ properties.setProperty("pinot.java_client.tls.truststore.password", "changeit");
 Connection connection = ConnectionFactory.fromController(properties, "controller.example.com:9000");
 ```
 
+When you customize `JsonAsyncHttpPinotClientTransportFactory` directly, the `scheme` property only overrides the factory when you set `scheme` in `Properties`. If `scheme` is absent, `withConnectionProperties(...)` keeps any scheme you already set on the factory and falls back to `http` only when neither the factory nor the properties specify one.
+
 ## Request Tracing
 
 The Java client (`JsonAsyncHttpPinotClientTransport`) automatically attaches an `X-Correlation-Id` header — a unique UUID per request — to every HTTP query. This ID:


### PR DESCRIPTION
## What changed for readers
- Clarified how the Java client resolves `scheme` when callers preconfigure `JsonAsyncHttpPinotClientTransportFactory`
- Documented that `withConnectionProperties(...)` only overrides the factory scheme when `scheme` is explicitly present in `Properties`

## Structural changes
- Updated the Java client guide only; no navigation or file moves

## Cross-check against apache/pinot
- Verified against `pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/JsonAsyncHttpPinotClientTransportFactory.java`
- Verified the precedence contract with `JsonAsyncHttpPinotClientTransportTest`

## Validation
- `git diff --check`
