### PR TITLE
docs: document Prometheus labels for minion subtasks (apache/pinot#18854)

### DIFF
--- a/operate-pinot/metrics-and-monitoring.md
+++ b/operate-pinot/metrics-and-monitoring.md
@@ -204,6 +204,8 @@ Minions run background tasks such as segment compaction, purge, and merge. These
 
 For table-specific queue alerts, prefer the controller gauges `MAX_SUBTASK_WAIT_TIME_MS` and `MAX_SUBTASK_RUNNING_TIME_MS` listed above. They are emitted per table and task type and self-resolve to `0` after the queue clears.
 
+When you scrape controller metrics through the bundled Prometheus JMX exporter config, the per-table minion-subtask gauges also expose `database`, `table`, `tableType`, and `taskType` labels. Use those labels to alert on a specific task type for one table instead of aggregating every minion queue together.
+
 | Metric | Type | Description | Alert Threshold |
 |--------|------|-------------|-----------------|
 | `NUMBER_OF_TASKS` | Gauge | Tasks currently running | Baseline-dependent |

--- a/operate-pinot/monitor-pinot-using-prometheus-and-grafana.md
+++ b/operate-pinot/monitor-pinot-using-prometheus-and-grafana.md
@@ -102,6 +102,8 @@ Then we can query metrics Prometheus scrapped:
 
 ![](../.gitbook/assets/prometheus-query-metrics.png)
 
+The bundled controller exporter config also labels the per-table minion-subtask gauges with `database`, `table`, `tableType`, and `taskType`. That lets you build task-specific panels and alerts for gauges such as `MAX_SUBTASK_WAIT_TIME_MS` and `MAX_SUBTASK_RUNNING_TIME_MS` without hand-maintaining a table-to-task mapping outside Prometheus.
+
 ## Deploy Grafana
 
 Similar to Pinot Helm, we will have Grafana Helm and it's config yaml file:


### PR DESCRIPTION
## What changed for readers
- documents that the bundled controller Prometheus exporter now attaches `database`, `table`, `tableType`, and `taskType` labels to the per-table minion-subtask gauges
- points operators to use those labels for targeted queue dashboards and alerts

## Structural changes
- updates `operate-pinot/metrics-and-monitoring.md`
- updates `operate-pinot/monitor-pinot-using-prometheus-and-grafana.md`

## Source cross-check
- verified against the merged controller JMX exporter config change in apache/pinot PR #18854

## Validation
- `git diff --check`
- targeted text checks for the exported label names and gauge references