### PR TITLE
docs: document field spec metadata map (apache/pinot#18984)

### DIFF
--- a/reference/configuration-reference/schema.md
+++ b/reference/configuration-reference/schema.md
@@ -137,7 +137,7 @@ All schema data types are comparable, and ordering must be consistent with equal
 
 Pinot groups columns into dimension, metric, date-time, and complex field specs. The field spec controls column behavior during ingestion, storage, and query execution.
 
-All field-spec families also accept optional metadata keys `fieldId` and `aliases`. Pinot preserves these values in schema JSON and omits them when unset, but it does not currently use them to validate backward-compatible schema updates or to rewrite ingestion and query paths automatically.
+All field-spec families also accept optional `fieldId`, `aliases`, and `metadata` values. Pinot preserves non-empty values in schema JSON, omits empty alias lists and metadata maps, and does not currently use these fields for backward-compatible schema validation or automatic rename and rewrite handling.
 
 ## Null Handling
 
@@ -183,6 +183,7 @@ Define one dimension field spec for each dimension column.
 | `tags` | Optional list of tags for categorizing the column. |
 | `fieldId` | Optional stable, name-independent identifier for the column. |
 | `aliases` | Optional list of alternate or historical names for the column. |
+| `metadata` | Optional free-form string map for column metadata. Pinot preserves non-empty values in schema JSON, omits empty maps, and does not assign built-in semantics or use them for backward-compatibility checks. |
 | `dataType` | Data type of the dimension column. Supported types are `INT`, `LONG`, `FLOAT`, `DOUBLE`, `BIG_DECIMAL`, `BOOLEAN`, `TIMESTAMP`, `STRING`, `BYTES`, and `JSON`. |
 | `defaultNullValue` | Value Pinot should write when the source record is null. If omitted, Pinot uses the internal default for the type. |
 | `singleValueField` | Whether the column is single-valued. If `false`, Pinot stores a multi-value list, preserves order, and allows duplicates. This includes `BIG_DECIMAL` and `BYTES` dimension columns. The default null value for a multi-value column is a single-element list containing the configured or internal null value. |
@@ -198,6 +199,7 @@ Define one metric field spec for each metric column.
 | `tags` | Optional list of tags for categorizing the column. |
 | `fieldId` | Optional stable, name-independent identifier for the column. |
 | `aliases` | Optional list of alternate or historical names for the column. |
+| `metadata` | Optional free-form string map for column metadata. Pinot preserves non-empty values in schema JSON, omits empty maps, and does not assign built-in semantics or use them for backward-compatibility checks. |
 | `dataType` | Data type of the metric column. Supported types are `INT`, `LONG`, `FLOAT`, `DOUBLE`, `BIG_DECIMAL`, and `BYTES` for serialized sketches such as HLL or TDigest. |
 | `defaultNullValue` | Value Pinot should write when the source record is null. If omitted, Pinot uses the internal default for the type. |
 
@@ -214,6 +216,7 @@ Pinot accepts legacy `TimeFieldSpec` objects when loading older schemas that are
 | `tags` | Optional list of tags for categorizing the column. |
 | `fieldId` | Optional stable, name-independent identifier for the column. |
 | `aliases` | Optional list of alternate or historical names for the column. |
+| `metadata` | Optional free-form string map for column metadata. Pinot preserves non-empty values in schema JSON, omits empty maps, and does not assign built-in semantics or use them for backward-compatibility checks. |
 | `dataType` | Data type of the date-time column. Supported types are `STRING`, `INT`, `LONG`, and `TIMESTAMP`. Internally `TIMESTAMP` is stored as `LONG` milliseconds since epoch. If you use `TIMESTAMP`, source data must be either `LONG` epoch values or JDBC timestamp strings such as `2021-01-01 01:01:01.123`. |
 | `format` | Format in which the time value is stored. See [New DateTime Formats](#new-datetime-formats). |
 | `granularity` | Bucket size and unit in `bucketSize:bucketUnit` form, for example `15:MINUTES`. This is descriptive metadata only; Pinot does not automatically round values to the declared granularity. |
@@ -278,6 +281,7 @@ Use complex field specs for complex data types. Pinot currently supports `MAP` a
 | `tags` | Optional list of tags for categorizing the column. |
 | `fieldId` | Optional stable, name-independent identifier for the column. |
 | `aliases` | Optional list of alternate or historical names for the column. |
+| `metadata` | Optional free-form string map for column metadata. Pinot preserves non-empty values in schema JSON, omits empty maps, and does not assign built-in semantics or use them for backward-compatibility checks. |
 | `dataType` | Complex data type. Currently supports `MAP` and `OPEN_STRUCT`. |
 | `fieldType` | Must be `COMPLEX`. |
 | `notNull` | Whether the column can contain null values. |
@@ -356,6 +360,7 @@ These advanced properties are available across field specs:
 | --- | --- |
 | `fieldId` | Optional stable, name-independent identifier for a field spec. Pinot preserves it in schema JSON but does not currently use it for compatibility validation or automatic rename handling. |
 | `aliases` | Optional list of alternate or historical names for a field spec. Pinot omits empty alias lists from stored JSON and preserves non-empty values as metadata only. |
+| `metadata` | Optional free-form string map for a field spec. Pinot preserves non-empty values in schema JSON, omits empty maps, and does not assign built-in semantics or use it for compatibility validation. |
 | `maxLength` | Maximum length for `STRING`, `JSON`, and `BYTES` columns. |
 | `maxLengthExceedStrategy` | Behavior when incoming values exceed `maxLength`. Supported values are `TRIM_LENGTH`, `SUBSTITUTE_DEFAULT_VALUE`, `NO_ACTION`, and `ERROR`. Defaults to `TRIM_LENGTH` for `STRING` and `NO_ACTION` for `JSON` and `BYTES`. |
 | `allowTrailingZeros` | Whether `BIG_DECIMAL` should preserve trailing zeros. Defaults to `false`, which strips them. |


### PR DESCRIPTION
## What changed
- document the optional `metadata` map for schema field specs in `reference/configuration-reference/schema.md`
- clarify that Pinot preserves non-empty metadata in schema JSON, omits empty maps, and does not assign built-in semantics or use metadata for backward-compatibility checks

## Structural changes
- none; this is a targeted schema reference update only

## Source cross-check
- apache/pinot merge commit `068b458883d645ee2c686ab2a5e123ef2ffe8cff`
- `pinot-spi/src/main/java/org/apache/pinot/spi/data/FieldSpec.java`
- `pinot-spi/src/test/java/org/apache/pinot/spi/data/FieldSpecTest.java`

## Validation
- `git diff --check`
- local relative Markdown link validation for `reference/configuration-reference/schema.md`
