### PR TITLE
Document OVERLAY string function

### DIFF
--- a/build-with-pinot/querying-and-sql/function-index.md
+++ b/build-with-pinot/querying-and-sql/function-index.md
@@ -103,6 +103,7 @@ For full details, see [String Functions](../../functions/string/).
 | [`SPLITPART`](../../functions/string/splitpart.md) | `SPLITPART(str, delimiter, index)` or `SPLITPART(str, delimiter, limit, index)` | STRING | Returns the selected element after splitting; negative indices count from the end | Both |
 | `SUBSTRINGINDEX` / `SUBSTRING_INDEX` | `SUBSTRINGINDEX(str, delimiter, count)` | STRING | Returns text before the Nth delimiter, or after it when count is negative | Both |
 | `FIRSTLINE` | `FIRSTLINE(str)` | STRING | Returns the first line using `\n`, `\r\n`, or `\r` as delimiters | Both |
+| `OVERLAY` | `OVERLAY(str, replacement, start [, length])` | STRING | SQL-standard overlay semantics with 1-based start positions; omitted `length` defaults to the replacement length | Both |
 | `REPEAT` | `REPEAT(str, times)` | STRING | Repeats string N times | Both |
 | `REGEXPCOUNT` / `REGEXP_COUNT` | `REGEXPCOUNT(str, pattern)` | INT | Counts non-overlapping regex matches | Both |
 | `REGEXPSUBSTR` / `REGEXP_SUBSTR` | `REGEXPSUBSTR(str, pattern)` | STRING | Returns the first regex match, or null if none | Both |

--- a/functions/string/README.md
+++ b/functions/string/README.md
@@ -145,6 +145,16 @@ Returns the rightmost `length` characters from the input string.
 Usage: `rightSubStr(col, length)` or `right(col, length)`\
 Example: `SELECT rightSubStr('hello', 3) FROM myTable` returns `'llo'`
 
+**overlay(str, replacement, start)** / **overlay(str, replacement, start, length)**\
+Implements SQL-standard `OVERLAY` semantics using Pinot function-call syntax. Replaces characters in `str` starting at the 1-based `start` position with `replacement`. When `length` is omitted, Pinot replaces `length(replacement)` characters.
+
+`start` is clamped to the valid range `[1, length(str) + 1]`, so values before the string begin at the first character and values beyond the end append `replacement`. `length = 0` performs insertion without deleting characters, and large `length` values delete only through the end of the string.
+
+Usage: `overlay(str, replacement, start)` or `overlay(str, replacement, start, length)`\
+Example: `SELECT overlay('hello world', 'there', 7) FROM myTable` returns `'hello there'`\
+Example: `SELECT overlay('abcdef', 'XY', 3, 0) FROM myTable` returns `'abXYcdef'`\
+Example: `SELECT overlay('abc', 'XY', 10) FROM myTable` returns `'abcXY'`
+
 **repeat(col, times)** / **repeat(col, separator, times)**\
 Concatenates the input string to itself the specified number of times. When a `separator` is provided, it is placed between each repetition.
 


### PR DESCRIPTION
## Summary
- document the `OVERLAY` string function in the string function reference
- add `OVERLAY` to the SQL function index with its Pinot call syntax
- describe the implementation-backed semantics for 1-based positions, omitted `length`, insertion, append, and clamping behavior

## Source cross-check
- `pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java`
- `pinot-common/src/test/java/org/apache/pinot/common/function/scalar/StringFunctionsTest.java`

## Validation
- `git diff --check`

## Upstream
- apache/pinot#18790
