### PR TITLE
docs: document JDK 25 baseline

### DIFF
--- a/basics/getting-started/install/README.md
+++ b/basics/getting-started/install/README.md
@@ -12,7 +12,7 @@ Select the right installation method for your use case and deploy a Pinot cluste
 
 | Method | Best for | Time | Prerequisites |
 |---|---|---|---|
-| [Local](local.md) | Development, debugging | 10 min | JDK 21+ |
+| [Local](local.md) | Development, debugging | 10 min | JDK 25+ |
 | [Docker](docker.md) | Quick evaluation, CI | 5 min | Docker |
 | [Kubernetes](kubernetes.md) | Staging, production | 15 min | K8s cluster, Helm |
 | [Managed Kubernetes](managed-kubernetes/) | Production on cloud | 20 min | Cloud account, CLI tools |

--- a/basics/getting-started/install/docker.md
+++ b/basics/getting-started/install/docker.md
@@ -289,9 +289,9 @@ You should see containers for ZooKeeper, Controller, Broker, Server, and Minion 
 
 ## Docker image versions
 
-Pinot Docker images are built with **JDK 21** by default. For forward-looking compatibility testing, a **JDK 25** image variant is also available. Previous JDK 11 and JDK 17 image variants are no longer published starting with this release.
+Pinot Docker images now target **JDK 25** runtimes. The `latest` tag promotes the `25-ms-openjdk` runtime, and `latest-25` plus versioned `-25` tags remain available for explicit pinning.
 
-If you are running deployments pinned to older JDK 11 or JDK 17 image tags (e.g., `apachepinot/pinot:1.4.0-java-11` or `apachepinot/pinot:1.4.0-java-17`), you must update to the JDK 21 image tag before adopting this release.
+Pinot no longer publishes `*-21-*` service image tags. If you are pinned to `apachepinot/pinot:latest-21-amazoncorretto`, `apachepinot/pinot:latest-21-ms-openjdk`, or similar versioned `*-21-*` tags, move to a `*-25-*` tag before upgrading.
 
 ## Next step
 

--- a/basics/getting-started/install/local.md
+++ b/basics/getting-started/install/local.md
@@ -10,7 +10,7 @@ Start a multi-component Pinot cluster directly on your machine without container
 
 ## Prerequisites
 
-* JDK 21 or later (required for building and running Pinot services)
+* JDK 25 or later (required for building and running Pinot services)
 * Apache Maven 3.6+ (only if building from source)
 
 {% hint style="info" %}

--- a/basics/getting-started/pinot-versions.md
+++ b/basics/getting-started/pinot-versions.md
@@ -43,12 +43,12 @@ Start Here pages never use the `latest` Docker tag. Always pin to a specific ver
 
 | Requirement | Detail |
 | --- | --- |
-| **Build/Runtime baseline** | **JDK 21+** (required for Pinot services) |
+| **Build/Runtime baseline** | **JDK 25+** (required for Pinot services) |
 | **Client libraries** | JDK 11+ (SPI and Java/JDBC client artifacts remain compatible with Java 11) |
 | Pinot 1.0+ minimum | JDK 11 or higher required |
 | JDK 8 support | Pinot **0.12.1** is the last version that supports JDK 8 |
 
-**Starting with this release:** Pinot services require **JDK 21 or later** for building and runtime. The SPI and Java/JDBC client modules (`pinot-spi`, `pinot-java-client`, `pinot-jdbc-client`) are compiled to Java 11 bytecode for backward compatibility with external JVM consumers.
+**Starting with this release:** Pinot services require **JDK 25 or later** for building and runtime. The SPI and Java/JDBC client modules (`pinot-spi`, `pinot-java-client`, `pinot-jdbc-client`) are compiled to Java 11 bytecode for backward compatibility with external JVM consumers.
 
 ## Release links
 

--- a/develop-contribute/build-docker-images.md
+++ b/develop-contribute/build-docker-images.md
@@ -20,6 +20,8 @@ You can find current supported 2 images in this directory:
 
 This is a docker image of [Apache Pinot](https://github.com/apache/pinot).
 
+Official Pinot service images now target **JDK 25**. The published `latest` tag promotes the `25-ms-openjdk` runtime, and `*-21-*` service tags are no longer published. When you build Pinot service images locally with the helper scripts below, pass `25` for the Java/JDK version arguments to match current releases.
+
 ### Docker Base Image Updates
 
 As of [PR #18178](https://github.com/apache/pinot/pull/18178), the Pinot Docker images have been overhauled to improve security and eliminate CVE vulnerabilities:
@@ -64,9 +66,9 @@ The docker image is tagged as `[Docker Tag]`.
 
 `Kafka Version`: The Kafka Version to build pinot with. Default is `3.0`. Supported values are `3.0` and `4.0`.
 
-`Java Version`: The Java Build and Runtime image version. Default is `21`
+`Java Version`: The Java build and runtime image version. Use `25` for current Pinot service releases. The helper script defaults to `21` if omitted.
 
-`JDK Version`: The JDK parameter to build pinot, set as part of maven build option: `-Djdk.version=${JDK_VERSION}`. Default is `21`
+`JDK Version`: The JDK parameter to build Pinot, set as part of the Maven build option `-Djdk.version=${JDK_VERSION}`. Use `25` for current Pinot service releases. The helper script defaults to `21` if omitted.
 
 `OpenJDK Image`: Base image to use for Pinot build and runtime. Default is `openjdk`.
 
@@ -89,19 +91,19 @@ For users on Mac M1 chips, they need to build the images with arm64 base image, 
 * Example of building an arm64 image:
 
 ```
-./docker-build.sh pinot:latest master https://github.com/apache/pinot.git 2.0 21 21 arm64v8/openjdk
+./docker-build.sh pinot:latest master https://github.com/apache/pinot.git 2.0 25 25 arm64v8/openjdk
 ```
 
 or just run the docker build script directly
 
 ```
-docker build -t pinot:latest --no-cache --network=host --build-arg PINOT_GIT_URL=https://github.com/apache/pinot.git --build-arg PINOT_BRANCH=master --build-arg JDK_VERSION=21 --build-arg OPENJDK_IMAGE=arm64v8/openjdk -f Dockerfile .
+docker build -t pinot:latest --no-cache --network=host --build-arg PINOT_GIT_URL=https://github.com/apache/pinot.git --build-arg PINOT_BRANCH=master --build-arg JDK_VERSION=25 --build-arg OPENJDK_IMAGE=arm64v8/openjdk -f Dockerfile .
 ```
 
 Note that if you are not on arm64 machine, you can still build the image by turning on the experimental feature of docker, and add `--platform linux/arm64` into the `docker build ...` script, e.g.
 
 ```
-docker build -t pinot:latest --platform linux/arm64 --no-cache --network=host --build-arg PINOT_GIT_URL=https://github.com/apache/pinot.git --build-arg PINOT_BRANCH=master --build-arg JDK_VERSION=21 --build-arg OPENJDK_IMAGE=arm64v8/openjdk -f Dockerfile .
+docker build -t pinot:latest --platform linux/arm64 --no-cache --network=host --build-arg PINOT_GIT_URL=https://github.com/apache/pinot.git --build-arg PINOT_BRANCH=master --build-arg JDK_VERSION=25 --build-arg OPENJDK_IMAGE=arm64v8/openjdk -f Dockerfile .
 ```
 
 ## How to publish a docker image

--- a/develop-contribute/codebase-basics.md
+++ b/develop-contribute/codebase-basics.md
@@ -21,7 +21,7 @@ This section helps you get the Apache Pinot source code onto your machine, under
 ## Prerequisites
 
 * Git installed and configured with SSH keys for GitHub.
-* JDK 21 (JDK 17 is also supported with additional VM options).
+* JDK 25.
 * Apache Maven 3.6 or later.
 * Docker (required only for building container images).
 

--- a/developers/developers-and-contributors/extending-pinot/README.md
+++ b/developers/developers-and-contributors/extending-pinot/README.md
@@ -49,4 +49,4 @@ Before extending Pinot, make sure you have:
 
 * A local Pinot development environment set up (see [Dev Environment Setup](../code-setup.md))
 * Familiarity with Pinot's [architecture and components](../../../basics/concepts/)
-* Java 21+ and Maven for building
+* Java 25+ and Maven for building

--- a/operate-pinot/deployment.md
+++ b/operate-pinot/deployment.md
@@ -11,7 +11,7 @@ This section covers everything you need to deploy an Apache Pinot cluster, from 
 
 ## Prerequisites
 
-- Java 21 or later installed (or Docker if using container-based deployment).
+- Java 25 or later installed (or Docker if using container-based deployment).
 - A running Apache ZooKeeper ensemble (three nodes recommended for production).
 - Access to a deep store (local filesystem for development; S3, GCS, HDFS, or ADLS for production).
 - The Pinot binary distribution downloaded from [pinot.apache.org/download](https://pinot.apache.org/download) or the official Docker image.


### PR DESCRIPTION
## Summary
- update the install, deployment, and contributor docs to reflect the JDK 25 Pinot service baseline
- document the current Docker runtime expectations, including the `latest` tag behavior and the end of `*-21-*` service tags
- keep the Java 11 client and SPI compatibility notes in place

## Source cross-check
- apache/pinot#19014 PR body
- `pom.xml` JDK baseline and enforcer message
- `README.md` build note for services vs. Java 11 client artifacts
- `docker/images/pinot-base/README.md`, Dockerfiles, and Docker packaging scripts for JDK 25/runtime tag behavior

## Validation
- `git diff --check`