### PR TITLE
docs: document JsonIndexReader bitmap contract (apache/pinot#18694)

### DIFF
--- a/developers/plugin-architecture/README.md
+++ b/developers/plugin-architecture/README.md
@@ -170,6 +170,16 @@ above. Revalidate these extensions on every Pinot upgrade. For example, Pinot
 [upgrade notes](../../operate-pinot/upgrade-notes.md) before upgrading custom
 segment/index extensions.
 
+The current `latest` branch also tightens the `JsonIndexReader` contract for
+custom JSON index readers and any code that calls the SPI directly:
+`getMatchingDocIds(...)` now returns `ImmutableRoaringBitmap`, and Pinot treats
+that result as read-only. A custom reader may return a bitmap that is borrowed
+from the index's underlying storage, so callers must not mutate it and should
+copy it with `toMutableRoaringBitmap()` before making in-place changes.
+Existing readers can still return `MutableRoaringBitmap` through the covariant
+override, but custom JSON index extensions should still be revalidated on every
+upgrade.
+
 {% content-ref url="write-custom-plugins/" %}
 [write-custom-plugins](write-custom-plugins/)
 {% endcontent-ref %}

--- a/operate-pinot/upgrade-notes.md
+++ b/operate-pinot/upgrade-notes.md
@@ -130,6 +130,31 @@ validation succeeds. Move the column to `fieldConfigList`, keep
 `IndexType` plugin against Pinot 1.6.0 and implement both methods before
 upgrading. Older binaries will fail with `AbstractMethodError` until updated.
 
+### `JsonIndexReader` now returns a read-only bitmap contract
+
+Apache Pinot also changes the `JsonIndexReader` SPI for custom JSON index
+readers and any code that calls the reader directly. [PR
+#18694](https://github.com/apache/pinot/pull/18694) changes all
+`getMatchingDocIds(...)` overloads to return `ImmutableRoaringBitmap` instead
+of `MutableRoaringBitmap`.
+
+This is a developer-facing compatibility change. Pinot's built-in `JSON_MATCH`
+behavior is unchanged, but direct SPI callers must now treat the returned
+bitmap as read-only. A reader may return a borrowed bitmap backed by the
+index's underlying storage, so the bitmap is only valid while the segment or
+index stays open and must not be mutated in place.
+
+The built-in OSS readers still return a fresh mutable bitmap through a
+covariant override, so custom readers can keep that behavior if they want. The
+important contract change is on the caller side:
+
+- Use `ImmutableRoaringBitmap` in code that stores the return value from
+  `getMatchingDocIds(...)`.
+- Call `toMutableRoaringBitmap()` first if your code needs to mutate the
+  bitmap.
+- Revalidate any custom JSON index reader, filter operator, or other
+  `pinot-segment-spi` integration that depends on this API before upgrading.
+
 ### `extractRawTimeValues` replaces Avro `enableLogicalTypes`
 
 Apache Pinot 1.6.0 changes the ingestion config for Avro logical types and


### PR DESCRIPTION
## What changed for readers
- document that `JsonIndexReader#getMatchingDocIds(...)` now returns a read-only `ImmutableRoaringBitmap` contract
- tell custom JSON index readers and direct SPI callers when to copy with `toMutableRoaringBitmap()`
- call out the upgrade-sensitive impact in both plugin architecture guidance and upgrade notes

## Structural changes
- updated the standing extension guidance in `developers/plugin-architecture/README.md`
- added an actionable upcoming-release note in `operate-pinot/upgrade-notes.md`

## Cross-check against apache/pinot
- verified the merged source in `pinot-segment-spi/.../JsonIndexReader.java`
- verified the caller behavior in `pinot-core/.../JsonMatchFilterOperator.java`
- confirmed the merged upstream change in `apache/pinot#18694`

## Validation
- `git diff --check`
