### PR TITLE
Document reload behavior for upsert TTL snapshots

### DIFF
--- a/build-with-pinot/ingestion/upsert-and-dedup/upsert.md
+++ b/build-with-pinot/ingestion/upsert-and-dedup/upsert.md
@@ -581,6 +581,12 @@ The snapshots are taken on every segment commit to ensure that they are consiste
 We recommend that you enable this feature so as to speed up server boot times during restarts.
 
 {% hint style="info" %}
+For upsert tables that use `metadataTTL` or `deletedKeysTTL`, [segment reload](../../../operate-pinot/segment-reload.md) rebuilds upsert metadata from the persisted `validDocIds` snapshot instead of rescanning every row in the immutable segment. This prevents reload from resurrecting keys that TTL expiry or delete handling had already removed from the upsert metadata.
+
+If reload would have to download a different copy of the segment, Pinot fails the reload when the segment CRC changes because the local docId-based snapshot might no longer match the downloaded rows. This applies to `forceDownload=true` reloads and to normal reloads that trigger a CRC-based re-download.
+{% endhint %}
+
+{% hint style="info" %}
 The lifecycle for validDocIds snapshots are shows as follows,
 
 1. If snapshot is enabled, snapshots for existing segments are taken or refreshed when the next consuming segment gets started.


### PR DESCRIPTION
## Summary
- explain that reload on upsert tables with `metadataTTL` or `deletedKeysTTL` reuses the persisted `validDocIds` snapshot instead of rescanning every row
- document that reload fails when it would download a CRC-mismatched immutable segment whose docId-based snapshot may no longer match the downloaded rows

## Structural changes
- add a short source-backed note in `build-with-pinot/ingestion/upsert-and-dedup/upsert.md` under the validDocIds snapshot section

## Cross-check
- verified against apache/pinot merge commit `cd6dd61ce3240efd62c2de851efc685bccd7e79e`
- inspected `BaseTableDataManager.reloadSegment(...)` and `BasePartitionUpsertMetadataManager.replaceSegment(...)`

## Validation
- `git diff --check`
- verified the edited relative link to `operate-pinot/segment-reload.md` resolves locally
