### PR TITLE
docs: document tenant attribution metric (apache/pinot#18823)

### DIFF
--- a/reference/configuration-reference/controller.md
+++ b/reference/configuration-reference/controller.md
@@ -285,6 +285,8 @@ At most one replica is allowed to be unavailable during rebalance unless you ove
 
 This task manages segment status metrics such as realtimeTableCount, offlineTableCount, disableTableCount, numberOfReplicas, percentOfReplicas, percentOfSegments, idealStateZnodeSize, idealStateZnodeByteSize, segmentCount, segmentsInErrorState, tableCompressedSize.
 
+It also emits the per-table `TABLE_TENANT_INFO` gauge for tenant attribution. Pinot registers one gauge per `(tenantType, tenant)` pair and sets each value to `1`: server tenant, broker tenant, and each tier server tenant derived from the table's tier configs. With the bundled controller JMX exporter config, Prometheus exposes these gauges with `table`, `tableType`, `tenantType`, and `tenant` labels so you can join tenant ownership onto other table-scoped metrics.
+
 | Config | Default Value |
 | --- | --- |
 | controller.statuschecker.frequencyPeriod | 5m |

--- a/reference/configuration-reference/monitoring-metrics.md
+++ b/reference/configuration-reference/monitoring-metrics.md
@@ -209,6 +209,7 @@ Pinot provides metrics out of the box so that you can monitor every aspect of pe
 | LLC_ZOOKEEPER_FETCH_FAILURES | Number of Zookeeper metadata fetch requests failed |  |
 | LLC_ZOOKEEPER_UPDATE_FAILURES | Number of Zookeeper metadata update requests failed |  |
 | LLC_STREAM_DATA_LOSS | Indicates data loss for table either due to offsets available to consume from topic larger than the last stored offset in pinot or segment lost in CONSUMING state |  |
+| TABLE_TENANT_INFO | Per-table controller info gauge for tenant attribution. Pinot emits one gauge with value `1` for each `(tenantType, tenant)` pair attached to a table: the server tenant, the broker tenant, and each tier server tenant. With the bundled controller JMX exporter config, Prometheus exposes `table`, `tableType`, `tenantType`, and `tenant` labels so you can join tenant ownership onto other table-scoped metrics. | Gauge |
 | TABLE_WITHOUT_TABLE_CONFIG_COUNT | Number of tables missing a `TableConfig` when startup enforcement is configured not to exit. |  |
 | TABLE_WITHOUT_SCHEMA_COUNT | Number of tables that have a `TableConfig` but no `Schema` when startup enforcement is configured not to exit. |  |
 | HELIX_ZOOKEEPER_RECONNECTS | Number of times broker instance re-connected to zookeeper. |  |


### PR DESCRIPTION
## What changed for readers
- documents the new controller `TABLE_TENANT_INFO` gauge used for table-to-tenant attribution
- explains which tenant mappings Pinot emits and which Prometheus labels the bundled controller exporter exposes

## Structural changes
- updates `reference/configuration-reference/controller.md`
- updates `reference/configuration-reference/monitoring-metrics.md`

## Source cross-check
- verified against merged apache/pinot source for `SegmentStatusChecker`, `ControllerGauge`, and the bundled controller JMX exporter config in PR #18823

## Validation
- `git diff --check`
- targeted text checks for the new metric references