### PR TITLE
docs: document server query routing toggle API (apache/pinot#18190)

### DIFF
--- a/operate-pinot/rebalance/rebalance-servers/README.md
+++ b/operate-pinot/rebalance/rebalance-servers/README.md
@@ -74,6 +74,29 @@ When upsizing/downsizing a cluster, you will need to make sure that the host nam
 pinot.set.instance.id.to.hostname=true
 ```
 
+#### Temporarily stop new query routing to a server
+
+Before you retag, replace, or troubleshoot a server, you can stop brokers from routing new queries to that server without disabling the Helix participant.
+
+Use the following API on a server instance:
+
+`PUT /instances/{instanceName}/state?state=QUERIES_DISABLE`
+
+To restore normal routing, call:
+
+`PUT /instances/{instanceName}/state?state=QUERIES_ENABLE`
+
+For example:
+
+```bash
+curl -X PUT "http://localhost:9000/instances/Server_10.1.10.51_7000/state?state=QUERIES_DISABLE" \
+  -H "accept: application/json"
+```
+
+{% hint style="info" %}
+This API only applies to server instances. It sets the server's `queriesDisabled` flag so brokers stop routing new queries to that server, but it does not disable the Helix participant lifecycle. The server remains online and can continue serving queries that were already routed to it.
+{% endhint %}
+
 ### Replication changes
 
 In order to change the replication factor of a table, update the table config as follows:


### PR DESCRIPTION
## Summary
- document the new server query-routing toggle API on the server rebalance guide
- explain that `QUERIES_DISABLE` and `QUERIES_ENABLE` only apply to server instances and stop brokers from routing new queries
- clarify that the API does not disable the Helix participant lifecycle

## Docs structure
- add a small maintenance-focused subsection to `operate-pinot/rebalance/rebalance-servers/README.md`

## Source cross-check
- verified merged behavior in `pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotInstanceRestletResource.java`
- verified merged behavior in `pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java`
- verified merged behavior in `pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/admin/InstanceAdminClient.java`
- checked controller and integration tests covering `QUERIES_DISABLE` / `QUERIES_ENABLE`

## Validation
- `git diff --check`