### PR TITLE
docs: add isPrivateIp function reference

### DIFF
--- a/build-with-pinot/querying-and-sql/function-index.md
+++ b/build-with-pinot/querying-and-sql/function-index.md
@@ -418,6 +418,7 @@ For full details, see [IP Address Functions](../../functions/ip-address/).
 | `IPSUBNETMAX` | `IPSUBNETMAX(prefix)` | STRING | Returns highest IP in subnet | Both |
 | `ISIPV4STRING` | `ISIPV4STRING(ip)` | BOOLEAN | Checks whether the input is a plain IPv4 address string | Both |
 | `ISIPV6STRING` | `ISIPV6STRING(ip)` | BOOLEAN | Checks whether the input is a plain IPv6 address string | Both |
+| `ISPRIVATEIP` / `IS_PRIVATE_IP` | `ISPRIVATEIP(ip)` | BOOLEAN | Checks whether a plain IP address is in Pinot's RFC 1918, loopback, link-local, or IPv6 ULA ranges | Both |
 | `IPFAMILY` / `IP_FAMILY` | `IPFAMILY(ip)` | INT | Returns 4 for IPv4 and 6 for IPv6 | Both |
 | `IPV4TOLONG` | `IPV4TOLONG(ip)` | LONG | Converts an IPv4 string to an unsigned 32-bit long | Both |
 | `LONGTOIPV4` | `LONGTOIPV4(value)` | STRING | Converts an unsigned 32-bit long to IPv4 text | Both |

--- a/functions/ip-address/README.md
+++ b/functions/ip-address/README.md
@@ -88,6 +88,29 @@ SELECT isIPv6String('2001:db8::1') AS valid_v6
 -- Returns true
 ```
 
+## isPrivateIp / is_private_ip
+
+```sql
+isPrivateIp(ipString)
+```
+
+Returns `true` when the input is a plain IPv4 or IPv6 address without a CIDR prefix and it falls into one of these ranges:
+
+- RFC 1918 IPv4: `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`
+- IPv4 loopback: `127.0.0.0/8`
+- IPv4 link-local: `169.254.0.0/16`
+- IPv6 loopback: `::1`
+- IPv6 link-local: `fe80::/10`
+- IPv6 ULA: `fc00::/7`
+
+```sql
+SELECT isPrivateIp(clientIp) AS is_private
+FROM accessLog
+WHERE isPrivateIp(clientIp)
+LIMIT 5
+-- Returns true for addresses such as '10.0.0.1', '127.0.0.1', 'fe80::1', and 'fd00::1'
+```
+
 ## ipFamily / ip_family
 
 ```sql


### PR DESCRIPTION
## What changed for readers
- documents the new `isPrivateIp` / `is_private_ip` scalar function on the IP address reference page
- adds the function to the SQL function index for discoverability

## Structure
- updates the existing IP address function reference only
- updates the existing function index entry only

## Source cross-check
- verified against `apache/pinot` commit `52b8fdcb5d8028f2014feffbc73a358abd804d9d`
- aligned the docs to the merged aliases and the exact shipped private-address ranges

## Validation
- `git diff --check`
- verified the edited docs paths and the function-index link target resolve locally