### PR TITLE
docs: document recommender UUID support (apache/pinot#18973)

### DIFF
--- a/operate-pinot/configuration-recommendation-engine.md
+++ b/operate-pinot/configuration-recommendation-engine.md
@@ -46,6 +46,7 @@ Data characteristics is defined in "schema" field. The content of this field is 
   * Metric columns cannot be defined as multi-value.
   * Columns of type BYTES cannot be defined as multi-value.
 * **averageLength**: For data type of BYTES or STRING only, this is the average length of the column value.
+* **UUID fields**: Schema columns with `dataType` set to `UUID` are supported when the engine generates sample data. Generated Avro sample data uses canonical UUID strings, and UUID columns are represented as Avro `string` with logical type `uuid`.
 
 ### 2. Table Characteristics
 


### PR DESCRIPTION
## What changed
Added a schema-input note to the configuration recommendation engine docs that UUID columns are supported in the sample-data generation path.

## Why
apache/pinot#18973 added UUID support for recommender sample-data generation, including canonical UUID string output and Avro `string` fields annotated with logical type `uuid`.

## Reader impact
Users can now include `UUID` fields in the schema they send to `/tables/recommender` without the sample-data generation path failing.

## Source cross-check
Verified against local `apache/pinot` merge commit `3790129aa15ec70d9870a5f61fa09b67d2a1fbc3`.

## Validation
- `git diff --check`
- Verified the edited page's existing relative link target `operate-pinot/tuning/realtime.md` resolves locally