### PR TITLE
docs: document compression stats APIs

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -150,6 +150,7 @@
   * [Bloom Filter](build-with-pinot/indexing/bloom-filter.md)
   * [Dictionary Index](build-with-pinot/indexing/dictionary-index.md)
   * [Forward Index](build-with-pinot/indexing/forward-index.md)
+  * [Compression Stats](build-with-pinot/indexing/compression-stats.md)
   * [FST Index](build-with-pinot/indexing/fst-index.md)
   * [Geospatial](build-with-pinot/indexing/geospatial-support.md)
   * [Inverted Index](build-with-pinot/indexing/inverted-index.md)

--- a/build-with-pinot/indexing/README.md
+++ b/build-with-pinot/indexing/README.md
@@ -34,6 +34,15 @@ Use the decision guide when you know the query shape but not the best index yet.
 * [Star-tree index](star-tree-index.md) for repeatable aggregation and group-by workloads.
 * [Vector index](vector-index.md) for similarity search on embeddings.
 
+## Inspect compression efficiency
+
+Use compression stats when you need to compare Pinot's tracked uncompressed value bytes with the bytes Pinot stores in
+forward indexes and dictionaries for a table.
+
+{% content-ref url="compression-stats.md" %}
+[compression-stats.md](compression-stats.md)
+{% endcontent-ref %}
+
 ### Index availability
 
 | Index Type          | Segment Type       |

--- a/build-with-pinot/indexing/compression-stats.md
+++ b/build-with-pinot/indexing/compression-stats.md
@@ -1,0 +1,73 @@
+---
+description: Measure forward-index and dictionary compression coverage for a Pinot table.
+---
+
+# Compression stats
+
+Compression stats let you inspect how much serialized column-value data Pinot stores in forward indexes and
+dictionaries after compression. The feature is off by default and surfaces through the existing controller table size
+and metadata APIs.
+
+## Enable collection
+
+Set `tableIndexConfig.compressionStatsEnabled` to `true` in the table config:
+
+```json
+{
+  "tableIndexConfig": {
+    "compressionStatsEnabled": true
+  }
+}
+```
+
+Pinot records stats only for segments built, or forward indexes rewritten, while the flag is enabled. Existing segments
+are not backfilled.
+
+## Query the stats
+
+Use the controller APIs documented in [Controller API Examples](../../reference/api-reference/controller-api.md):
+
+* `GET /tables/{tableName}/size` returns a `compressionStats` summary for each covered offline or realtime sub-table.
+  Add `includeColumnCompressionStats=true` to include `columnCompressionStats`.
+* `GET /tables/{tableName}/metadata?type=OFFLINE` returns the offline table's aggregate `compressionStats` summary.
+  Add `columns=...` to scope the metadata response and `includeColumnCompressionStats=true` to include per-column
+  entries.
+
+The table-level summary reports:
+
+| Field | Meaning |
+| --- | --- |
+| `uncompressedValueSizePerReplicaInBytes` | Tracked serialized value bytes for one logical copy of the covered segments |
+| `forwardIndexAndDictionaryStorageSizePerReplicaInBytes` | Forward-index and dictionary bytes on disk for the same logical copy |
+| `compressionRatio` | `uncompressedValueSizePerReplicaInBytes / forwardIndexAndDictionaryStorageSizePerReplicaInBytes` |
+| `segmentsWithCompleteStats` | Number of logical segments that contributed complete stats |
+| `totalSegments` | Total logical segments in the sub-table |
+| `partialCoverage` | `true` when one or more logical segments could not contribute stats |
+
+Per-column entries break out the column name, observed index types, aggregate sizes, ratio, and
+`encodingBreakdown`. Raw forward indexes report the chunk compression type; dictionary-encoded columns report combined
+forward-index and dictionary bytes.
+
+## Coverage caveats
+
+Only eligible forward-index columns contribute to the ratio. Columns without a forward index, and older segments that
+do not have persisted value-size metadata, are excluded from the summary and from per-column coverage.
+
+In verbose `GET /tables/{tableName}/size` responses, Pinot selects one complete replica for each logical segment when
+it attaches segment-level compression fields under `segments.<segment>.serverInfo.<server>`. Other replicas still
+report disk size, but not segment-level compression details.
+
+`GET /tables/{tableName}/metadata` currently supports offline tables only. During rolling upgrades or mixed old/new
+segment populations, `partialCoverage` stays `true` until Pinot can read stats for every covered logical segment.
+
+## Controller gauges
+
+When compression stats are available for a table, the lead controller emits these gauges:
+
+| Gauge | Unit |
+| --- | --- |
+| `tableCompressionStatsRatioPercent` | Percent |
+| `tableCompressionStatsUncompressedValueSizePerReplica` | Bytes |
+| `tableCompressionStatsForwardIndexAndDictionaryStorageSizePerReplica` | Bytes |
+
+These gauges are removed when collection is disabled or when no covered segment remains.

--- a/reference/api-reference/controller-api.md
+++ b/reference/api-reference/controller-api.md
@@ -701,6 +701,77 @@ curl -X GET "http://localhost:9000/debug/tables/baseballStats?type=OFFLINE&verbo
 ]
 ```
 
+### GET /tables/\<tableName>/size
+
+Get controller-aggregated table size details for the requested table. Pinot accepts either a raw table name such as
+`myTable` or a typed table name such as `myTable_OFFLINE`.
+
+When `tableIndexConfig.compressionStatsEnabled=true`, this response also includes a `compressionStats` summary for each
+covered offline or realtime sub-table. Per-column details are opt-in because the response can grow quickly.
+
+**Query parameters**
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `verbose` | boolean | Defaults to `true`. When `false`, Pinot still returns the table and sub-table totals but leaves the `segments` maps empty. |
+| `includeReplacedSegments` | boolean | Defaults to `true`. Include replaced segments in the size rollup. |
+| `includeColumnCompressionStats` | boolean | Defaults to `false`. Add `columnCompressionStats` to each covered sub-table and selected segment-replica entry. |
+
+**Request**
+
+```bash
+curl -X GET "http://localhost:9000/tables/compressionStats/size?verbose=true&includeColumnCompressionStats=true" \
+  -H "accept: application/json"
+```
+
+**Response behavior**
+
+* `offlineSegments.compressionStats` and `realtimeSegments.compressionStats` stay available even when
+  `includeColumnCompressionStats=false`.
+* `columnCompressionStats` is returned only when `includeColumnCompressionStats=true`.
+* In verbose responses, Pinot attaches segment-level compression fields to one selected replica per logical segment
+  under `segments.<segment>.serverInfo.<server>`. Other replicas continue to report disk size only.
+
+For field definitions and coverage caveats, see [Compression Stats](../../build-with-pinot/indexing/compression-stats.md).
+
+### GET /tables/\<tableName>/metadata
+
+Get aggregate segment metadata for an offline table, including optional compression summaries.
+
+**Query parameters**
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `type` | string | Use `OFFLINE`. `REALTIME` is not supported for this endpoint. |
+| `columns` | string[] | Optional repeated query parameter to limit the response to specific columns. |
+| `includeColumnCompressionStats` | boolean | Defaults to `false`. Add per-column compression entries to the response. |
+
+`compressionStatsEnabled` in the table config controls whether servers collect compression stats at all.
+`includeColumnCompressionStats` only controls whether Pinot includes the per-column list in the controller response.
+
+**Request**
+
+```bash
+curl -X GET "http://localhost:9000/tables/compressionStats/metadata?type=OFFLINE&includeColumnCompressionStats=true" \
+  -H "accept: application/json"
+```
+
+To scope the metadata response to one column:
+
+```bash
+curl -X GET "http://localhost:9000/tables/compressionStats/metadata?type=OFFLINE&columns=message&includeColumnCompressionStats=true" \
+  -H "accept: application/json"
+```
+
+**Response behavior**
+
+* The response includes a top-level `compressionStats` summary when Pinot can read any covered segment stats.
+* `columnCompressionStats` is returned only when `includeColumnCompressionStats=true`.
+* `partialCoverage=true` means Pinot could not contribute stats for at least one logical segment, such as older
+  segments built before the flag was enabled or segments whose current replicas cannot supply stats.
+
+For field definitions and coverage caveats, see [Compression Stats](../../build-with-pinot/indexing/compression-stats.md).
+
 ## Application Quotas
 
 Application-level query quotas allow you to limit the queries per second (QPS) issued by different applications connecting to Pinot, regardless of which tables or databases they query. Applications are identified by the `applicationName` query option. For more details on how application quotas interact with table and database quotas, see [Query Quotas](../../build-with-pinot/querying-and-sql/query-execution-controls/query-quotas.md).


### PR DESCRIPTION
## What changed
- add a new indexing page for compression stats and link it from the indexing landing page and `SUMMARY.md`
- document how to enable `tableIndexConfig.compressionStatsEnabled`
- document the controller `GET /tables/{tableName}/size` and `GET /tables/{tableName}/metadata` compression-stats parameters and response behavior

## Source cross-check
- `pinot-tools/src/main/resources/examples/compression-stats/README.md`
- `pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableSize.java`
- `pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java`
- `pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/CompressionStatsSummary.java`

## Validation
- `git diff --check`
- verified the new relative Markdown and `content-ref` targets resolve locally
