### PR TITLE
docs: fix 1.5.1 changelog link

### DIFF
--- a/reference/releases/1.5.1.md
+++ b/reference/releases/1.5.1.md
@@ -27,4 +27,4 @@ The only Jetty in Pinot's distribution was Hadoop's embedded `HttpServer2`, whic
 
 ## Full changelog
 
-[`release-1.5.0...release-1.5.1`](https://github.com/apache/pinot/compare/release-1.5.0...release-1.5.1)
+[`release-1.5.0...release-1.5.1`](https://github.com/apache/pinot/compare/30fdfeea3a533d61d4eaf4c8050f5f4c07493de4...020ff0d0538b2079d4cf4cb2676a191c87c95d4d)


### PR DESCRIPTION
## Summary
- fix the 1.5.1 release-notes changelog URL to use an immutable tag-to-tag compare
- avoid drifting to the moving `release-1.5.1` maintenance branch
- follow up on #880, which updated the release notes but left the compare link ambiguous

## Validation
- git diff --check
- verified the compare URL returns HTTP 200
