### PR TITLE
docs: document swagger auth header (apache/pinot#18974)

### DIFF
--- a/operate-pinot/authentication/basic-auth-access-control.md
+++ b/operate-pinot/authentication/basic-auth-access-control.md
@@ -100,6 +100,8 @@ Congratulations! You've successfully enabled authentication on Apache Pinot. Rea
 
 Apache Pinot's Basic Auth follows the established standards for HTTP Basic Auth. Credentials are provided via an HTTP Authorization header. The pinot-controller web ui dynamically adapts to your auth configuration and will display a login prompt when basic auth is enabled. Restricted users are still shown all available ui functions, but their operations will fail with an error message if ACLs prohibit access.
 
+The controller Swagger UI also exposes that same `Authorization` header through the standard `Authorize` dialog. Enter `Basic <token>` there once per session instead of editing each request by hand. If your deployment uses bearer tokens on the same header, the same dialog also accepts `Bearer <token>`. This only changes how Swagger documents and collects the header; Pinot's runtime authentication behavior is unchanged.
+
 If you're using pinot's CLI clients you can provide your credentials either via dedicated username and password arguments, or as pre-serialized token for the HTTP Authorization header. Note, that while most of Apache Pinot's CLI commands support auth, not all of them have been back-fitted yet. If you encounter any such case, you can access the REST API directly, e.g. via curl.
 
 {% tabs %}

--- a/reference/api-reference/controller-admin-api.md
+++ b/reference/api-reference/controller-admin-api.md
@@ -6,6 +6,8 @@ description: Pinot controller admin UI reference.
 
 The controller admin UI at `http://<controller-host>:<port>/help` is the quickest way to inspect and exercise Pinot's administrative endpoints. Use it for schema, table, and segment operations when you want the interactive Swagger surface instead of raw curl examples.
 
+If controller authentication is enabled, use the Swagger UI `Authorize` control to set the `Authorization` header once for the session instead of editing each request manually. Enter `Basic <token>` for Basic auth or `Bearer <token>` when your deployment uses bearer tokens on the same header.
+
 ## What It Covers
 
 | Area | Typical task |


### PR DESCRIPTION
## What changed
- documented how authenticated controller Swagger sessions now use the standard `Authorize` dialog to set the `Authorization` header
- clarified that users can enter either `Basic <token>` or `Bearer <token>` there, depending on deployment auth

## Why
apache/pinot#18974 exposed Pinot's existing `Authorization` header in the generated Swagger/OpenAPI security definition.

## Reader impact
Users of the controller admin UI no longer need to infer or hand-edit the auth header for every Swagger request.

## Source cross-check
Verified against local `apache/pinot` merge commit `00d1c88763d4015b9ce966ad7c13a52abf30f9b2`.

## Validation
- `git diff --check`
- lightweight local link validation for the edited files
