### PR TITLE
docs: document unsigned CAST targets (apache/pinot#18658)

### DIFF
--- a/build-with-pinot/querying-and-sql/sql-reference.md
+++ b/build-with-pinot/querying-and-sql/sql-reference.md
@@ -478,6 +478,10 @@ SELECT CAST(revenue AS BIGINT) FROM orders
 | `BYTES` | Byte array |
 | `JSON` | JSON value |
 
+Pinot also accepts `TINYINT UNSIGNED`, `SMALLINT UNSIGNED`, and `INTEGER UNSIGNED` as cast targets. These return the
+smallest signed Pinot type that preserves the full range: `TINYINT UNSIGNED` and `SMALLINT UNSIGNED` behave like
+`INTEGER`, while `INTEGER UNSIGNED` behaves like `BIGINT` / `LONG`. `BIGINT UNSIGNED` is not supported.
+
 ```sql
 SELECT CAST(event_time AS TIMESTAMP), CAST(user_id AS VARCHAR)
 FROM events

--- a/functions/type-conversion/README.md
+++ b/functions/type-conversion/README.md
@@ -24,6 +24,11 @@ Converts a value to the specified target type. This is the standard SQL cast syn
 | `BYTES` | `VARBINARY` | Byte array |
 | `BIG_DECIMAL` | `DECIMAL` | Arbitrary-precision decimal |
 
+Pinot also accepts the SQL-standard unsigned integer targets `TINYINT UNSIGNED`, `SMALLINT UNSIGNED`, and
+`INTEGER UNSIGNED`. Because Pinot does not store unsigned integers, these casts return the narrowest signed type that
+preserves the full range: `TINYINT UNSIGNED` and `SMALLINT UNSIGNED` behave like `INT`, while `INTEGER UNSIGNED`
+behaves like `LONG`. `BIGINT UNSIGNED` is not supported; use `BIGINT` or `DECIMAL` instead.
+
 For array-valued casts, Pinot supports `CAST(expr AS DECIMAL ARRAY)` in standard SQL. In the single-stage engine, Pinot also accepts the Pinot-specific target name `BIG_DECIMAL_ARRAY`.
 
 ```sql


### PR DESCRIPTION
## What changed for readers
- document that `CAST(... AS TINYINT UNSIGNED)`, `CAST(... AS SMALLINT UNSIGNED)`, and `CAST(... AS INTEGER UNSIGNED)` are accepted
- clarify that Pinot returns the smallest signed type that preserves the full range and that `BIGINT UNSIGNED` is not supported

## Structural changes
- no navigation or file moves; updated the existing CAST docs in the function reference and SQL reference

## Cross-checked against apache/pinot
- `pinot-common/src/main/java/org/apache/pinot/common/function/scalar/DataTypeConversionFunctions.java`
- `pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RelToPlanNodeConverter.java`
- `pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/PRelToPlanNodeConverter.java`
- `pinot-query-planner/src/test/java/org/apache/pinot/query/QueryCompilationTest.java`

## Validation
- `git diff --check`