### PR TITLE
docs: clarify remote vector index loading

### DIFF
--- a/build-with-pinot/indexing/vector-index.md
+++ b/build-with-pinot/indexing/vector-index.md
@@ -145,6 +145,7 @@ Set `storeInSegmentFile` in the vector index `properties` map to store vector in
 
 - When the flag changes from `false` to `true`, Pinot absorbs the existing vector index into `columns.psf` on the next segment load.
 - When the flag changes from `true` to `false`, Pinot extracts the vector index back to the legacy on-disk layout on the next segment load.
+- When `storeInSegmentFile` is `true`, Pinot can load the vector index directly from `columns.psf` even when the segment directory is non-local or remote-backed, such as tiered storage on S3, so no local legacy sidecar files are required.
 - The query surface does not change. This flag only changes how Pinot stores the segment index bytes.
 
 For HNSW-style configs, add the property under `indexes.vector.properties`. For IVF-style configs, add it to the vector index `properties` map.


### PR DESCRIPTION
## What changed
- clarified that `storeInSegmentFile=true` lets Pinot load vector indexes directly from `columns.psf` even when the segment directory is non-local or remote-backed, such as tiered storage on S3

## Structural changes
- none; this is a targeted clarification in the existing vector index storage section

## Source cross-check
- verified against `apache/pinot#18930` merge commit `b6c3ca686af50988a39e762151dcec3646466744`
- checked `VectorIndexType` and `VectorIndexTypeTest` in the local `apache/pinot` clone

## Validation
- `git diff --check`
