### PR TITLE
docs: include MSE adaptive query routing latency metrics

### DIFF
--- a/operate-pinot/tuning/query-routing-using-adaptive-server-selection.md
+++ b/operate-pinot/tuning/query-routing-using-adaptive-server-selection.md
@@ -99,18 +99,20 @@ curl -X POST \
 
 #### Available Metrics
 
-Single-stage adaptive routing exports three metrics for each broker × server pair, and multi-stage adaptive routing now exports its own in-flight gauge:
+Adaptive routing exports three metrics for each broker × server pair, for each of MSE and SSE.
 
-| Metric Name | Type | Description |
-| --- | --- | --- |
-| `adaptiveServerNumInFlightRequests` | Gauge | Number of in-flight (pending) requests currently being processed on this server |
-| `adaptiveServerLatencyEma` | Gauge | Exponential moving average of query latency (in milliseconds) observed on this server |
-| `adaptiveServerHybridScore` | Gauge | Combined score balancing in-flight requests and latency to indicate server health; higher scores indicate less healthy servers |
-| `adaptiveServerMseNumInFlightRequests` | Gauge | Number of in-flight multi-stage requests currently being processed on this server. Pinot currently exports only the MSE in-flight gauge; MSE latency and hybrid-score series are not emitted yet. |
+| Metric Name | Type | Description                                                                                                                        |
+| --- | --- |------------------------------------------------------------------------------------------------------------------------------------|
+| `adaptiveServerNumInFlightRequests` | Gauge | Number of in-flight (pending) SSE requests currently being processed on this server                                                |
+| `adaptiveServerLatencyEma` | Gauge | Exponential moving average of SSE query latency (in milliseconds) observed on this server                                          |
+| `adaptiveServerHybridScore` | Gauge | Combined score balancing SSE in-flight requests and latency to indicate server health; higher scores indicate less healthy servers |
+| `adaptiveServerMseNumInFlightRequests` | Gauge | Number of in-flight (pending) MSE requests currently being processed on this server                                                |
+| `adaptiveServerMseLatencyEma` | Gauge | Exponential moving average of MSE query latency (in milliseconds) observed on this server                                          |
+| `adaptiveServerMseHybridScore` | Gauge | Combined score balancing MSE in-flight requests and latency to indicate server health; higher scores indicate less healthy servers |
 
 #### Metric Format
 
-Metric names follow the pattern `pinot.broker.adaptiveServer<MetricName>.server.<instance>` for single-stage metrics and `pinot.broker.adaptiveServerMseNumInFlightRequests.server.<instance>` for the MSE in-flight series.
+Metric names follow the pattern `pinot.broker.adaptiveServer<MetricName>.server.<instance>` for single-stage metrics and `pinot.broker.adaptiveServerMse<MetricName>.server.<instance>` for multi-stage metrics.
 
 Example: `pinot.broker.adaptiveServerLatencyEma.server.Server_pinotdb1_8098`
 

--- a/reference/configuration-reference/monitoring-metrics.md
+++ b/reference/configuration-reference/monitoring-metrics.md
@@ -249,7 +249,7 @@ Pinot provides metrics out of the box so that you can monitor every aspect of pe
 
 #### Adaptive Server Routing Metrics
 
-Broker tracks per-server adaptive routing statistics when `pinot.broker.adaptive.server.selector.enable.stats.collection=true`. With stats collection enabled, Pinot can export those stats as broker metrics by enabling `pinot.broker.adaptive.server.selector.enable.stats.metric.export=true` (disabled by default to avoid cardinality concerns). Pinot exports the SSE metrics as `pinot.broker.adaptiveServer<MetricName>.server.<instance>` and the MSE in-flight gauge as `pinot.broker.adaptiveServerMseNumInFlightRequests.server.<instance>`.
+Broker tracks per-server adaptive routing statistics when `pinot.broker.adaptive.server.selector.enable.stats.collection=true`. With stats collection enabled, Pinot can export those stats as broker metrics by enabling `pinot.broker.adaptive.server.selector.enable.stats.metric.export=true` (disabled by default to avoid cardinality concerns). Pinot exports the SSE metrics as `pinot.broker.adaptiveServer<MetricName>.server.<instance>` and the MSE metrics as `pinot.broker.adaptiveServerMse<MetricName>.server.<instance>`.
 
 **Configuration:**
 - `pinot.broker.adaptive.server.selector.enable.stats.collection`: Enable or disable stats collection (default: `false`). Pinot reads this at broker startup.
@@ -263,4 +263,6 @@ Broker tracks per-server adaptive routing statistics when `pinot.broker.adaptive
 | adaptiveServerNumInFlightRequests | Number of in-flight requests to a specific server | Gauge |
 | adaptiveServerLatencyEma | Exponential moving average of latency (ms) for a specific server | Gauge |
 | adaptiveServerHybridScore | Hybrid score for a specific server (combines in-flight requests and latency) | Gauge |
-| adaptiveServerMseNumInFlightRequests | Number of in-flight multi-stage requests to a specific server. Pinot currently exports only this MSE adaptive-routing gauge; MSE latency and hybrid-score gauges are not emitted yet. | Gauge |
+| adaptiveServerMseNumInFlightRequests | Number of in-flight multi-stage requests to a specific server | Gauge |
+| adaptiveServerMseLatencyEma | Exponential moving average of latency (ms) for multi-stage requests to a specific server | Gauge |
+| adaptiveServerMseHybridScore | Hybrid score for multi-stage requests to a specific server (combines in-flight requests and latency) | Gauge |


### PR DESCRIPTION
https://github.com/apache/pinot/pull/18791 introduces MSE latency tracking for adaptive query routing, and exports the new  stats as metrics.

Update the documentation to reflect the new metrics. 