### PR TITLE
docs: document SSE grouping sets support

### DIFF
--- a/build-with-pinot/querying-and-sql/sql-reference.md
+++ b/build-with-pinot/querying-and-sql/sql-reference.md
@@ -54,6 +54,9 @@ FROM table_reference
 [ OPTION ( key = value [, key = value ]* ) ]
 ```
 
+In the single-stage engine (SSE), the `GROUP BY` clause also accepts grouping constructs such as
+`ROLLUP(...)`, `CUBE(...)`, and `GROUPING SETS (...)`. See [GROUP BY](#group-by) for syntax and limits.
+
 ### Column Expressions
 
 A `select_expression` can be any of the following:
@@ -300,6 +303,67 @@ GROUP BY city
 - Every non-aggregated column in the `SELECT` list must appear in the `GROUP BY` clause.
 - Aggregation functions and non-aggregation columns cannot be mixed in the `SELECT` list without a `GROUP BY`.
 - Aggregate expressions are not allowed inside the `GROUP BY` clause.
+
+### GROUPING SETS, ROLLUP, and CUBE (SSE Only)
+
+Pinot's single-stage engine also supports grouped subtotal queries:
+
+```sql
+SELECT country, city, SUM(revenue) AS total_revenue
+FROM sales
+GROUP BY ROLLUP(country, city)
+```
+
+Use the following forms:
+
+- `GROUP BY ROLLUP(a, b, c)` expands to `GROUPING SETS ((a, b, c), (a, b), (a), ())`
+- `GROUP BY CUBE(a, b, c)` expands to every combination of those grouping columns
+- `GROUP BY GROUPING SETS ((a, b), (a), ())` uses exactly the grouping sets you list
+- `GROUP BY a, ROLLUP(b, c)` is valid; Pinot cross-multiplies plain keys with grouping constructs
+
+`()` represents the grand-total grouping set. Pinot de-duplicates repeated grouping sets, so
+`GROUPING SETS ((a), (a), ())` returns only one `(a)` subtotal.
+
+{% hint style="warning" %}
+`GROUPING SETS`, `ROLLUP`, and `CUBE` currently run only on the single-stage engine. Do not set
+`useMultistageEngine=true` for these queries.
+{% endhint %}
+
+```sql
+SELECT country, city, SUM(revenue) AS total_revenue
+FROM sales
+GROUP BY GROUPING SETS ((country, city), (country), ())
+```
+
+Important limits and caveats:
+
+- Pinot requires at least one aggregation function somewhere in the query (`SELECT`, `HAVING`, or `ORDER BY`)
+- A query can reference at most `31` distinct grouping columns and expand to at most `4096` grouping sets
+- `DISTINCT` is not supported together with `GROUPING SETS`, `ROLLUP`, or `CUBE`
+- Rolled-up columns are returned as real `NULL` values even when null handling is disabled
+- Existing non-grouping-set queries remain wire-compatible during a rolling upgrade, but do not issue grouping-set queries until all servers are upgraded
+
+### GROUPING() and GROUPING_ID() (SSE Only)
+
+Use `GROUPING()` and `GROUPING_ID()` to tell subtotal rows apart from genuine data `NULL`s:
+
+```sql
+SELECT
+  country,
+  city,
+  SUM(revenue) AS total_revenue,
+  GROUPING(country) AS country_rolled_up,
+  GROUPING(city) AS city_rolled_up,
+  GROUPING_ID(country, city) AS grouping_id
+FROM sales
+GROUP BY ROLLUP(country, city)
+ORDER BY GROUPING_ID(country, city)
+```
+
+- `GROUPING(col)` returns `1` when `col` is rolled up in the current row and `0` otherwise
+- `GROUPING_ID(c1, c2, ...)` returns the grouping bitmask, with the first argument as the most significant bit
+- Each argument must also appear in the `GROUP BY` columns for the query
+- Pinot supports these functions in `SELECT`, `HAVING`, and `ORDER BY`
 
 ---
 
@@ -683,6 +747,8 @@ The following table summarizes feature support across the single-stage engine (S
 | Feature | SSE | MSE |
 |---|---|---|
 | SELECT, WHERE, GROUP BY, HAVING, ORDER BY, LIMIT | Yes | Yes |
+| GROUPING SETS / ROLLUP / CUBE | Yes | No |
+| GROUPING() / GROUPING_ID() | Yes | No |
 | DISTINCT | Yes | Yes |
 | Aggregation functions | Yes | Yes |
 | CASE WHEN | Yes | Yes |

--- a/build-with-pinot/querying-and-sql/sse-vs-mse.md
+++ b/build-with-pinot/querying-and-sql/sse-vs-mse.md
@@ -4,7 +4,7 @@ description: Understand the differences between the single-stage engine (SSE) an
 
 # Query Engines (SSE vs MSE)
 
-Pinot ships two supported query engines. The **single-stage engine (SSE)** uses a scatter-gather model and is the default for simple analytic queries. The **multi-stage engine (MSE)** supports distributed joins, window functions, subqueries, and other advanced SQL operations.
+Pinot ships two supported query engines. The **single-stage engine (SSE)** uses a scatter-gather model and is the default for simple analytic queries. The **multi-stage engine (MSE)** supports distributed joins, window functions, subqueries, set operations, and many advanced SQL operations. `GROUPING SETS`, `ROLLUP`, `CUBE`, `GROUPING()`, and `GROUPING_ID()` are a current exception: they run on SSE only.
 
 SSE is the default because it has lower overhead for the most common Pinot workloads; that default does not imply that MSE is experimental. MSE is Pinot's supported engine for queries that require relational operators beyond simple scatter-gather execution.
 
@@ -17,6 +17,7 @@ SSE is the default because it has lower overhead for the most common Pinot workl
 | If your query needs… | Use | Why |
 | --- | --- | --- |
 | Basic filtering, projection, aggregation | SSE | Lowest overhead; simple scatter-gather model |
+| `GROUP BY GROUPING SETS`, `ROLLUP`, `CUBE`, `GROUPING()`, or `GROUPING_ID()` | SSE | These grouping features are currently implemented only in SSE |
 | JOINs | MSE | JOIN support requires the multi-stage engine |
 | Window functions | MSE | Window functions require multi-stage execution |
 | Colocated or partitioned joins | MSE | These are multi-stage patterns |
@@ -33,10 +34,20 @@ The single-stage engine uses a scatter-gather execution model. The broker receiv
 **Choose SSE when:**
 
 - The query is a plain scatter-gather read over one or more tables
+- You need `GROUP BY GROUPING SETS`, `ROLLUP`, `CUBE`, `GROUPING()`, or `GROUPING_ID()`
 - You only need functions available in both engines
 - You want the lowest conceptual and operational overhead
 
 SSE is the default fit for the most common Pinot workloads: filter, project, group, and aggregate.
+
+### Grouping sets on SSE
+
+`GROUPING SETS`, `ROLLUP`, `CUBE`, `GROUPING()`, and `GROUPING_ID()` currently execute only on SSE. Leave
+`useMultistageEngine` unset or set it to `false` for those queries.
+
+During a rolling upgrade, existing queries that do not use grouping sets remain wire-compatible. The new
+grouping-set feature itself should be used only after all servers are upgraded; otherwise Pinot rejects the
+query with an actionable "upgrade all servers" error instead of returning a partial or incorrect result.
 
 ## Multi-stage engine (MSE)
 


### PR DESCRIPTION
## Summary
- document single-stage support for `GROUP BY GROUPING SETS`, `ROLLUP`, `CUBE`, `GROUPING()`, and `GROUPING_ID()`
- add SSE-vs-MSE guidance so readers do not enable `useMultistageEngine` for grouping-set queries
- call out shipped limits and rollout caveats, including the requirement to wait until all servers are upgraded before issuing grouping-set queries

## Cross-checks against apache/pinot
- verified parser expansion and limits in `pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java`
- verified wire-compatibility for plain queries in `pinot-common/src/test/java/org/apache/pinot/sql/parsers/GroupingSetsParserTest.java`
- verified the upgrade guard in `pinot-core/src/main/java/org/apache/pinot/core/query/reduce/ReducerDataSchemaUtils.java` and `pinot-core/src/test/java/org/apache/pinot/core/query/reduce/ReducerDataSchemaUtilsTest.java`
- verified user-facing behavior in `pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/GroupingSetsQueriesTest.java`

## Validation
- `git diff --check`
- lightweight anchor/section checks for the edited markdown files
