### PR TITLE
docs: document table-config env validation (apache/pinot#18851)

### DIFF
--- a/reference/configuration-reference/table.md
+++ b/reference/configuration-reference/table.md
@@ -347,6 +347,8 @@ Pinot allows users to define environment variables in the format of `${ENV_NAME}
 
 Pinot instance will override it during runtime.
 
+When you create or update a table, the controller now validates these placeholders against its own runtime environment before persisting the table config. If a placeholder without a default value cannot be resolved there, Pinot rejects the write instead of saving a config that would later fail on read paths such as realtime segment commit.
+
 {% hint style="warning" %}
 Brackets are required when defining the environment variable.`"$ENV_NAME"`is not supported.
 {% endhint %}


### PR DESCRIPTION
## What changed for readers
- documents that controllers now fail table create/update requests when a table-config placeholder without a default value cannot be resolved in the controller runtime environment
- keeps the existing warning that every Pinot component still needs the same variables for successful reads and ingestion

## Structural changes
- updates only `reference/configuration-reference/table.md`

## Source cross-check
- verified against merged apache/pinot controller validation flow in PR #18851

## Validation
- `git diff --check`
- targeted text checks in `reference/configuration-reference/table.md`