### PR TITLE
docs: refresh Pinot admin client examples (apache/pinot#18755)

### DIFF
--- a/build-with-pinot/connectors-clients-apis/flink-connector.md
+++ b/build-with-pinot/connectors-clients-apis/flink-connector.md
@@ -44,7 +44,8 @@ The Pinot Flink Connector provides a `PinotSink` that plugs into any Flink strea
 
 Replace `${pinot.version}` with your Pinot release version. Check [Apache Pinot releases](https://pinot.apache.org/download/) for the latest stable version.
 
-The artifact is published to the Apache Maven repository and transitively includes the Pinot controller client, segment writer, and Flink 2.x core dependencies.
+The artifact is published to the Apache Maven repository and transitively includes the Pinot admin client,
+segment writer, and Flink 2.x core dependencies.
 
 ## Quick Example
 
@@ -54,17 +55,28 @@ execEnv.setParallelism(2);
 
 DataStream<Row> srcRows = execEnv.fromData(...);
 
-HttpClient httpClient = HttpClient.getInstance();
-ControllerRequestClient client = new ControllerRequestClient(
-    ControllerRequestURLBuilder.baseUrl("http://localhost:9000"), httpClient);
+String controllerUrl = "http://localhost:9000";
+URI controllerUri = URI.create(controllerUrl);
+String controllerAddress = controllerUri.getAuthority();
+String controllerPath = controllerUri.getPath();
+if (controllerPath != null && !controllerPath.isEmpty() && !"/".equals(controllerPath)) {
+  controllerAddress += controllerPath.endsWith("/") ? controllerPath.substring(0, controllerPath.length() - 1)
+      : controllerPath;
+}
+Properties properties = new Properties();
+properties.setProperty(PinotAdminTransport.ADMIN_TRANSPORT_SCHEME, controllerUri.getScheme());
 
-Schema schema = PinotConnectionUtils.getSchema(client, "myTable");
-TableConfig tableConfig = PinotConnectionUtils.getTableConfig(client, "myTable", "OFFLINE");
+try (PinotAdminClient adminClient = new PinotAdminClient(controllerAddress, properties)) {
+  Schema schema = adminClient.getSchemaClient().getSchemaObject("myTable");
+  TableConfig tableConfig =
+      adminClient.getTableClient().getTableConfigObjectForType("myTable", TableType.OFFLINE);
 
-srcRows.sinkTo(new PinotSink<>(
-    new FlinkRowGenericRowConverter(typeInfo),
-    tableConfig,
-    schema));
+  srcRows.sinkTo(new PinotSink<>(
+      new FlinkRowGenericRowConverter(typeInfo),
+      tableConfig,
+      schema,
+      controllerUrl));
+}
 execEnv.execute();
 ```
 

--- a/build-with-pinot/ingestion/batch-ingestion/flink.md
+++ b/build-with-pinot/ingestion/batch-ingestion/flink.md
@@ -48,23 +48,37 @@ RowTypeInfo typeInfo = new RowTypeInfo(
 
 DataStream<Row> srcRows = execEnv.fromData(...);
 
-// Create a ControllerRequestClient to fetch Pinot schema and table config
-HttpClient httpClient = HttpClient.getInstance();
-ControllerRequestClient client = new ControllerRequestClient(
-    ControllerRequestURLBuilder.baseUrl(DEFAULT_CONTROLLER_URL), httpClient);
+// Create a PinotAdminClient to fetch Pinot schema and table config
+String controllerUrl = "http://localhost:9000";
+URI controllerUri = URI.create(controllerUrl);
+String controllerAddress = controllerUri.getAuthority();
+String controllerPath = controllerUri.getPath();
+if (controllerPath != null && !controllerPath.isEmpty() && !"/".equals(controllerPath)) {
+  controllerAddress += controllerPath.endsWith("/") ? controllerPath.substring(0, controllerPath.length() - 1)
+      : controllerPath;
+}
+Properties properties = new Properties();
+properties.setProperty(PinotAdminTransport.ADMIN_TRANSPORT_SCHEME, controllerUri.getScheme());
 
-// Fetch Pinot schema
-Schema schema = PinotConnectionUtils.getSchema(client, "starbucksStores");
-// Fetch Pinot table config
-TableConfig tableConfig = PinotConnectionUtils.getTableConfig(client, "starbucksStores", "OFFLINE");
+try (PinotAdminClient client = new PinotAdminClient(controllerAddress, properties)) {
+  // Fetch Pinot schema
+  Schema schema = client.getSchemaClient().getSchemaObject("starbucksStores");
+  // Fetch Pinot table config
+  TableConfig tableConfig =
+      client.getTableClient().getTableConfigObjectForType("starbucksStores", TableType.OFFLINE);
 
-// Create Flink Pinot Sink (Flink 2.x API)
-srcRows.sinkTo(new PinotSink<>(
-    new FlinkRowGenericRowConverter(typeInfo),
-    tableConfig,
-    schema));
+  // Create Flink Pinot Sink (Flink 2.x API)
+  srcRows.sinkTo(new PinotSink<>(
+      new FlinkRowGenericRowConverter(typeInfo),
+      tableConfig,
+      schema,
+      controllerUrl));
+}
 execEnv.execute();
 ```
+
+Passing `controllerUrl` to `PinotSink` lets the sink inject the `push.controllerUri` and default `outputDirURI`
+values it needs for segment upload.
 
 ### Table Configuration
 
@@ -112,16 +126,19 @@ For a complete executable example, refer to [FlinkQuickStart.java](https://githu
 For standard realtime tables without upsert, use the same approach as offline tables, but specify `REALTIME` as the table type:
 
 ```java
-// Same setup as offline table example above...
+// Reuse the PinotAdminClient setup from the offline example above...
 
 // Fetch table config for realtime table
-TableConfig tableConfig = PinotConnectionUtils.getTableConfig(client, "myTable", "REALTIME");
+Schema schema = client.getSchemaClient().getSchemaObject("myTable");
+TableConfig tableConfig =
+    client.getTableClient().getTableConfigObjectForType("myTable", TableType.REALTIME);
 
 // Same sink configuration
 srcRows.sinkTo(new PinotSink<>(
     new FlinkRowGenericRowConverter(typeInfo),
     tableConfig,
-    schema));
+    schema,
+    controllerUrl));
 execEnv.execute();
 ```
 
@@ -150,20 +167,32 @@ RowTypeInfo typeInfo = new RowTypeInfo(
 
 DataStream<Row> srcRows = execEnv.fromData(...);
 
-// Fetch schema and table config (same as offline table example)
-// HttpClient httpClient = HttpClient.getInstance();
-// ControllerRequestClient client = ...
-Schema schema = PinotConnectionUtils.getSchema(client, "myUpsertTable");
-TableConfig tableConfig = PinotConnectionUtils.getTableConfig(client, "myUpsertTable", "REALTIME");
+String controllerUrl = "http://localhost:9000";
+URI controllerUri = URI.create(controllerUrl);
+String controllerAddress = controllerUri.getAuthority();
+String controllerPath = controllerUri.getPath();
+if (controllerPath != null && !controllerPath.isEmpty() && !"/".equals(controllerPath)) {
+  controllerAddress += controllerPath.endsWith("/") ? controllerPath.substring(0, controllerPath.length() - 1)
+      : controllerPath;
+}
+Properties properties = new Properties();
+properties.setProperty(PinotAdminTransport.ADMIN_TRANSPORT_SCHEME, controllerUri.getScheme());
 
-// IMPORTANT: Partition data by primary key using the SAME logic as the stream
-srcRows.partitionCustom(
-    (Partitioner<Integer>) (key, partitions) -> key % partitions,
-    r -> (Integer) r.getField("playerId"))  // Primary key field
-  .sinkTo(new PinotSink<>(
-      new FlinkRowGenericRowConverter(typeInfo),
-      tableConfig,
-      schema));
+try (PinotAdminClient client = new PinotAdminClient(controllerAddress, properties)) {
+  Schema schema = client.getSchemaClient().getSchemaObject("myUpsertTable");
+  TableConfig tableConfig =
+      client.getTableClient().getTableConfigObjectForType("myUpsertTable", TableType.REALTIME);
+
+  // IMPORTANT: Partition data by primary key using the SAME logic as the stream
+  srcRows.partitionCustom(
+      (Partitioner<Integer>) (key, partitions) -> key % partitions,
+      r -> (Integer) r.getField("playerId"))  // Primary key field
+    .sinkTo(new PinotSink<>(
+        new FlinkRowGenericRowConverter(typeInfo),
+        tableConfig,
+        schema,
+        controllerUrl));
+}
 execEnv.execute();
 ```
 


### PR DESCRIPTION
## What changed for readers
- Replaced stale `ControllerRequestClient`-based Flink examples with the current `PinotAdminClient` flow in the two Flink docs pages that still showed the old client.
- Updated the example sink construction to pass `controllerUrl`, matching the current connector quick-start pattern.

## Cross-checked against apache/pinot
- `pinot-connectors/pinot-flink-connector/README.md`
- `pinot-connectors/pinot-flink-connector/src/main/java/org/apache/pinot/connector/flink/FlinkQuickStart.java`
- `pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/admin/PinotAdminClient.java`
- `apache/pinot#18755` merge commit removing `ControllerRequestClient`

## Validation
- `git diff --check`
- Verified the edited Flink docs no longer reference `ControllerRequestClient` or `PinotConnectionUtils`