### PR TITLE
docs: bump current stable version to 1.5.1

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -582,6 +582,7 @@
   * [Environment Provider](reference/plugin-reference/environment-provider.md)
 * [Release notes](reference/release-notes/README.md)
   * [All Releases](reference/releases/README.md)
+    * [1.5.1](reference/releases/1.5.1.md)
     * [1.5.0](reference/releases/1.5.0.md)
     * [1.4.0](reference/releases/1.4.0.md)
     * [1.3.0](reference/releases/1.3.0.md)

--- a/basics/getting-started/install/docker.md
+++ b/basics/getting-started/install/docker.md
@@ -22,7 +22,7 @@ Start a multi-component Pinot cluster using Docker, suitable for local evaluatio
 ### 1. Set the image versions
 
 ```bash
-export PINOT_VERSION=1.5.0
+export PINOT_VERSION=1.5.1
 export PINOT_IMAGE=apachepinot/pinot:${PINOT_VERSION}
 export ZK_IMAGE=zookeeper:3.9.5
 export KAFKA_IMAGE=apache/kafka:4.0.0
@@ -68,7 +68,7 @@ services:
       start_period: 10s
 
   pinot-controller:
-    image: ${PINOT_IMAGE:-apachepinot/pinot:1.5.0}
+    image: ${PINOT_IMAGE:-apachepinot/pinot:1.5.1}
     command: "StartController -zkAddress pinot-zookeeper:2181"
     container_name: "pinot-controller"
     restart: unless-stopped
@@ -89,7 +89,7 @@ services:
       start_period: 10s
 
   pinot-broker:
-    image: ${PINOT_IMAGE:-apachepinot/pinot:1.5.0}
+    image: ${PINOT_IMAGE:-apachepinot/pinot:1.5.1}
     command: "StartBroker -zkAddress pinot-zookeeper:2181"
     container_name: "pinot-broker"
     restart: unless-stopped
@@ -110,7 +110,7 @@ services:
       start_period: 10s
 
   pinot-server:
-    image: ${PINOT_IMAGE:-apachepinot/pinot:1.5.0}
+    image: ${PINOT_IMAGE:-apachepinot/pinot:1.5.1}
     command: "StartServer -zkAddress pinot-zookeeper:2181"
     container_name: "pinot-server"
     restart: unless-stopped
@@ -131,7 +131,7 @@ services:
       start_period: 10s
 
   pinot-minion:
-    image: ${PINOT_IMAGE:-apachepinot/pinot:1.5.0}
+    image: ${PINOT_IMAGE:-apachepinot/pinot:1.5.1}
     command: "StartMinion -zkAddress pinot-zookeeper:2181"
     restart: unless-stopped
     container_name: "pinot-minion"

--- a/basics/getting-started/install/local.md
+++ b/basics/getting-started/install/local.md
@@ -24,7 +24,7 @@ Start a multi-component Pinot cluster directly on your machine without container
 {% tabs %}
 {% tab title="Download release" %}
 ```bash
-export PINOT_VERSION=1.5.0
+export PINOT_VERSION=1.5.1
 
 wget https://downloads.apache.org/pinot/apache-pinot-${PINOT_VERSION}/apache-pinot-${PINOT_VERSION}-bin.tar.gz
 ```

--- a/basics/getting-started/pinot-versions.md
+++ b/basics/getting-started/pinot-versions.md
@@ -9,7 +9,7 @@ description: Current Apache Pinot release version and how to pin versions in exa
 Know which Pinot version to use and how to pin versions in examples.
 
 {% hint style="warning" %}
-All code samples in the **Start Here** guide use `PINOT_VERSION=1.5.0`. If you are using a different version, set the variable accordingly before running any commands.
+All code samples in the **Start Here** guide use `PINOT_VERSION=1.5.1`. If you are using a different version, set the variable accordingly before running any commands.
 {% endhint %}
 
 This page is the single source of truth for version information across the Start Here guide and the wider documentation. When following tutorials or code samples, make sure the version you use matches your installed release.
@@ -18,16 +18,16 @@ This page is the single source of truth for version information across the Start
 
 | Artifact | Version |
 | --- | --- |
-| Apache Pinot binary | **1.5.0** |
-| Docker image | `apachepinot/pinot:1.5.0` |
-| Maven / Gradle clients | `1.5.0` |
+| Apache Pinot binary | **1.5.1** |
+| Docker image | `apachepinot/pinot:1.5.1` |
+| Maven / Gradle clients | `1.5.1` |
 
 ## Using PINOT\_VERSION in examples
 
 Most code samples in these docs set a `PINOT_VERSION` environment variable near the top of each snippet. Always verify that the value matches your installed version:
 
 ```bash
-export PINOT_VERSION=1.5.0
+export PINOT_VERSION=1.5.1
 
 # Then use ${PINOT_VERSION} in commands:
 docker pull apachepinot/pinot:${PINOT_VERSION}

--- a/basics/getting-started/ten-minute-quickstart.md
+++ b/basics/getting-started/ten-minute-quickstart.md
@@ -18,7 +18,7 @@ By the end of this guide you will have a fully functional Apache Pinot cluster r
 **1. Set the Pinot version**
 
 ```bash
-export PINOT_VERSION=1.5.0
+export PINOT_VERSION=1.5.1
 ```
 
 See the [Version reference](pinot-versions.md) page for the current stable release.

--- a/reference/releases/1.5.1.md
+++ b/reference/releases/1.5.1.md
@@ -1,0 +1,30 @@
+---
+description: Release Notes for 1.5.1
+---
+
+# 1.5.1
+
+Apache Pinot 1.5.1 is a **security patch release** based on 1.5.0. It contains only dependency updates and dependency-exclusion changes to resolve reported CVEs — **no functional, API, configuration, or wire-format changes**. A vulnerability scan of the 1.5.1 binary distribution reports **0 critical and 0 high** findings.
+
+## Upgrade notes
+
+Drop-in security update for 1.5.0 — no behavioral changes. Upgrade by replacing the 1.5.0 binary or Docker image with the 1.5.1 equivalent.
+
+## Security fixes
+
+| Dependency | 1.5.0 → 1.5.1 | CVEs addressed |
+| --- | --- | --- |
+| Netty (`netty-bom`) | `4.1.122.Final` → `4.1.134.Final` | CVE-2025-55163, CVE-2025-59419, CVE-2026-33870, CVE-2026-33871, CVE-2026-42579, CVE-2026-42583, CVE-2026-42584, CVE-2026-42587 |
+| Apache Log4j Core | `2.25.3` → `2.26.0` | CVE-2026-34478, CVE-2026-34479, CVE-2026-34480, CVE-2026-34481 |
+| async-http-client | `3.0.7` → `3.0.10` | CVE-2026-45300 |
+| Apache HttpClient 5 | `5.6` → `5.6.1` | CVE-2026-40542 |
+| Apache Pulsar (bundles BouncyCastle) | `4.0.9` → `4.0.10` (bcprov/bcpkix/bcutil → `1.84`) | CVE-2026-5598, CVE-2026-0636, CVE-2026-5588 |
+| commons-configuration2 | `2.13.0` → `2.15.0` | CVE-2026-45205 |
+
+## CVE-2026-2332 (Jetty request smuggling)
+
+The only Jetty in Pinot's distribution was Hadoop's embedded `HttpServer2`, which Pinot never starts. As of 1.5.1 it is excluded from the Hadoop dependencies and stripped from the shaded jars ([#18659](https://github.com/apache/pinot/pull/18659)), so Jetty no longer ships in the distribution at all. Jetty 9.4.x itself is end-of-life with no available patch; removing the unused artifact is the resolution.
+
+## Full changelog
+
+[`release-1.5.0...release-1.5.1`](https://github.com/apache/pinot/compare/release-1.5.0...release-1.5.1)

--- a/reference/releases/README.md
+++ b/reference/releases/README.md
@@ -10,6 +10,12 @@ description: >-
 
 Before upgrading from one version to another one, read the release notes. While the Pinot committers strive to keep releases backward-compatible and introduce new features in a compatible manner, your environment may have a unique combination of configurations/data/schema that may have been somehow overlooked. Before you roll out a new release of Pinot on your cluster, it is best that you run the [compatibility test suite](../../operate-pinot/upgrading-pinot-cluster.md) that Pinot provides. The tests can be easily customized to suit the configurations and tables in your pinot cluster(s). As a good practice, you should build your own test suite, mirroring the table configurations, schema, sample data, and queries that are used in your cluster.
 
+## 1.5.1 (June 2026)
+
+{% content-ref url="1.5.1.md" %}
+[1.5.1.md](1.5.1.md)
+{% endcontent-ref %}
+
 ## 1.5.0 (April 2026)
 
 {% content-ref url="1.5.0.md" %}

--- a/tutorials/data-ingestion/batch-data-ingestion-in-practice.md
+++ b/tutorials/data-ingestion/batch-data-ingestion-in-practice.md
@@ -409,7 +409,7 @@ Or put all the required plugins jars to CLASSPATH, then set `-Dplugins.dir=${CLA
 {% endhint %}
 
 ```
-export PINOT_VERSION=1.5.0 #set to the Pinot version you have installed
+export PINOT_VERSION=1.5.1 #set to the Pinot version you have installed
 export PINOT_DISTRIBUTION_DIR=${PINOT_ROOT_DIR}/build/
 cd ${PINOT_DISTRIBUTION_DIR}
 ${SPARK_HOME}/bin/spark-submit \
@@ -564,7 +564,7 @@ pushJobSpec:
 Ensure parameter `PINOT_ROOT_DIR` and `PINOT_VERSION` are set properly.
 
 ```
-export PINOT_VERSION=1.5.0 #set to the Pinot version you have installed
+export PINOT_VERSION=1.5.1 #set to the Pinot version you have installed
 export PINOT_DISTRIBUTION_DIR=${PINOT_ROOT_DIR}/build/
 export HADOOP_CLIENT_OPTS="-Dplugins.dir=${PINOT_DISTRIBUTION_DIR}/plugins -Dlog4j2.configurationFile=${PINOT_DISTRIBUTION_DIR}/conf/pinot-ingestion-job-log4j2.xml"
 hadoop jar  \

--- a/tutorials/deep-storage/use-s3-and-pinot-in-docker.md
+++ b/tutorials/deep-storage/use-s3-and-pinot-in-docker.md
@@ -92,7 +92,7 @@ docker run --rm -ti \
     --env AWS_ACCESS_KEY_ID=<aws-access-key-id> \
     --env AWS_SECRET_ACCESS_KEY=<aws-secret-access-key> \
     --mount type=bind,source=/tmp/pinot-s3-docker,target=/tmp \
-    apachepinot/pinot:1.5.0 StartController \
+    apachepinot/pinot:1.5.1 StartController \
     -configFileName /tmp/controller.conf
 ```
 
@@ -106,7 +106,7 @@ docker run --rm -ti \
     --network=pinot-demo \
     --env AWS_ACCESS_KEY_ID=<aws-access-key-id> \
     --env AWS_SECRET_ACCESS_KEY=<aws-secret-access-key> \
-    apachepinot/pinot:1.5.0 StartBroker \
+    apachepinot/pinot:1.5.1 StartBroker \
     -zkAddress zookeeper:2181 -clusterName pinot-s3-example-docker
 ```
 
@@ -140,7 +140,7 @@ docker run --rm -ti \
     --env AWS_ACCESS_KEY_ID=<aws-access-key-id> \
     --env AWS_SECRET_ACCESS_KEY=<aws-secret-access-key> \
     --mount type=bind,source=/tmp/pinot-s3-docker,target=/tmp \
-    apachepinot/pinot:1.5.0 StartServer \
+    apachepinot/pinot:1.5.1 StartServer \
     -zkAddress zookeeper:2181 -clusterName pinot-s3-example-docker \
     -configFileName /tmp/server.conf
 ```
@@ -155,7 +155,7 @@ You can also mount your table conf and schema files to the container and run it.
 docker run --rm -ti \
     --name pinot-ingestion-job \
     --network=pinot-demo \
-    apachepinot/pinot:1.5.0 AddTable \
+    apachepinot/pinot:1.5.1 AddTable \
     -controllerHost pinot-controller \
     -controllerPort 9000 \
     -schemaFile examples/batch/airlineStats/airlineStats_schema.json \
@@ -318,7 +318,7 @@ docker run --rm -ti \
     --env AWS_ACCESS_KEY_ID=<aws-access-key-id> \
     --env AWS_SECRET_ACCESS_KEY=<aws-secret-access-key> \
     --mount type=bind,source=/tmp/pinot-s3-docker,target=/tmp \
-    apachepinot/pinot:1.5.0 LaunchDataIngestionJob \
+    apachepinot/pinot:1.5.1 LaunchDataIngestionJob \
     -jobSpecFile /tmp/ingestionJobSpec.yaml
 ```
 

--- a/tutorials/getting-started/dash.md
+++ b/tutorials/getting-started/dash.md
@@ -46,7 +46,7 @@ services:
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
       CLUSTER_ID: MkU3OEVBNTcwNTJENDM2Qk
   pinot-controller:
-    image: apachepinot/pinot:1.5.0
+    image: apachepinot/pinot:1.5.1
     command: "StartController -zkAddress zookeeper-wiki:2181 -dataDir /data"
     container_name: "pinot-controller-wiki"
     volumes:
@@ -58,7 +58,7 @@ services:
     depends_on:
       - zookeeper
   pinot-broker:
-    image: apachepinot/pinot:1.5.0
+    image: apachepinot/pinot:1.5.1
     command: "StartBroker -zkAddress zookeeper-wiki:2181"
     restart: unless-stopped
     container_name: "pinot-broker-wiki"
@@ -69,7 +69,7 @@ services:
     depends_on:
       - pinot-controller
   pinot-server:
-    image: apachepinot/pinot:1.5.0
+    image: apachepinot/pinot:1.5.1
     command: "StartServer -zkAddress zookeeper-wiki:2181"
     restart: unless-stopped
     container_name: "pinot-server-wiki"

--- a/tutorials/getting-started/redash.md
+++ b/tutorials/getting-started/redash.md
@@ -46,7 +46,7 @@ docker run \
   -p 2123:2123 \
   -p 9000:9000 \
   -p 8000:8000 \
-  apachepinot/pinot:1.5.0 QuickStart -type batch
+  apachepinot/pinot:1.5.1 QuickStart -type batch
 ```
 
 ## Run a query in Redash

--- a/tutorials/getting-started/streamlit.md
+++ b/tutorials/getting-started/streamlit.md
@@ -46,7 +46,7 @@ services:
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
       CLUSTER_ID: MkU3OEVBNTcwNTJENDM2Qk
   pinot-controller:
-    image: apachepinot/pinot:1.5.0
+    image: apachepinot/pinot:1.5.1
     command: "StartController -zkAddress zookeeper-wiki:2181 -dataDir /data"
     container_name: "pinot-controller-wiki"
     volumes:
@@ -58,7 +58,7 @@ services:
     depends_on:
       - zookeeper
   pinot-broker:
-    image: apachepinot/pinot:1.5.0
+    image: apachepinot/pinot:1.5.1
     command: "StartBroker -zkAddress zookeeper-wiki:2181"
     restart: unless-stopped
     container_name: "pinot-broker-wiki"
@@ -69,7 +69,7 @@ services:
     depends_on:
       - pinot-controller
   pinot-server:
-    image: apachepinot/pinot:1.5.0
+    image: apachepinot/pinot:1.5.1
     command: "StartServer -zkAddress zookeeper-wiki:2181"
     restart: unless-stopped
     container_name: "pinot-server-wiki"


### PR DESCRIPTION
## Summary

- Bump current stable version from **1.5.0 to 1.5.1** across all tutorial, quickstart, and install examples
- Add release notes page for 1.5.1 (security-only patch: CVE fixes in Netty, Log4j 2, async-http-client, HttpClient5, Pulsar/BouncyCastle, commons-configuration2; Jetty removed from distribution entirely)
- Add 1.5.1 entry to the releases index and SUMMARY.md

Historical references to 1.5.0 (feature availability notes, removal notices, changelog tables) are left unchanged as they describe when features arrived.

## Files changed

| File | Change |
|------|--------|
| `basics/getting-started/pinot-versions.md` | Canonical version table + example snippet |
| `basics/getting-started/install/docker.md` | `PINOT_VERSION` export + docker-compose image tags |
| `basics/getting-started/install/local.md` | `PINOT_VERSION` export |
| `basics/getting-started/ten-minute-quickstart.md` | `PINOT_VERSION` export |
| `tutorials/data-ingestion/batch-data-ingestion-in-practice.md` | `PINOT_VERSION` export |
| `tutorials/deep-storage/use-s3-and-pinot-in-docker.md` | Docker image tags |
| `tutorials/getting-started/dash.md` | Docker image tags |
| `tutorials/getting-started/redash.md` | Docker image tag |
| `tutorials/getting-started/streamlit.md` | Docker image tags |
| `reference/releases/1.5.1.md` | New release notes page |
| `reference/releases/README.md` | Add 1.5.1 entry |
| `SUMMARY.md` | Add 1.5.1 to table of contents |

## Test plan

- [ ] Verify all `apachepinot/pinot:1.5.1` Docker tags exist on Docker Hub
- [ ] Verify Maven artifact `org.apache.pinot:pinot:1.5.1` is published to Maven Central
- [ ] Check GitBook renders the new 1.5.1 release notes page
