### PR TITLE
docs: clarify transform intermediate columns (apache/pinot#18721)

### DIFF
--- a/build-with-pinot/ingestion/ingestion-level-transformations.md
+++ b/build-with-pinot/ingestion/ingestion-level-transformations.md
@@ -393,6 +393,35 @@ We can apply one transformation to extract the `userId` and then another one to 
 }
 ```
 
+Pinot validates these chains by dependency, not by list order. A transform can consume a column produced by another transform even if the consumer appears earlier in `transformConfigs`, as long as the dependency graph is valid.
+
+{% hint style="info" %}
+Intermediate transform outputs do not need schema columns when they are only consumed by later transforms. Final outputs that Pinot stores or aggregates still need schema columns.
+
+For example, the following pattern is valid even when `message_obj` is not in the schema:
+
+```json
+"ingestionConfig": {
+  "transformConfigs": [
+    {
+      "columnName": "message_obj",
+      "transformFunction": "JSONEXTRACTOBJECT(message)"
+    },
+    {
+      "columnName": "level",
+      "transformFunction": "JSONPATHSTRING(message_obj, '$.level', null)"
+    },
+    {
+      "columnName": "msg_time",
+      "transformFunction": "JSONPATHSTRING(message_obj, '$.time', null)"
+    }
+  ]
+}
+```
+
+In this example, `message_obj` is an intermediate column, so Pinot materializes it during transformation and drops it before indexing. The leaf columns such as `level` and `msg_time` are the stored outputs, so those columns still belong in the schema.
+{% endhint %}
+
 ### Flattening
 
 There are 2 kinds of flattening:


### PR DESCRIPTION
## Summary
- document that transform chains are validated by dependency, not list order
- explain that intermediate transform outputs can stay out of the schema when only later transforms consume them
- add a concrete chained-transform example using an intermediate JSON object column

## Source cross-check
- `pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java`
- `pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java`

## Validation
- `git diff --check`
