### PR TITLE
docs: document binary JSON stream decoding (apache/pinot#18953)

### DIFF
--- a/build-with-pinot/ingestion/pinot-input-formats.md
+++ b/build-with-pinot/ingestion/pinot-input-formats.md
@@ -113,6 +113,12 @@ dataFormat: 'json'
 className: 'org.apache.pinot.plugin.inputformat.json.JSONRecordReader'
 ```
 
+For batch ingestion, `dataFormat: 'json'` uses `JSONRecordReader` and reads newline-delimited UTF-8 text JSON files only.
+
+For stream ingestion, use `org.apache.pinot.plugin.inputformat.json.JSONMessageDecoder`. When `stream.<type>.decoder.prop.jsonFormat` is unset, the decoder keeps the same UTF-8 text JSON behavior. You can also pin the stream payload format to `TEXT`, `POSTGRES_JSONB`, `SQLITE_JSONB`, `SMILE`, or `CBOR`, or set `AUTO` to opt into per-message detection for mixed streams.
+
+`AUTO` is opt-in and only detects CBOR when the payload includes the self-describe tag. If you already know the wire format, pin it explicitly instead of using `AUTO`. For a Kafka example and the config key details, see [Ingest streaming data from Apache Kafka](stream-ingestion/import-from-apache-kafka.md) and [Ingestion Configuration](../../reference/configuration-reference/ingestion.md).
+
 ### BSON
 
 ```

--- a/build-with-pinot/ingestion/stream-ingestion/import-from-apache-kafka.md
+++ b/build-with-pinot/ingestion/stream-ingestion/import-from-apache-kafka.md
@@ -231,6 +231,22 @@ Create a file called `/tmp/pinot/table-config-stream.json` and add the following
 }
 ```
 
+### JSON stream payload formats
+
+`org.apache.pinot.plugin.inputformat.json.JSONMessageDecoder` still defaults to UTF-8 text JSON when `stream.kafka.decoder.prop.jsonFormat` is unset, so existing Kafka table configs keep their historical behavior.
+
+To decode a binary JSON stream, add `stream.kafka.decoder.prop.jsonFormat` to the `streamConfigs` block and pin the payload encoding:
+
+```json
+"stream.kafka.decoder.prop.jsonFormat": "SQLITE_JSONB"
+```
+
+Supported values are `TEXT`, `POSTGRES_JSONB`, `SQLITE_JSONB`, `SMILE`, `CBOR`, and `AUTO`.
+
+Use `AUTO` only when a topic can legitimately contain more than one of those encodings. `AUTO` is opt-in, and its CBOR detection only works when each message includes the CBOR self-describe tag. If the producer always emits one known format, pin that format explicitly instead.
+
+This setting applies only to stream decoding. Batch ingestion with `JSONRecordReader` still reads text JSON files.
+
 ## Create schema and table
 
 Create the table and schema by running the appropriate command below:

--- a/reference/configuration-reference/ingestion.md
+++ b/reference/configuration-reference/ingestion.md
@@ -75,6 +75,7 @@ In this example, Pinot converts `ts` to `LONG` before `toEpochDays(ts)` runs. It
 | `stream.[streamType].consumer.factory.class.name` | Name of factory class to provide the appropriate implementation of consumer, as well as the metadata | String. Available options: - `org.apache.pinot.plugin.stream.kafka30.KafkaConsumerFactory` - `org.apache.pinot.plugin.stream.kafka30.KafkaConsumerFactory` - `org.apache.pinot.plugin.stream.kinesis.KinesisConsumerFactory` - `org.apache.pinot.plugin.stream.pulsar.PulsarConsumerFactory` |
 | `stream.[streamType].consumer.prop.auto.offset.reset` | Determines the offset from which to start the ingestion | `smallest` , `largest` Period (`10d`, `4h30m`, etc) Timestamp (in format `yyyy-MM-dd'T'HH:mm:ss.SSSZ` eg. `2022-08-09T12:31:38.222Z`) |
 | `stream.[streamType].decoder.prop.format` | Specifies the data format to ingest via a stream. The value of this property should match the format of the data in the stream. | - `JSON` |
+| `stream.[streamType].decoder.prop.jsonFormat` | Applies only to `org.apache.pinot.plugin.inputformat.json.JSONMessageDecoder`. Selects the JSON stream payload encoding. When unset, the decoder preserves its historical UTF-8 text JSON behavior. `AUTO` is opt-in, and CBOR is auto-detected only when the payload carries the CBOR self-describe tag. | `TEXT`, `POSTGRES_JSONB`, `SQLITE_JSONB`, `SMILE`, `CBOR`, `AUTO` |
 | `realtime.segment.flush.threshold.time` | Maximum elapsed time after which a consuming segment persist. Note that this time should be smaller than the Kafka retention period configured for the corresponding topic. | String, such `1d` or `4h30m`. Default is `6h` (six hours). |
 | `realtime.segment.flush.threshold.rows` | The maximum number of rows to consume before persisting the consuming segment. If this value is set to 0, the configuration looks to `realtime.segment.flush.threshold.segment.size` below. See note below this table for more information. | Default is 5,000,000 |
 | `realtime.segment.flush.threshold.segment.rows` | The maximum number of rows to consume before persisting the consuming segment. Added since `release-1.2.0`. See note below this table for more information. | Int |
@@ -107,6 +108,10 @@ When offset auto reset is enabled, Pinot checks the configured lag thresholds du
 
 {% hint style="info" %}
 For BSON streams, set `stream.[streamType].decoder.class.name` to `org.apache.pinot.plugin.inputformat.bson.BSONMessageDecoder`. Each stream message must contain a single BSON document; BSON does not use `stream.[streamType].decoder.prop.format`.
+{% endhint %}
+
+{% hint style="info" %}
+`stream.[streamType].decoder.prop.jsonFormat` is a stream-only setting. Batch ingestion with `org.apache.pinot.plugin.inputformat.json.JSONRecordReader` still reads text JSON files.
 {% endhint %}
 
 ## `streamIngestionConfig`

--- a/reference/configuration-reference/plugin-reference.md
+++ b/reference/configuration-reference/plugin-reference.md
@@ -67,7 +67,7 @@ Pinot ships two Kafka connector modules: `pinot-kafka-3.0` (Kafka client 3.9.2, 
 
 | Decoder Class | Description |
 | --- | --- |
-| `org.apache.pinot.plugin.inputformat.json.JSONMessageDecoder` | Decodes plain JSON messages without a schema registry. |
+| `org.apache.pinot.plugin.inputformat.json.JSONMessageDecoder` | Decodes stream JSON messages without a schema registry. Defaults to UTF-8 text JSON and also supports `stream.<type>.decoder.prop.jsonFormat` values `TEXT`, `POSTGRES_JSONB`, `SQLITE_JSONB`, `SMILE`, `CBOR`, and opt-in `AUTO`. |
 | `org.apache.pinot.plugin.inputformat.avro.SimpleAvroMessageDecoder` | Decodes Avro messages using a schema provided via `stream.kafka.decoder.prop.schema`. |
 | `org.apache.pinot.plugin.inputformat.avro.confluent.KafkaConfluentSchemaRegistryAvroMessageDecoder` | Decodes Avro messages whose schemas are registered in Confluent Schema Registry. Requires `stream.kafka.decoder.prop.schema.registry.rest.url`. |
 | `org.apache.pinot.plugin.inputformat.json.confluent.KafkaConfluentSchemaRegistryJsonMessageDecoder` | Decodes JSON messages whose schemas are registered in Confluent Schema Registry. Requires `stream.kafka.decoder.prop.schema.registry.rest.url`. Added in Pinot 1.4. |


### PR DESCRIPTION
## What changed for readers
- documented that `JSONMessageDecoder` still defaults to UTF-8 text JSON when `stream.<type>.decoder.prop.jsonFormat` is unset
- documented the new `stream.<type>.decoder.prop.jsonFormat` values for stream ingestion: `TEXT`, `POSTGRES_JSONB`, `SQLITE_JSONB`, `SMILE`, `CBOR`, and opt-in `AUTO`
- clarified that `AUTO` only detects CBOR when the self-describe tag is present, and that pinned formats are preferred when the encoding is known
- clarified that this applies to stream decoding only; batch ingestion with `JSONRecordReader` still reads text JSON files

## Structural updates
- updated the supported input formats page, the Kafka ingestion guide, the ingestion config reference, and the plugin config reference entry for `JSONMessageDecoder`

## Source cross-check
- verified against `pinot-plugins/pinot-input-format/pinot-json/README.md`
- verified against `JSONMessageDecoder`, `JsonPayloadFormat`, and `JSONMessageDecoderBinaryTest` from apache/pinot commit `d59403e74410ced40350a735b6568cc56734ac49`

## Validation
- `git diff --check`
- verified the edited internal doc paths resolve in the repo
