### PR TITLE
docs: clean up stale high-level consumer (HLC) documentation

### DIFF
--- a/build-with-pinot/ingestion/stream-ingestion/confluent-schema-registry-decoders.md
+++ b/build-with-pinot/ingestion/stream-ingestion/confluent-schema-registry-decoders.md
@@ -46,7 +46,6 @@ Decodes Avro-serialized Kafka messages with schema managed by Confluent Schema R
     "streamType": "kafka",
     "stream.kafka.topic.name": "my-avro-topic",
     "stream.kafka.broker.list": "kafka:9092",
-    "stream.kafka.consumer.type": "lowlevel",
     "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka30.KafkaConsumerFactory",
     "stream.kafka.decoder.class.name": "org.apache.pinot.plugin.inputformat.avro.confluent.KafkaConfluentSchemaRegistryAvroMessageDecoder",
     "stream.kafka.decoder.prop.schema.registry.rest.url": "http://schema-registry:8081"
@@ -64,7 +63,6 @@ Decodes JSON messages serialized with Confluent's JSON Schema serializer. Messag
     "streamType": "kafka",
     "stream.kafka.topic.name": "my-json-topic",
     "stream.kafka.broker.list": "kafka:9092",
-    "stream.kafka.consumer.type": "lowlevel",
     "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka30.KafkaConsumerFactory",
     "stream.kafka.decoder.class.name": "org.apache.pinot.plugin.inputformat.json.confluent.KafkaConfluentSchemaRegistryJsonMessageDecoder",
     "stream.kafka.decoder.prop.schema.registry.rest.url": "http://schema-registry:8081"
@@ -86,7 +84,6 @@ Decodes Protocol Buffer messages serialized with Confluent's Protobuf serializer
     "streamType": "kafka",
     "stream.kafka.topic.name": "my-protobuf-topic",
     "stream.kafka.broker.list": "kafka:9092",
-    "stream.kafka.consumer.type": "lowlevel",
     "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka30.KafkaConsumerFactory",
     "stream.kafka.decoder.class.name": "org.apache.pinot.plugin.inputformat.protobuf.KafkaConfluentSchemaRegistryProtoBufMessageDecoder",
     "stream.kafka.decoder.prop.schema.registry.rest.url": "http://schema-registry:8081"

--- a/build-with-pinot/ingestion/stream-ingestion/import-from-apache-kafka.md
+++ b/build-with-pinot/ingestion/stream-ingestion/import-from-apache-kafka.md
@@ -269,7 +269,7 @@ The legacy `kafka-0.9` and `kafka-2.x` connector modules have been removed. If y
 {% endhint %}
 
 {% hint style="info" %}
-Pinot does _**not support**_ using high-level Kafka consumers (HLC). Pinot uses low-level consumers to ensure accurate results, supports operational complexity and scalability, and minimizes storage overhead.
+Pinot does _**not support**_ using high-level Kafka consumers (HLC). Pinot uses low-level (partition-level) consumers to ensure accurate results, reduce operational complexity, scale horizontally, and minimize storage overhead.
 {% endhint %}
 
 #### Migrating from the kafka-2.x connector

--- a/build-with-pinot/ingestion/stream-ingestion/kafka-connector-versions.md
+++ b/build-with-pinot/ingestion/stream-ingestion/kafka-connector-versions.md
@@ -38,7 +38,6 @@ The Kafka 4.0 connector uses the same configuration properties as the Kafka 3.0 
     "streamType": "kafka",
     "stream.kafka.topic.name": "your-topic",
     "stream.kafka.broker.list": "kafka:9092",
-    "stream.kafka.consumer.type": "lowlevel",
     "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka40.KafkaConsumerFactory",
     "stream.kafka.decoder.class.name": "org.apache.pinot.plugin.stream.kafka.KafkaJSONMessageDecoder",
     "realtime.segment.flush.threshold.rows": "0",
@@ -85,7 +84,6 @@ mvn clean install -Pscala-2.12 -DskipTests
     "streamType": "kafka",
     "stream.kafka.topic.name": "your-topic",
     "stream.kafka.broker.list": "kafka:9092",
-    "stream.kafka.consumer.type": "lowlevel",
     "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka30.KafkaConsumerFactory",
     "stream.kafka.decoder.class.name": "org.apache.pinot.plugin.stream.kafka.KafkaJSONMessageDecoder"
   }

--- a/developers/plugin-architecture/write-custom-plugins/write-your-stream.md
+++ b/developers/plugin-architecture/write-custom-plugins/write-your-stream.md
@@ -6,25 +6,9 @@ description: This page describes how to write your own stream ingestion plugin f
 
 You can write custom stream ingestion plugins to add support for your own streaming platforms such as Pravega, Kinesis etc.
 
-Stream Ingestion Plugins can be of two types -
+Pinot consumes each stream partition independently, tracking offsets per partition. A stream you want to integrate must therefore expose per-partition offsets and support consuming from a given offset.
 
-* High Level - Consume data without control over the partitions
-* Low Level - Consume data from each partition with offset management
-
-## Requirements to support Stream Level (High Level) consumers
-
-The stream should provide the following guarantees:
-
-* Exactly once delivery (unless restarting from a checkpoint) for each consumer of the stream.
-* (Optionally) support mechanism to split events (in some arbitrary fashion) so that each event in the stream is delivered exactly to one host out of set of hosts.
-* Provide ways to save a checkpoint for the data consumed so far. If the stream is partitioned, then this checkpoint is a vector of checkpoints for events consumed from individual partitions.
-* The checkpoints should be recorded only when Pinot makes a call to do so.
-* The consumer should be able to start consumption from one of:
-  * latest available data
-  * earliest available data
-  * last saved checkpoint
-
-## Requirements to support Partition Level (Low Level) consumers
+## Requirements to support a stream
 
 While consuming rows at a partition level, the stream should support the following properties:
 
@@ -45,12 +29,9 @@ In addition, we have an operational requirement that the number of partitions sh
 In order to add a new type of stream (say, Foo) implement the following classes:
 
 1. FooConsumerFactory extends [StreamConsumerFactory](https://github.com/apache/pinot/blob/master/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConsumerFactory.java)
-2. FooPartitionLevelConsumer implements [PartitionLevelConsumer](https://github.com/apache/pinot/blob/master/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionLevelConsumer.java)
-3. FooStreamLevelConsumer implements [StreamLevelConsumer](https://github.com/apache/pinot/blob/master/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamLevelConsumer.java)
-4. FooMetadataProvider implements [StreamMetadataProvider](https://github.com/apache/pinot/blob/master/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamMetadataProvider.java)
-5. FooMessageDecoder implements [StreamMessageDecoder](https://github.com/apache/pinot/blob/master/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamMessageDecoder.java)
-
-Depending on stream level or partition level, your implementation needs to include StreamLevelConsumer or PartitionLevelConsumer.
+2. FooPartitionGroupConsumer implements [PartitionGroupConsumer](https://github.com/apache/pinot/blob/master/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionGroupConsumer.java)
+3. FooMetadataProvider implements [StreamMetadataProvider](https://github.com/apache/pinot/blob/master/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamMetadataProvider.java)
+4. FooMessageDecoder implements [StreamMessageDecoder](https://github.com/apache/pinot/blob/master/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamMessageDecoder.java)
 
 The properties for the stream implementation are to be set in the table configuration, inside `streamConfigs` section.
 
@@ -59,7 +40,6 @@ Use the `streamType` property to define the stream type. For example, for the im
 The rest of the configuration properties for your stream should be set with the prefix `"stream.foo"`. Be sure to use the same suffix for: (see examples below):
 
 * topic
-* consumer type
 * stream consumer factory
 * offset
 * decoder class name

--- a/operate-pinot/pauseless-consumption.md
+++ b/operate-pinot/pauseless-consumption.md
@@ -66,7 +66,6 @@ To enable pauseless consumption on a REALTIME table, set `pauselessConsumptionEn
         {
           "stream.kafka.topic.name": "myTopic",
           "stream.kafka.broker.list": "kafka:9092",
-          "stream.kafka.consumer.type": "lowlevel",
           "stream.kafka.decoder.class.name": "org.apache.pinot.plugin.stream.kafka.KafkaJSONMessageDecoder",
           "realtime.segment.flush.threshold.rows": "500000"
         }

--- a/playbooks/cdc-upsert-pipeline.md
+++ b/playbooks/cdc-upsert-pipeline.md
@@ -94,8 +94,7 @@ Use the source table's primary key as Pinot's primary key. Include a comparison 
       "streamType": "kafka",
       "stream.kafka.topic.name": "dbserver1.public.orders",
       "stream.kafka.broker.list": "kafka:9092",
-      "stream.kafka.consumer.type": "lowlevel",
-      "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory",
+      "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka30.KafkaConsumerFactory",
       "stream.kafka.decoder.class.name": "org.apache.pinot.plugin.stream.kafka.KafkaJSONMessageDecoder",
       "realtime.segment.flush.threshold.rows": "100000",
       "realtime.segment.flush.threshold.time": "4h"

--- a/playbooks/hybrid-offline-realtime.md
+++ b/playbooks/hybrid-offline-realtime.md
@@ -95,8 +95,7 @@ The `enrichedSegment` column is filled by the batch job but may be null in real-
       "streamType": "kafka",
       "stream.kafka.topic.name": "web-analytics-events",
       "stream.kafka.broker.list": "kafka:9092",
-      "stream.kafka.consumer.type": "lowlevel",
-      "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory",
+      "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka30.KafkaConsumerFactory",
       "stream.kafka.decoder.class.name": "org.apache.pinot.plugin.stream.kafka.KafkaJSONMessageDecoder",
       "realtime.segment.flush.threshold.rows": "500000",
       "realtime.segment.flush.threshold.time": "6h"

--- a/playbooks/multi-tenant-analytics.md
+++ b/playbooks/multi-tenant-analytics.md
@@ -90,8 +90,7 @@ For customers with strict compliance requirements, create a separate table per t
       "streamType": "kafka",
       "stream.kafka.topic.name": "saas-events",
       "stream.kafka.broker.list": "kafka:9092",
-      "stream.kafka.consumer.type": "lowlevel",
-      "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory",
+      "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka30.KafkaConsumerFactory",
       "stream.kafka.decoder.class.name": "org.apache.pinot.plugin.stream.kafka.KafkaJSONMessageDecoder",
       "realtime.segment.flush.threshold.rows": "500000",
       "realtime.segment.flush.threshold.time": "6h"

--- a/playbooks/real-time-product-analytics.md
+++ b/playbooks/real-time-product-analytics.md
@@ -104,8 +104,7 @@ Keep the schema narrow. Every dimension column you add increases segment size an
       "streamType": "kafka",
       "stream.kafka.topic.name": "product-events",
       "stream.kafka.broker.list": "kafka:9092",
-      "stream.kafka.consumer.type": "lowlevel",
-      "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory",
+      "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka30.KafkaConsumerFactory",
       "stream.kafka.decoder.class.name": "org.apache.pinot.plugin.stream.kafka.KafkaJSONMessageDecoder",
       "realtime.segment.flush.threshold.rows": "500000",
       "realtime.segment.flush.threshold.time": "6h"

--- a/playbooks/text-search-analytics.md
+++ b/playbooks/text-search-analytics.md
@@ -111,8 +111,7 @@ The `subject` and `body` columns will carry the text index. They must be declare
       "streamType": "kafka",
       "stream.kafka.topic.name": "support-tickets",
       "stream.kafka.broker.list": "kafka:9092",
-      "stream.kafka.consumer.type": "lowlevel",
-      "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory",
+      "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka30.KafkaConsumerFactory",
       "stream.kafka.decoder.class.name": "org.apache.pinot.plugin.stream.kafka.KafkaJSONMessageDecoder",
       "realtime.segment.flush.threshold.rows": "250000",
       "realtime.segment.flush.threshold.time": "4h"


### PR DESCRIPTION
## Summary

High-level consumers (HLC) were removed from Pinot in 1.0.0 ([apache/pinot#11017](https://github.com/apache/pinot/pull/11017)), but some docs still presented HLC as a live option. A prior cleanup (#433) caught most of it, but missed the developer stream-plugin guide and left the vestigial `stream.kafka.consumer.type` config scattered across examples.

Verified against `apache/pinot` `master`: `StreamLevelConsumer` and `PartitionLevelConsumer` no longer exist (the SPI now uses `PartitionGroupConsumer`), and `consumer.type` has **0 references** in the Java source.

## Changes

- **`write-your-stream.md`** — Drop the "High Level (Stream Level) consumers" framing and requirements section. Update the plugin implementation class list to the current `PartitionGroupConsumer` SPI (the old `StreamLevelConsumer` / `PartitionLevelConsumer` links were dead), and remove the stale "consumer type" config bullet.
- **Ingestion + playbook examples** — Remove the no-op `"stream.kafka.consumer.type": "lowlevel"` line (a leftover of the HLC/LLC toggle) from `pauseless-consumption.md`, `confluent-schema-registry-decoders.md`, `kafka-connector-versions.md`, and the five `playbooks/*.md` guides. JSON blocks remain valid.
- **Playbook examples** — Update `stream.kafka.consumer.factory.class.name` from the removed `kafka20` (`pinot-kafka-2.0`) factory to the current `kafka30` factory. The migration notes in `kafka-connector-versions.md` and `import-from-apache-kafka.md` intentionally still reference `kafka20` as the class to migrate away from.
- **`import-from-apache-kafka.md`** — Keep the (correct) note that Pinot does not support HLC, but fix its wording: "supports operational complexity" → "reduce operational complexity".

Release notes under `reference/releases/` are left untouched — they record the historical removal.
