### PR TITLE
docs: document startup status timing gauges

### DIFF
--- a/operate-pinot/server-startup-status-checkers.md
+++ b/operate-pinot/server-startup-status-checkers.md
@@ -31,6 +31,17 @@ Pinot will wait up to 10 minutes for all server startup operations to complete. 
 
 Waiting for Ideal State to match External State is not configurable. If `enableServiceStatusCheck=true`, this will always be one of the checks.
 
+## Monitoring Startup Checker Timing
+
+Pinot exposes server-level startup gauges so you can see which checks are still blocking readiness and how long each one took to first report healthy:
+
+* `STARTUP_STATUS_CHECK_IN_PROGRESS` is `1` while startup service-status polling is running and `0` after it finishes.
+* `STARTUP_CURRENT_STATE_MATCH_TIME_MS` records how long it took the ideal-state/current-state check to first report `GOOD`.
+* `STARTUP_EXTERNAL_VIEW_MATCH_TIME_MS` records how long it took the ideal-state/external-view check to first report `GOOD`.
+* `STARTUP_REALTIME_CONSUMPTION_CATCHUP_TIME_MS` records how long it took the realtime catchup check to first report `GOOD` when you use the offset-based or freshness-based checker.
+
+Pinot does not emit `STARTUP_REALTIME_CONSUMPTION_CATCHUP_TIME_MS` for the static wait mode because that path becomes healthy strictly from wall-clock time elapsed, not from observed catchup progress.
+
 ## Static Consumption Wait
 
 The most basic startup check is the static one. It is configured by the following:

--- a/reference/configuration-reference/monitoring-metrics.md
+++ b/reference/configuration-reference/monitoring-metrics.md
@@ -63,8 +63,12 @@ Pinot provides metrics out of the box so that you can monitor every aspect of pe
 | GRPC_TOTAL_USED_DIRECT_MEMORY | Current direct memory allocated by the shaded Netty runtime used by the server gRPC query service and MSE mailbox traffic |  |
 | MAILBOX_CLIENT_USED_DIRECT_MEMORY | Current direct memory pinned by the server's outbound MSE mailbox gRPC clients |  |
 | MAILBOX_CLIENT_USED_HEAP_MEMORY | Current heap memory pinned by the server's outbound MSE mailbox gRPC clients |  |
-| STARTUP_SUCCESS_DURATION_MS | Time spent starting the server when startup finishes in a healthy state |  |
-| STARTUP_FAILURE_DURATION_MS | Time spent starting the server when startup finishes in an unhealthy state |  |
+| STARTUP_STATUS_CHECK_IN_PROGRESS | Global gauge that is `1` while the startup service-status checks are running and `0` after they finish. | Gauge |
+| STARTUP_CURRENT_STATE_MATCH_TIME_MS | Global gauge for the time in milliseconds from startup checker registration until the ideal-state/current-state match check first reports `GOOD`. | Gauge |
+| STARTUP_EXTERNAL_VIEW_MATCH_TIME_MS | Global gauge for the time in milliseconds from startup checker registration until the ideal-state/external-view match check first reports `GOOD`. | Gauge |
+| STARTUP_REALTIME_CONSUMPTION_CATCHUP_TIME_MS | Global gauge for the time in milliseconds from startup checker registration until the realtime consumption catchup check first reports `GOOD`. Pinot emits this gauge only for the offset-based and freshness-based realtime catchup checkers; the static wait path does not set it. | Gauge |
+| STARTUP_SUCCESS_DURATION_MS | Timer for the total time spent starting the server when startup finishes in a healthy state. | Timer |
+| STARTUP_FAILURE_DURATION_MS | Timer for the total time spent starting the server when startup finishes in an unhealthy state. | Timer |
 | EXECUTION_THREAD_CPU_TIME_NS | time spent by all threads processing query and results (doesn't includes time spent in system activities) |  |
 | SYSTEM_ACTIVITIES_CPU_TIME_NS | time spent in nanoseconds processing query on the servers (only counts system acitivities such as GC, OS paging etc.) |  |
 | RESPONSE_SER_CPU_TIME_NS | time spent in nanoseconds serializing query response on servers |  |


### PR DESCRIPTION
## What changed for readers
- documents the new server startup status timing gauges in the monitoring metrics reference
- explains when the realtime catchup timing gauge is emitted in the startup status checker guide

## Structural changes
- updated the metrics inventory in `reference/configuration-reference/monitoring-metrics.md`
- added a short operational note in `operate-pinot/server-startup-status-checkers.md`

## Cross-check against apache/pinot
- verified `apache/pinot#18493` and the merged source in `ServerGauge`, `BaseServerStarter`, and `ServiceStatus`

## Validation
- `git diff --check`
- verified the exact metric names and emission conditions against the merged Pinot source