### PR TITLE
docs: add warnings about StrictReplicaGroup + adaptive routing

### DIFF
--- a/build-with-pinot/ingestion/upsert-and-dedup/upsert.md
+++ b/build-with-pinot/ingestion/upsert-and-dedup/upsert.md
@@ -559,6 +559,10 @@ Using implicit partitioned replica-group assignment from low-level consumer won'
 To prevent this, we recommend using explicit [partitioned replica-group instance assignment](../../../operate-pinot/instance-assignment.md#partitioned-replica-group-instance-assignment) to ensure the instance assignment is persisted. Note that `numInstancesPerPartition` should always be `1` in `replicaGroupPartitionConfig`.
 {% endhint %}
 
+{% hint style="warning" %}
+Do not enable [Adaptive Server Selection](../../../operate-pinot/tuning/query-routing-using-adaptive-server-selection.md) on upsert tables. The adaptive selector does not respect `strictReplicaGroup` boundaries and may route a query to servers across multiple replica groups, breaking the upsert consistency guarantee that all segments of the same partition are served from the same server. See [#12507](https://github.com/apache/pinot/issues/12507) for details.
+{% endhint %}
+
 ### Enable validDocIds snapshots for upsert metadata recovery
 
 Upsert snapshot support is also added in `release-0.12.0`. To enable the snapshot, set `snapshot` to `ENABLE`. For example:

--- a/operate-pinot/tuning/query-routing-using-adaptive-server-selection.md
+++ b/operate-pinot/tuning/query-routing-using-adaptive-server-selection.md
@@ -39,6 +39,10 @@ The above strategies works in tandem with the following available Routing mechan
 
 So, a table can be configured to use Balanced or Replica group segment assignment + routing and can still leverage the adaptive server selection feature.
 
+{% hint style="warning" %}
+Adaptive Server Selection does not correctly respect `strictReplicaGroup` routing boundaries. When enabled, the selector may route a single query to servers spanning multiple replica groups, violating the guarantee that all segments of a partition are served from the same replica group. This breaks correctness for upsert tables, which depend on `strictReplicaGroup` to ensure data consistency. Do not enable Adaptive Server Selection on tables that use `strictReplicaGroup` routing. See [#12507](https://github.com/apache/pinot/issues/12507) for details.
+{% endhint %}
+
 ### Configs
 
 The configuration for enabling/disabling this feature and the knobs for performance tuning are present at the Broker instance level. The feature is currently turned off by default.&#x20;


### PR DESCRIPTION
While we wait for https://github.com/apache/pinot/pull/18947 to land, we should warn users about the potential correctness bug from combining adaptive routing and StrictReplicaGroups. This warning will be relevant for everyone running Pinot on a version before that commit. 

I will follow up with a second change that will mention the fix and version.