### PR TITLE
docs: document colocated set-op hint (apache/pinot#18804)

### DIFF
--- a/build-with-pinot/querying-and-sql/multi-stage-query/hints.md
+++ b/build-with-pinot/querying-and-sql/multi-stage-query/hints.md
@@ -7,3 +7,48 @@ Apache Pinot supports the following hints:
 * `aggOptions`, explained in [aggregate operator](operator-types/aggregate.md#hints).
 * `windowOptions`, explained in [window operator](operator-types/window.md#hints).
 * `joinOptions`, explained in [join operator](operator-types/hash_join.md#hints).
+* `setOpOptions`, explained in [union](operator-types/union.md#hints), [intersect](operator-types/intersect.md#hints), and [minus](operator-types/minus.md#hints).
+
+## setOpOptions
+
+Use `setOpOptions` to control the exchange Pinot inserts below `UNION`, `UNION ALL`, `INTERSECT`, and `EXCEPT` / `MINUS`.
+
+### is_colocated_by_set_op_keys
+
+Type: Boolean
+
+Default: planner chosen
+
+When the option is unset, the V1 planner auto-detects whether each set-op input is already partitioned compatibly and can use a direct exchange. You can override that decision explicitly:
+
+* `'true'` forces a pre-partitioned direct exchange on every input.
+* `'false'` forces a shuffled hash exchange on every input.
+
+This hint is only honored by the V1 planner. The V2 physical optimizer ignores it and determines set-op colocation on its own.
+
+Pinot accepts the hint in two places:
+
+* Inline on the first branch:
+
+```sql
+SELECT /*+ setOpOptions(is_colocated_by_set_op_keys='true') */ col FROM a
+UNION ALL
+SELECT col FROM b
+```
+
+* On an outer `SELECT` that wraps the set operation:
+
+```sql
+SELECT /*+ setOpOptions(is_colocated_by_set_op_keys='true') */ *
+FROM (
+  SELECT col FROM a
+  INTERSECT
+  SELECT col FROM b
+)
+```
+
+{% hint style="warning" %}
+Only force `'true'` when every input is partitioned compatibly on one or more projected columns, so equal full output rows land on the same worker. If that is not true, `INTERSECT`, `EXCEPT`, and plain `UNION` can return wrong results. `UNION ALL` is always safe because it only concatenates rows.
+{% endhint %}
+
+Use the outer-wrap form for plain `UNION`, which Pinot rewrites before the exchange rule resolves the inline hint. Prefer the outer-wrap form for nested `INTERSECT` or `EXCEPT` queries too when you want the hint to apply at every set-op level.

--- a/build-with-pinot/querying-and-sql/multi-stage-query/operator-types/intersect.md
+++ b/build-with-pinot/querying-and-sql/multi-stage-query/operator-types/intersect.md
@@ -45,7 +45,23 @@ emit EOS
 
 ## Hints
 
-None
+### is_colocated_by_set_op_keys
+
+Type: Boolean
+
+Default: planner chosen
+
+Apply this option with `setOpOptions(is_colocated_by_set_op_keys='...')` to control whether Pinot shuffles rows before the intersect stage:
+
+* `'true'` forces a pre-partitioned direct exchange.
+* `'false'` forces a shuffled hash exchange.
+* Unset leaves the V1 planner's auto-detection in place.
+
+Only force `'true'` when all inputs are partitioned compatibly on one or more projected columns so equal full output rows land on the same worker. If that does not hold, `INTERSECT` can return wrong results.
+
+Use the outer-wrap form described in [Hints](../hints.md#setopoptions) when you want the hint to cover nested `INTERSECT` levels. An inline hint on the first branch only applies to the innermost set operation.
+
+The V2 physical optimizer ignores this hint and determines set-op colocation on its own.
 
 ## Stats
 

--- a/build-with-pinot/querying-and-sql/multi-stage-query/operator-types/minus.md
+++ b/build-with-pinot/querying-and-sql/multi-stage-query/operator-types/minus.md
@@ -47,7 +47,23 @@ emit EOS
 
 ## Hints
 
-None
+### is_colocated_by_set_op_keys
+
+Type: Boolean
+
+Default: planner chosen
+
+Apply this option with `setOpOptions(is_colocated_by_set_op_keys='...')` to control whether Pinot shuffles rows before the minus stage used for SQL `EXCEPT` / `MINUS`:
+
+* `'true'` forces a pre-partitioned direct exchange.
+* `'false'` forces a shuffled hash exchange.
+* Unset leaves the V1 planner's auto-detection in place.
+
+Only force `'true'` when all inputs are partitioned compatibly on one or more projected columns so equal full output rows land on the same worker. If that does not hold, `EXCEPT` / `MINUS` can return wrong results.
+
+Use the outer-wrap form described in [Hints](../hints.md#setopoptions) when you want the hint to cover nested `EXCEPT` / `MINUS` levels. An inline hint on the first branch only applies to the innermost set operation.
+
+The V2 physical optimizer ignores this hint and determines set-op colocation on its own.
 
 ## Stats
 

--- a/build-with-pinot/querying-and-sql/multi-stage-query/operator-types/union.md
+++ b/build-with-pinot/querying-and-sql/multi-stage-query/operator-types/union.md
@@ -22,7 +22,23 @@ The union operator is a streaming operator that consumes the input relations one
 
 ## Hints
 
-None
+### is_colocated_by_set_op_keys
+
+Type: Boolean
+
+Default: planner chosen
+
+Apply this option with `setOpOptions(is_colocated_by_set_op_keys='...')` to control whether Pinot shuffles rows before the union stage:
+
+* `'true'` forces a pre-partitioned direct exchange.
+* `'false'` forces a shuffled hash exchange.
+* Unset leaves the V1 planner's auto-detection in place.
+
+`UNION ALL` is always safe with `'true'` because it only concatenates rows. Plain `UNION` is only safe with `'true'` when all inputs are partitioned compatibly on one or more projected columns so equal full output rows land on the same worker.
+
+Use the outer-wrap form described in [Hints](../hints.md#setopoptions) for plain `UNION`. Pinot rewrites distinct `UNION` to an aggregate over `UNION ALL`, so the inline hint on the first branch does not apply there.
+
+The V2 physical optimizer ignores this hint and determines set-op colocation on its own.
 
 ## Stats
 


### PR DESCRIPTION
## Summary
- document `setOpOptions(is_colocated_by_set_op_keys='...')` in the multi-stage query hints page
- add operator-specific guidance for `UNION`, `INTERSECT`, and `EXCEPT` / `MINUS`
- call out V1-only behavior, supported hint placement, safety caveats, and the plain `UNION` / nested set-op caveats

## Source cross-check
- verified shipped behavior against `apache/pinot` merge commit `f865accd77820505953cfbb106523b34ef5c9a5e`
- aligned the docs with the planner hint definitions, set-op exchange rule, planner tests, and query-hint fixtures added in `apache/pinot#18804`

## Validation
- `git diff --check`
- lightweight link validation for the edited files and new hint anchors