### PR TITLE
docs: document realtime ingestion OOM protection

### DIFF
--- a/build-with-pinot/ingestion/upsert-and-dedup/upsert.md
+++ b/build-with-pinot/ingestion/upsert-and-dedup/upsert.md
@@ -1036,6 +1036,16 @@ Putting these together, you can find the table configurations of the quick start
 Pinot server maintains a primary key to record location map across all the segments served in an upsert-enabled table. As a result, when updating the config for an existing upsert table (e.g. change the columns in the primary key, change the comparison column), servers need to be restarted in order to apply the changes and rebuild the map.
 {% endhint %}
 
+### Realtime ingestion OOM protection
+
+Pinot can apply server-side realtime ingestion backpressure when JVM heap usage is high. The default server mode
+`pinot.server.instance.ingestion.oom.protection.mode=DISABLE` leaves the feature off; set it to
+`UPSERT_DEDUP_ONLY` to protect realtime upsert and dedup tables by default, or use
+`ingestionConfig.streamIngestionConfig.oomProtection` to opt an individual table in or out.
+
+For the full configuration keys, defaults, runtime behavior, and metric, see
+[OOM Protection Using Automatic Query Killing](../../../operate-pinot/oom-protection-using-automatic-query-killing.md#realtime-ingestion-oom-protection-on-servers).
+
 ### Parallel consumption during commit, download, and replacement
 
 For partial upsert tables, Pinot can pause the next consuming segment while the previous segment is still being finalized so that replicas do not advance with different merged-row state during commit handling.

--- a/operate-pinot/oom-protection-using-automatic-query-killing.md
+++ b/operate-pinot/oom-protection-using-automatic-query-killing.md
@@ -243,6 +243,83 @@ In critical mode, queries below a certain threshold (expressed as a ratio of tot
 pinot.query.scheduler.accounting.min.memory.footprint.to.kill.ratio=0.025 (default)
 ```
 
+### Realtime Ingestion OOM Protection on Servers
+
+Pinot servers can also apply heap-based backpressure to realtime ingestion. This path is separate from automatic query
+killing: it uses the same JVM heap signal, but instead of selecting a query victim, the server waits before the next
+realtime fetch while heap usage stays above the configured threshold.
+
+**Off by default.** With the default mode `DISABLE`, Pinot does not hold realtime ingestion unless a table explicitly
+opts in.
+
+Set the server-level policy in the server instance config:
+
+```properties
+pinot.server.instance.ingestion.oom.protection.mode=UPSERT_DEDUP_ONLY
+pinot.server.instance.ingestion.oom.protection.heapUsageThrottleThreshold=0.95
+pinot.server.instance.ingestion.oom.protection.heapUsageRecoveryThreshold=0.90
+pinot.server.instance.ingestion.oom.protection.checkIntervalMs=1000
+pinot.server.instance.ingestion.oom.protection.gcIntervalMs=30000
+```
+
+The same full `pinot.server.instance.*` keys can also be set through Pinot cluster config. Cluster config values
+override the server instance config while they are present, and servers reload them at runtime without a restart.
+
+#### Server Modes
+
+| Mode | Effect |
+| --- | --- |
+| `ENABLE` | Protect all realtime tables unless a table sets `oomProtection=DISABLE`. |
+| `UPSERT_DEDUP_ONLY` | Protect only upsert and dedup realtime tables unless a table opts in or out. |
+| `DISABLE` | Leave the server policy off unless a table sets `oomProtection=ENABLE`. |
+
+#### Server Configuration
+
+| Property | Default | Description |
+| --- | --- | --- |
+| `pinot.server.instance.ingestion.oom.protection.mode` | `DISABLE` | Server-wide policy. Valid values are `ENABLE`, `UPSERT_DEDUP_ONLY`, and `DISABLE`. |
+| `pinot.server.instance.ingestion.oom.protection.heapUsageThrottleThreshold` | `0.95` | Heap usage ratio that starts realtime ingestion backpressure. |
+| `pinot.server.instance.ingestion.oom.protection.heapUsageRecoveryThreshold` | `0.90` | Heap usage ratio at or below which ingestion resumes. This value must be lower than `heapUsageThrottleThreshold`. |
+| `pinot.server.instance.ingestion.oom.protection.checkIntervalMs` | `1000` | Wait interval, in milliseconds, between throttle checks while a consuming thread is paused. |
+| `pinot.server.instance.ingestion.oom.protection.gcIntervalMs` | `30000` | Minimum interval, in milliseconds, between explicit JVM GC requests while throttled. Set to `0` or a negative value to disable the explicit GC request. |
+
+#### Table Override
+
+Each realtime table can override the server policy under `ingestionConfig.streamIngestionConfig`:
+
+```json
+{
+  "ingestionConfig": {
+    "streamIngestionConfig": {
+      "oomProtection": "ENABLE"
+    }
+  }
+}
+```
+
+`oomProtection` supports the following values:
+
+* `DEFAULT` (default): Follow the server mode.
+* `ENABLE`: Protect this realtime table even when the server mode is `DISABLE` or would otherwise skip it.
+* `DISABLE`: Skip protection for this realtime table even when the server mode would protect it.
+
+Thresholds remain server-level only and are shared by all enrolled consuming threads on the server.
+
+#### Runtime Behavior
+
+When protection is active for a realtime segment, the server waits before the next stream fetch instead of advancing
+ingestion into higher heap pressure. Pinot rechecks the shared throttle state every `checkIntervalMs` and resumes
+ingestion after heap usage drops to the recovery threshold.
+
+* The protection applies only while a segment is in `INITIAL_CONSUMING`; catch-up paths do not wait on this guard.
+* The throttle is server-local. It does not pause the table through controller APIs, and stream offsets do not advance while Pinot is waiting to fetch the next batch.
+* Pinot uses hysteresis: throttling starts when heap usage is at or above `heapUsageThrottleThreshold` and releases when heap usage drops to `heapUsageRecoveryThreshold` or lower.
+* While throttled, Pinot can request `System.gc()` at most once every `gcIntervalMs`.
+* Pinot rechecks stop and segment-end conditions between waits, so force commits and normal segment rollover still proceed.
+
+Monitor the global server gauge `REALTIME_INGESTION_OOM_PROTECTION_ACTIVE`, which is `1` while the realtime ingestion
+throttle is active and `0` otherwise.
+
 ## Configuration
 
 Here are the configurations that can be commonly applied to server/broker:
@@ -286,6 +363,7 @@ QUERIES_KILLED_SCAN
 QUERIES_KILLED_SCAN_DRY_RUN
 QUERIES_KILLED_SCAN_ERROR
 JVM_HEAP_USED_BYTES
+REALTIME_INGESTION_OOM_PROTECTION_ACTIVE
 HEAP_CRITICAL_LEVEL_EXCEEDED
 HEAP_PANIC_LEVEL_EXCEEDED
 ```


### PR DESCRIPTION
## Summary
- document server-side realtime ingestion OOM protection in the operations guide
- add a short upsert note that points readers to the operations guide for the full configuration surface

## Reader impact
- documents the exact server config keys, defaults, runtime behavior, table override, and metric for the new ingestion OOM protection feature
- makes it clear how `UPSERT_DEDUP_ONLY` interacts with realtime upsert and dedup tables

## Source cross-check
- verified against the merged `apache/pinot` implementation in `CommonConstants`, `StreamIngestionConfig`, `ServerIngestionOomProtectionManager`, `RealtimeSegmentDataManager`, and `ServerGauge`

## Validation
- `git diff --check`
- lightweight link/anchor check for the new upsert-to-operations guide cross-reference
