### PR TITLE
Document upsert validDocIds consensus controls

### DIFF
--- a/build-with-pinot/ingestion/upsert-and-dedup/segment-compaction-on-upserts.md
+++ b/build-with-pinot/ingestion/upsert-and-dedup/segment-compaction-on-upserts.md
@@ -26,7 +26,9 @@ To compact segments on upserts, complete the following steps:
       "invalidRecordsThresholdPercent": "30",
       "invalidRecordsThresholdCount": "100000",
       "tableMaxNumTasks": "100",
-      "validDocIdsType": "SNAPSHOT"
+      "validDocIdsType": "SNAPSHOT",
+      "validDocIdsConsensusMode": "EQUAL",
+      "validDocIdsValidationMode": "STRICT"
     }
   }
 }
@@ -41,6 +43,8 @@ To compact segments on upserts, complete the following steps:
   * `SNAPSHOT_WITH_DELETE`: Loads the delete-aware `queryableDocIds` snapshot from the Pinot segment. `upsertConfig.snapshot` must not be `DISABLE`, and `upsertConfig.deleteRecordColumn` must be set.
   * `IN_MEMORY`: Loads the `validDocIds` bitmap from the real-time server's memory.&#x20;
   * `IN_MEMORY_WITH_DELETE`: Loads the delete-aware `queryableDocIds` bitmap from the real-time server's memory. `upsertConfig.deleteRecordColumn` must be set for this type.
+* `validDocIdsConsensusMode` (Optional) Controls how Pinot chooses validDocIds when replicas disagree. `EQUAL` is the default and requires all expected healthy replicas to report matching CRC or data CRC plus the same valid-doc count. `UNSAFE` uses the first healthy replica whose CRC or data CRC matches. `MOST_VALID_DOCS` keeps the strict replica health and CRC checks, then picks the replica with the highest valid-doc count.
+* `validDocIdsValidationMode` (Optional) Controls generator-side validation before Pinot schedules the task. `STRICT` is the default and skips a segment when replica health, CRC or data CRC, or validDocIds consensus checks fail. `EXECUTOR_ONLY` skips those pre-scheduling checks and lets the minion executor enforce the configured `validDocIdsConsensusMode` when the task runs.
 
 {% hint style="warning" %}
 When using the two in-memory types, if the server gets restarted, the upsert view gets back consistent once server re-ingests the data it has ingested before starting. The in-memory bitmaps are updated when server ingests data into consuming segment, even before the consuming segment gets committed. So if server gets restarted whlie still consuming data, the upsert view gets back consistent once it catches up the previously ingested data. Instead, the bitmap snapshots are only taken after committing the segment, thus can be more consistent on server restarts, but is eventually consistent as well if server gets restarted while ingesting data.

--- a/operate-pinot/upsert-compact-merge-task.md
+++ b/operate-pinot/upsert-compact-merge-task.md
@@ -89,6 +89,8 @@ This approach leverages ZooKeeper metadata and snapshot-enabled commit cycles to
 
 **validDocIds snapshot requirement**: The task requires validDocIds to be available from the servers hosting the segments. This depends on `upsertConfig.snapshot` not being set to `DISABLE`.
 
+**Replica validation**: In the default `validDocIdsValidationMode=STRICT`, the controller only schedules a segment when every expected replica is healthy, its CRC or data CRC matches ZooKeeper, and the replicas satisfy the configured `validDocIdsConsensusMode`. `EXECUTOR_ONLY` skips those pre-scheduling checks and leaves enforcement to the executor.
+
 ### Configuration
 
 1. Start a Pinot Minion.
@@ -106,7 +108,9 @@ This approach leverages ZooKeeper metadata and snapshot-enabled commit cycles to
             "maxNumRecordsPerTask": "50000000",
             "maxNumSegmentsPerTask": "10",
             "outputSegmentMaxSize": "200MB",
-            "numSegmentsBatchPerServerRequest": "500"
+            "numSegmentsBatchPerServerRequest": "500",
+            "validDocIdsConsensusMode": "EQUAL",
+            "validDocIdsValidationMode": "STRICT"
         }
     }
 }
@@ -139,6 +143,8 @@ controller.task.frequencyPeriod=1h
 | maxNumSegmentsPerTask            | Maximum number of segments to merge in a single task. Prevents overly large tasks                                                                                                 | 10                                    |
 | outputSegmentMaxSize             | Maximum size of output segments in bytes. When specified, enables size-based segment merging in addition to record-count-based merging. Accepts formats like '200MB', '1GB', etc. | None (size-based disabled by default) |
 | numSegmentsBatchPerServerRequest | Number of segments to query in one batch when fetching validDocIds from servers                                                                                                   | 500                                   |
+| validDocIdsConsensusMode         | Controls how Pinot chooses validDocIds when replicas disagree. `UNSAFE` uses the first healthy replica whose CRC or data CRC matches, `EQUAL` requires all expected healthy replicas to match on CRC or data CRC and valid-doc count, and `MOST_VALID_DOCS` keeps the strict health and CRC checks then picks the replica with the highest valid-doc count. | `EQUAL` |
+| validDocIdsValidationMode        | Controls generator-side validation before task scheduling. `STRICT` skips segments when replica health, CRC or data CRC, or validDocIds consensus checks fail. `EXECUTOR_ONLY` skips those pre-scheduling checks and lets the executor enforce the configured `validDocIdsConsensusMode` when the task runs. | `STRICT` |
 | retentionExpiryBufferPeriod      | **Buffer period to exclude segments nearing retention expiry**. Prevents task generation for segments that are close to being deleted by the RetentionManager, avoiding a race condition where segments may be deleted between task generation (controller) and download (minion). Format: time duration strings like `"1h"`, `"30m"`, `"2d"`. If this buffer is greater than or equal to the table retention, the filter fails open (returns all segments) with a WARN log. | None (no buffer, uses exact retention boundary) |
 
 ### Prerequisites
@@ -202,6 +208,7 @@ Monitor task execution through the following methods:
 * Verify `snapshot` is not set to `DISABLE` in upsert config
 * Check that segments meet the selection criteria (small enough and old enough based on `bufferTimePeriod`)
 * Ensure completed segments exist for the table with validDocIds available
+* With `validDocIdsValidationMode=STRICT`, verify all expected replicas are healthy and report matching CRC or data CRC before the controller schedules the segment
 * Verify table configuration passes validation (upsert enabled, correct table type)
 
 **Segments not being cleaned up**:

--- a/operate-pinot/upsert-compaction-task.md
+++ b/operate-pinot/upsert-compaction-task.md
@@ -15,6 +15,7 @@ The Upsert Compaction Task uses the Minion Task Framework, and therefore consist
 * **UpsertCompactionTaskGenerator**:  Invoked by the Pinot Controller according the specified schedule. It’s `generateTasks` method:
   * Retrieves segment metadata for the table’s completed segments.
   * Retrieves validDocIds from the servers hosting the completed segments.
+  * In the default `validDocIdsValidationMode=STRICT`, only schedules a segment when the expected replicas are healthy, their CRC or data CRC matches ZooKeeper, and they satisfy the configured `validDocIdsConsensusMode`.
   * Processes validDocIds to determine which segments to compact or delete.
   * Generates a task for every completed segment.
 * **UpsertCompactionTaskExecutor**: Invoked by a Pinot Minion.
@@ -37,7 +38,9 @@ The Upsert Compaction Task uses the Minion Task Framework, and therefore consist
             "schedule": "0 */5 * ? * *",
             "bufferTimePeriod": "7d",
             "invalidRecordsThresholdPercent": "30",
-            "invalidRecordsThresholdCount": "100000"
+            "invalidRecordsThresholdCount": "100000",
+            "validDocIdsConsensusMode": "EQUAL",
+            "validDocIdsValidationMode": "STRICT"
         }
     }
 }
@@ -55,6 +58,8 @@ controller.task.frequencyPeriod=1h  #Alternative to "schedule" in task config.
 | bufferTimePeriod | The minimum amount of time that has elapsed since the segment was consuming | 7d |
 | invalidRecordsThresholdPercent             | A limit to the amount of older records allowed in the completed segment represented as a percentage of the total number of records in the segment (i.e. old records / total records). Must be configured if invalidRecordsThresholdCount isn’t configured. | 0       |
 | invalidRecordsThresholdCount | A limit to the amount of older records allowed in the completed segment represented as a record count. Must be configured if invalidRecordsThresholdPercent isn’t configured. | 0 |
+| validDocIdsConsensusMode | Controls how Pinot chooses validDocIds when replicas disagree. `UNSAFE` uses the first healthy replica whose CRC or data CRC matches, `EQUAL` requires all expected healthy replicas to match on CRC or data CRC and valid-doc count, and `MOST_VALID_DOCS` keeps the strict health and CRC checks then picks the replica with the highest valid-doc count. | `EQUAL` |
+| validDocIdsValidationMode | Controls generator-side validation before task scheduling. `STRICT` skips segments when replica health, CRC or data CRC, or validDocIds consensus checks fail. `EXECUTOR_ONLY` skips those pre-scheduling checks and lets the executor enforce the configured `validDocIdsConsensusMode` when the task runs. | `STRICT` |
 
 {% hint style="info" %}
 **Original design doc**: [https://docs.google.com/document/d/1tDFjyun81KiMfAVO-A7ZFL1mGNm1VEkXDcxqOov8aeI/edit?usp=sharing](https://docs.google.com/document/d/1tDFjyun81KiMfAVO-A7ZFL1mGNm1VEkXDcxqOov8aeI/edit?usp=sharing)

--- a/operate-pinot/upsert-merge-compact-task.md
+++ b/operate-pinot/upsert-merge-compact-task.md
@@ -79,6 +79,8 @@ This approach leverages ZooKeeper metadata and snapshot-enabled commit cycles to
 
 **validDocIds snapshot requirement**: The task requires validDocIds to be available from the servers hosting the segments. This depends on `upsertConfig.snapshot` not being set to `DISABLE`.
 
+**Replica validation**: In the default `validDocIdsValidationMode=STRICT`, the controller only schedules a segment when every expected replica is healthy, its CRC or data CRC matches ZooKeeper, and the replicas satisfy the configured `validDocIdsConsensusMode`. `EXECUTOR_ONLY` skips those pre-scheduling checks and leaves enforcement to the executor.
+
 ## Configuration
 
 1. Start a Pinot Minion.
@@ -97,7 +99,9 @@ This approach leverages ZooKeeper metadata and snapshot-enabled commit cycles to
             "maxNumRecordsPerTask": "50000000",
             "maxNumSegmentsPerTask": "10",
             "outputSegmentMaxSize": "200MB",
-            "numSegmentsBatchPerServerRequest": "500"
+            "numSegmentsBatchPerServerRequest": "500",
+            "validDocIdsConsensusMode": "EQUAL",
+            "validDocIdsValidationMode": "STRICT"
         }
     }
 }
@@ -130,6 +134,8 @@ controller.task.frequencyPeriod=1h
 | maxNumSegmentsPerTask | Maximum number of segments to merge in a single task. Prevents overly large tasks | 10 |
 | outputSegmentMaxSize | Maximum size of output segments in bytes. When specified, enables size-based segment merging in addition to record-count-based merging. Accepts formats like '200MB', '1GB', etc. | None (size-based disabled by default) |
 | numSegmentsBatchPerServerRequest | Number of segments to query in one batch when fetching validDocIds from servers | 500 |
+| validDocIdsConsensusMode | Controls how Pinot chooses validDocIds when replicas disagree. `UNSAFE` uses the first healthy replica whose CRC or data CRC matches, `EQUAL` requires all expected healthy replicas to match on CRC or data CRC and valid-doc count, and `MOST_VALID_DOCS` keeps the strict health and CRC checks then picks the replica with the highest valid-doc count. | `EQUAL` |
+| validDocIdsValidationMode | Controls generator-side validation before task scheduling. `STRICT` skips segments when replica health, CRC or data CRC, or validDocIds consensus checks fail. `EXECUTOR_ONLY` skips those pre-scheduling checks and lets the executor enforce the configured `validDocIdsConsensusMode` when the task runs. | `STRICT` |
 
 ## Prerequisites
 
@@ -186,6 +192,7 @@ Monitor task execution through the following methods:
 - Verify `snapshot` is not set to `DISABLE` in upsert config
 - Check that segments meet the selection criteria (small enough and old enough based on `bufferTimePeriod`)
 - Ensure completed segments exist for the table with validDocIds available
+- With `validDocIdsValidationMode=STRICT`, verify all expected replicas are healthy and report matching CRC or data CRC before the controller schedules the segment
 - Verify table configuration passes validation (upsert enabled, correct table type)
 
 **Segments not being cleaned up**:


### PR DESCRIPTION
## What changed for readers
- document the new `validDocIdsConsensusMode` and `validDocIdsValidationMode` task configs for upsert compaction and upsert compact-merge workflows
- explain the default `EQUAL`/`STRICT` behavior and the `UNSAFE`, `MOST_VALID_DOCS`, and `EXECUTOR_ONLY` options where operators configure these tasks
- add a brief troubleshooting note that strict generator validation now skips segments when replica health or CRC consensus is missing

## Structural reorganization
- none; this only updates the existing upsert task pages and the upsert compaction how-to

## Cross-checked against apache/pinot
- merged commit `f0329f33762de8afbe1b2901952c7129d9ca7a85`
- `MinionTaskUtils`, `UpsertCompactionTaskGenerator`, `UpsertCompactionTaskExecutor`, `UpsertCompactMergeTaskGenerator`, and `UpsertCompactMergeTaskExecutor`
- `MinionTaskUtilsTest`, `UpsertCompactionTaskGeneratorTest`, and `UpsertCompactMergeTaskGeneratorTest`

## Validation
- `git diff --check`