### PR TITLE
docs: plugins-external + working local batch ingestion tutorial (#14234, #9923)

### DIFF
--- a/build-with-pinot/ingestion/batch-ingestion/README.md
+++ b/build-with-pinot/ingestion/batch-ingestion/README.md
@@ -441,6 +441,10 @@ If you are using the docker, you can set the following under `JAVA_OPTS` variabl
 
 You can set `-D mapreduce.map.memory.mb=8192` to set the mapper memory size when submitting the Hadoop job.
 
+The Hadoop batch plugin is under `plugins-external/pinot-batch-ingestion/pinot-batch-ingestion-hadoop/`. Point `plugins.dir` at both `plugins` and `plugins-external` (semicolon-separated) and put the shaded Hadoop plugin jar on `HADOOP_CLASSPATH`. See [Hadoop](hadoop.md).
+
 #### Spark
 
 You can add config `spark.executor.memory` to tune the memory usage for segment creation when submitting the Spark job.
+
+The Spark 3 batch plugin is under `plugins-external/pinot-batch-ingestion/pinot-batch-ingestion-spark-3/`. `pinot-all` does not include it. Point `plugins.dir` at both `plugins` and `plugins-external`, and put the shaded Spark plugin jar on the Spark classpath. See [Spark](spark.md).

--- a/build-with-pinot/ingestion/batch-ingestion/hadoop.md
+++ b/build-with-pinot/ingestion/batch-ingestion/hadoop.md
@@ -6,9 +6,13 @@ description: Batch ingestion of data into Apache Pinot using Apache Hadoop.
 
 ## Segment Creation and Push
 
-Pinot supports [Apache Hadoop](https://hadoop.apache.org) as a processor to create and push segment files to the database. Pinot distribution is bundled with the Spark code to process your files and convert and upload them to Pinot.
+Pinot supports [Apache Hadoop](https://hadoop.apache.org) as a processor to create and push segment files to the database. Pinot distribution is bundled with the Hadoop batch-ingestion plugin to process your files and convert and upload them to Pinot.
 
 You can follow the [local install guide](../../../basics/getting-started/install/local.md#1-download-or-build-apache-pinot) to build Pinot from source. The resulting JAR file can be found in `pinot/target/pinot-all-${PINOT_VERSION}-jar-with-dependencies.jar`
+
+{% hint style="info" %}
+`pinot-all-*-jar-with-dependencies.jar` does **not** include the Hadoop batch-ingestion plugin. That plugin is packaged under `plugins-external/pinot-batch-ingestion/pinot-batch-ingestion-hadoop/` in the binary distribution. You must put it on the Hadoop classpath and include `plugins-external` in `plugins.dir`.
+{% endhint %}
 
 Next, you need to change the execution config in the job spec to the following -
 
@@ -47,16 +51,26 @@ Finally execute the hadoop job using the command -
 ```
 export PINOT_VERSION=1.4.0 #set to the Pinot version you have installed
 export PINOT_DISTRIBUTION_DIR=${PINOT_ROOT_DIR}/build/
-export HADOOP_CLIENT_OPTS="-Dplugins.dir=${PINOT_DISTRIBUTION_DIR}/plugins -Dlog4j2.configurationFile=${PINOT_DISTRIBUTION_DIR}/conf/pinot-ingestion-job-log4j2.xml"
 
-hadoop jar  \\
-        ${PINOT_DISTRIBUTION_DIR}/lib/pinot-all-${PINOT_VERSION}-jar-with-dependencies.jar \\
-        org.apache.pinot.tools.admin.PinotAdministrator \\
-        LaunchDataIngestionJob \\
+HADOOP_BATCH_PLUGIN=${PINOT_DISTRIBUTION_DIR}/plugins-external/pinot-batch-ingestion/pinot-batch-ingestion-hadoop/pinot-batch-ingestion-hadoop-${PINOT_VERSION}-shaded.jar
+PINOT_ALL_JAR=${PINOT_DISTRIBUTION_DIR}/lib/pinot-all-${PINOT_VERSION}-jar-with-dependencies.jar
+
+# plugins.dir accepts a semicolon-separated list. Include plugins (record readers, FS) and plugins-external (Hadoop batch runners).
+export HADOOP_CLIENT_OPTS="-Dplugins.dir=${PINOT_DISTRIBUTION_DIR}/plugins;${PINOT_DISTRIBUTION_DIR}/plugins-external -Dlog4j2.configurationFile=${PINOT_DISTRIBUTION_DIR}/conf/pinot-ingestion-job-log4j2.xml"
+export HADOOP_CLASSPATH="${HADOOP_BATCH_PLUGIN}:${PINOT_ALL_JAR}:${HADOOP_CLASSPATH}"
+
+hadoop jar \
+        ${PINOT_ALL_JAR} \
+        org.apache.pinot.tools.admin.PinotAdministrator \
+        LaunchDataIngestionJob \
         -jobSpecFile ${PINOT_DISTRIBUTION_DIR}/examples/batch/airlineStats/hadoopIngestionJobSpec.yaml
 ```
 
 Ensure environment variables `PINOT_ROOT_DIR` and `PINOT_VERSION` are set properly.
+
+{% hint style="warning" %}
+**ClassNotFoundException for Hadoop runners** usually means `plugins-external` is missing from `plugins.dir` or the shaded `pinot-batch-ingestion-hadoop-*-shaded.jar` is not on `HADOOP_CLASSPATH`. `pinot-all` alone is not enough.
+{% endhint %}
 
 ## Data Preprocessing before Segment Creation
 

--- a/build-with-pinot/ingestion/batch-ingestion/spark.md
+++ b/build-with-pinot/ingestion/batch-ingestion/spark.md
@@ -25,16 +25,16 @@ executionFrameworkSpec:
   name: 'spark'
 
   # segmentGenerationJobRunnerClassName: class name implements org.apache.pinot.spi.ingestion.batch.runner.IngestionJobRunner interface.
-  segmentGenerationJobRunnerClassName: 'org.apache.pinot.plugin.ingestion.batch.spark.SparkSegmentGenerationJobRunner'
+  segmentGenerationJobRunnerClassName: 'org.apache.pinot.plugin.ingestion.batch.spark3.SparkSegmentGenerationJobRunner'
 
   # segmentTarPushJobRunnerClassName: class name implements org.apache.pinot.spi.ingestion.batch.runner.IngestionJobRunner interface.
-  segmentTarPushJobRunnerClassName: 'org.apache.pinot.plugin.ingestion.batch.spark.SparkSegmentTarPushJobRunner'
+  segmentTarPushJobRunnerClassName: 'org.apache.pinot.plugin.ingestion.batch.spark3.SparkSegmentTarPushJobRunner'
 
   # segmentUriPushJobRunnerClassName: class name implements org.apache.pinot.spi.ingestion.batch.runner.IngestionJobRunner interface.
-  segmentUriPushJobRunnerClassName: 'org.apache.pinot.plugin.ingestion.batch.spark.SparkSegmentUriPushJobRunner'
+  segmentUriPushJobRunnerClassName: 'org.apache.pinot.plugin.ingestion.batch.spark3.SparkSegmentUriPushJobRunner'
 
   #segmentMetadataPushJobRunnerClassName: class name implements org.apache.pinot.spi.ingestion.batch.runner.IngestionJobRunner interface
-  segmentMetadataPushJobRunnerClassName: 'org.apache.pinot.plugin.ingestion.batch.spark.SparkSegmentMetadataPushJobRunner'
+  segmentMetadataPushJobRunnerClassName: 'org.apache.pinot.plugin.ingestion.batch.spark3.SparkSegmentMetadataPushJobRunner'
 
   # extraConfigs: extra configs for execution framework.
   extraConfigs:
@@ -45,38 +45,46 @@ executionFrameworkSpec:
 
 Spark job specs can filter input paths with `includeFileNamePattern` and `excludeFileNamePattern`. Both properties accept Java NIO `glob:` and `regex:` patterns; see [File name patterns](../../../reference/configuration-reference/job-specification.md#file-name-patterns) for working examples and path-normalization details.
 
-To run Spark ingestion, you need the following jars in your classpath
+## Required jars and plugins.dir
 
-* `pinot-batch-ingestion-spark` plugin jar - available in `plugins-external` directory in the package
-* `pinot-all` jar - available in `lib` directory in the package
+`pinot-all-*-jar-with-dependencies.jar` does **not** bundle Spark or Hadoop batch-ingestion plugins. Those live under `plugins-external/` in the binary distribution (see `pinot-assembly.xml`). You must put them on the Spark classpath **and** point `plugins.dir` at directories that contain them.
 
-These jars can be specified using `spark.driver.extraClassPath` or any other option.
+To run Spark ingestion you need:
+
+* `pinot-all` jar — under `lib/` in the package
+* `pinot-batch-ingestion-spark-3` shaded plugin jar — under `plugins-external/pinot-batch-ingestion/pinot-batch-ingestion-spark-3/`
+* Any other plugins your job uses (record readers, file systems) — under `plugins/` (for example `pinot-avro`, `pinot-parquet`, `pinot-s3`)
+
+`plugins.dir` accepts a **semicolon-separated** list of directories. Include both `plugins` and `plugins-external` so record readers and the Spark batch runners load correctly:
+
+```
+-Dplugins.dir=${PINOT_DISTRIBUTION_DIR}/plugins;${PINOT_DISTRIBUTION_DIR}/plugins-external
+```
+
+Put the Spark batch plugin and `pinot-all` on the driver (and executor) classpath with `spark.driver.extraClassPath` / `spark.executor.extraClassPath`:
 
 ```
 spark.driver.extraClassPath =>
-pinot-batch-ingestion-spark-${PINOT_VERSION}-shaded.jar:pinot-all-${PINOT_VERSION}-jar-with-dependencies.jar
+${PINOT_DISTRIBUTION_DIR}/plugins-external/pinot-batch-ingestion/pinot-batch-ingestion-spark-3/pinot-batch-ingestion-spark-3-${PINOT_VERSION}-shaded.jar:${PINOT_DISTRIBUTION_DIR}/lib/pinot-all-${PINOT_VERSION}-jar-with-dependencies.jar
 ```
 
-For loading any other plugins that you want to use, use:
-
-```
-spark.driver.extraJavaOptions =>
--Dplugins.dir=${PINOT_DISTRIBUTION_DIR}/plugins
-```
-
-The complete spark-submit command should look like this:
+The complete local-mode `spark-submit` command:
 
 ```
 export PINOT_VERSION=1.4.0 #set to the Pinot version you have installed
 export PINOT_DISTRIBUTION_DIR=/path/to/apache-pinot-${PINOT_VERSION}-bin
 
-spark-submit //
---class org.apache.pinot.tools.admin.command.LaunchDataIngestionJobCommand //
---master local --deploy-mode client //
---conf "spark.driver.extraJavaOptions=-Dplugins.dir=${PINOT_DISTRIBUTION_DIR}/plugins" //
---conf "spark.driver.extraClassPath=${PINOT_DISTRIBUTION_DIR}/plugins-external/pinot-batch-ingestion/pinot-batch-ingestion-spark-3/pinot-batch-ingestion-spark-3-${PINOT_VERSION}-shaded.jar:${PINOT_DISTRIBUTION_DIR}/lib/pinot-all-${PINOT_VERSION}-jar-with-dependencies.jar" //
--conf "spark.executor.extraClassPath=${PINOT_DISTRIBUTION_DIR}/plugins-external/pinot-batch-ingestion/pinot-batch-ingestion-spark-3/pinot-batch-ingestion-spark-3-${PINOT_VERSION}-shaded.jar:${PINOT_DISTRIBUTION_DIR}/lib/pinot-all-${PINOT_VERSION}-jar-with-dependencies.jar" //
-local://${PINOT_DISTRIBUTION_DIR}/lib/pinot-all-${PINOT_VERSION}-jar-with-dependencies.jar -jobSpecFile /path/to/spark_job_spec.yaml
+SPARK_BATCH_PLUGIN=${PINOT_DISTRIBUTION_DIR}/plugins-external/pinot-batch-ingestion/pinot-batch-ingestion-spark-3/pinot-batch-ingestion-spark-3-${PINOT_VERSION}-shaded.jar
+PINOT_ALL_JAR=${PINOT_DISTRIBUTION_DIR}/lib/pinot-all-${PINOT_VERSION}-jar-with-dependencies.jar
+
+spark-submit \
+  --class org.apache.pinot.tools.admin.command.LaunchDataIngestionJobCommand \
+  --master local --deploy-mode client \
+  --conf "spark.driver.extraJavaOptions=-Dplugins.dir=${PINOT_DISTRIBUTION_DIR}/plugins;${PINOT_DISTRIBUTION_DIR}/plugins-external" \
+  --conf "spark.driver.extraClassPath=${SPARK_BATCH_PLUGIN}:${PINOT_ALL_JAR}" \
+  --conf "spark.executor.extraClassPath=${SPARK_BATCH_PLUGIN}:${PINOT_ALL_JAR}" \
+  local://${PINOT_ALL_JAR} \
+  -jobSpecFile /path/to/spark_job_spec.yaml
 ```
 
 Ensure environment variables `PINOT_ROOT_DIR` and `PINOT_VERSION` are set properly.
@@ -87,28 +95,31 @@ Ensure environment variables `PINOT_ROOT_DIR` and `PINOT_VERSION` are set proper
 The `spark-core` dependency is not included in Pinot jars since the 0.10.0 release. If you run into runtime issues, make sure your Spark environment provides the dependency, or [build from source](../../../basics/getting-started/) with the matching Spark profile.
 {% endhint %}
 
-### Running in Cluster Mode on YARN
+### Running on YARN
 
-If you want to run the spark job in cluster mode on YARN/EMR cluster, the following needs to be done -
+The example below uses YARN with `client` deploy mode so the Spark driver can read the unpacked Pinot distribution referenced by `plugins.dir`. Before running it:
 
 * Build Pinot from source with option `-DuseProvidedHadoop`
-* Copy Pinot binaries to S3, HDFS or any other distributed storage that is accessible from all nodes.
-* Copy Ingestion spec YAML file to S3, HDFS or any other distributed storage. Mention this path as part of `--files` argument in the command
-* Add `--jars` options that contain the s3/hdfs paths to all the required plugin and pinot-all jar
-* Point `classPath` to spark working directory. Generally, just specifying the jar names without any paths works. Same should be done for main jar as well as the spec YAML file
+* Keep the unpacked Pinot distribution available on the submit host.
+* Copy the ingestion spec YAML to S3, HDFS, or another location accessible through `--files`.
+* Add the Spark batch plugin and `pinot-all` through `--jars` so Spark distributes them to executors.
+* Point the driver and executor classpaths at the distributed jar names.
+
+For YARN `cluster` deploy mode, the driver runs remotely. You must separately distribute and unpack the `plugins` and `plugins-external` directories, then set `plugins.dir` to paths that exist in the remote driver container.
 
 **Example**
 
 ```
-spark-submit //
---class org.apache.pinot.tools.admin.command.LaunchDataIngestionJobCommand //
---master yarn --deploy-mode cluster //
---conf "spark.driver.extraJavaOptions=-Dplugins.dir=${PINOT_DISTRIBUTION_DIR}/plugins" //
---conf "spark.driver.extraClassPath=pinot-batch-ingestion-spark-3/pinot-batch-ingestion-spark-3-${PINOT_VERSION}-shaded.jar:pinot-all-${PINOT_VERSION}-jar-with-dependencies.jar" //
---conf "spark.executor.extraClassPath=pinot-batch-ingestion-spark-3/pinot-batch-ingestion-spark-3-${PINOT_VERSION}-shaded.jar:pinot-all-${PINOT_VERSION}-jar-with-dependencies.jar" //
---jars "${PINOT_DISTRIBUTION_DIR}/plugins-external/pinot-batch-ingestion/pinot-batch-ingestion-spark-3/pinot-batch-ingestion-spark-3-${PINOT_VERSION}-shaded.jar,${PINOT_DISTRIBUTION_DIR}/lib/pinot-all-${PINOT_VERSION}-jar-with-dependencies.jar"
---files s3://path/to/spark_job_spec.yaml
-local://pinot-all-${PINOT_VERSION}-jar-with-dependencies.jar -jobSpecFile spark_job_spec.yaml
+spark-submit \
+  --class org.apache.pinot.tools.admin.command.LaunchDataIngestionJobCommand \
+  --master yarn --deploy-mode client \
+  --conf "spark.driver.extraJavaOptions=-Dplugins.dir=${PINOT_DISTRIBUTION_DIR}/plugins;${PINOT_DISTRIBUTION_DIR}/plugins-external" \
+  --conf "spark.driver.extraClassPath=pinot-batch-ingestion-spark-3-${PINOT_VERSION}-shaded.jar:pinot-all-${PINOT_VERSION}-jar-with-dependencies.jar" \
+  --conf "spark.executor.extraClassPath=pinot-batch-ingestion-spark-3-${PINOT_VERSION}-shaded.jar:pinot-all-${PINOT_VERSION}-jar-with-dependencies.jar" \
+  --jars "${PINOT_DISTRIBUTION_DIR}/plugins-external/pinot-batch-ingestion/pinot-batch-ingestion-spark-3/pinot-batch-ingestion-spark-3-${PINOT_VERSION}-shaded.jar,${PINOT_DISTRIBUTION_DIR}/lib/pinot-all-${PINOT_VERSION}-jar-with-dependencies.jar" \
+  --files s3://path/to/spark_job_spec.yaml \
+  ${PINOT_DISTRIBUTION_DIR}/lib/pinot-all-${PINOT_VERSION}-jar-with-dependencies.jar \
+  -jobSpecFile spark_job_spec.yaml
 ```
 
 
@@ -120,11 +131,11 @@ Since 0.8.0 release, Pinot binaries are compiled with JDK 11. If you are using S
 
 Q - **I am not able to find `pinot-batch-ingestion-spark` jar.**
 
-Since Pinot 0.10.0, the spark plugin is located in the `pinot-external` directory of the binary distribution (in older versions it was in `plugin`).
+Since Pinot 0.10.0, the Spark batch plugin is located under `plugins-external/pinot-batch-ingestion/` in the binary distribution (in older versions it lived under `plugins/`). Current Spark 3 builds ship `pinot-batch-ingestion-spark-3-*-shaded.jar`.
 
 Q - **Spark is not able to find the jars** **leading to** **`java.nio.file.NoSuchFileException`**
 
-This means the classpath for spark job has not been configured properly. If you are running spark in a distributed environment such as Yarn or k8s, make sure both `spark.driver.classpath` and `spark.executor.classpath` are set. Also, the jars in `driver.classpath` should be added to `--jars` argument in `spark-submit` so that spark can distribute those jars to all the nodes in your cluster. You also need to take provide appropriate scheme with the file path when running the jar. In this doc, we have used `local:\\` but it can be different depending on your cluster setup.
+This means the classpath for spark job has not been configured properly. If you are running spark in a distributed environment such as Yarn or k8s, make sure both `spark.driver.extraClassPath` and `spark.executor.extraClassPath` are set. Also, the jars in `driver.extraClassPath` should be added to `--jars` argument in `spark-submit` so that spark can distribute those jars to all the nodes in your cluster. You also need to take provide appropriate scheme with the file path when running the jar. In this doc, we have used `local://` but it can be different depending on your cluster setup.
 
 Q - **Spark job failing while pushing the segments.**
 
@@ -138,8 +149,13 @@ If already set to `APPEND`, this is likely due to a missing `timeColumnName` in 
 
 Q - **I am getting `java.lang.RuntimeException: java.io.IOException: Failed to create directory: pinot-plugins-dir-0/plugins/*`**
 
-Removing `-Dplugins.dir=${PINOT_DISTRIBUTION_DIR}/plugins` from `spark.driver.extraJavaOptions` should fix this. As long as plugins are mentioned in classpath and `jars` argument it should not be an issue.
+Removing `-Dplugins.dir=...` from `spark.driver.extraJavaOptions` can fix this when the plugin jars are already on the Spark classpath via `extraClassPath` and `--jars`. Prefer pointing `plugins.dir` at real local paths that exist on the driver (`plugins` and `plugins-external` under the distribution).
 
-Q - Getting `Class not found:` exception
+Q - Getting `Class not found:` exception (for example `SparkSegmentGenerationJobRunner`)
 
-Check if `extraClassPath` arguments contain all the plugin jars for both driver and executors. Also, all the plugin jars are mentioned in the `--jars` argument. If both of these are correct, check if the `extraClassPath` contains local filesystem classpaths and not s3 or hdfs or any other distributed file system classpaths.
+The Spark/Hadoop batch runners are **not** inside `pinot-all`. Confirm that:
+
+1. `extraClassPath` for both driver and executors includes the shaded jar under `plugins-external/pinot-batch-ingestion/pinot-batch-ingestion-spark-3/`
+2. That same jar is listed in `--jars` for cluster mode
+3. `plugins.dir` includes `${PINOT_DISTRIBUTION_DIR}/plugins-external` (semicolon-separated with `plugins` if you also need record readers / file-system plugins from `plugins/`)
+4. The job spec uses the Spark 3 package: `org.apache.pinot.plugin.ingestion.batch.spark3.*`

--- a/tutorials/data-ingestion/batch-data-ingestion-in-practice.md
+++ b/tutorials/data-ingestion/batch-data-ingestion-in-practice.md
@@ -80,17 +80,14 @@ jobType: SegmentCreationAndTarPush
 # inputDirURI: Root directory of input data, expected to have scheme configured in PinotFS.
 inputDirURI: 'examples/batch/airlineStats/rawdata'
 
-# includeFileNamePattern: include file name pattern, supported glob pattern.
+# includeFileNamePattern / excludeFileNamePattern: Java NIO PathMatcher patterns (glob: or regex:).
+# See https://docs.pinot.apache.org/configuration-reference/job-specification#file-name-patterns
 # Sample usage:
-#   'glob:*.avro' will include all avro files just under the inputDirURI, not sub directories;
-#   'glob:**\/*.avro' will include all the avro files under inputDirURI recursively.
+#   'glob:**/*.avro' or 'regex:.*[.]avro' matches Avro paths under inputDirURI (full path).
 includeFileNamePattern: 'glob:**/*.avro'
 
-# excludeFileNamePattern: exclude file name pattern, supported glob pattern.
-# Sample usage:
-#   'glob:*.avro' will exclude all avro files just under the inputDirURI, not sub directories;
-#   'glob:**\/*.avro' will exclude all the avro files under inputDirURI recursively.
-# _excludeFileNamePattern: ''
+# excludeFileNamePattern: 'glob:**/*.tmp' or 'regex:.*[.]tmp'
+# excludeFileNamePattern: ''
 
 # outputDirURI: Root directory of output segments, expected to have scheme configured in PinotFS.
 outputDirURI: 'examples/batch/airlineStats/segments'
@@ -244,20 +241,17 @@ After job finished, segments are stored in `examples/batch/airlineStats/segments
 
 ## Executing the job using Spark
 
-Below example is running in a spark local mode. You can download spark distribution and start it by running:
+{% hint style="warning" %}
+**`pinot-all` is not enough for Spark.** Spark (and Hadoop) batch runners ship under `plugins-external/` and are not packaged inside `pinot-all-*-jar-with-dependencies.jar`. If you only put `pinot-all` on the classpath you will get `ClassNotFoundException` for classes such as `SparkSegmentGenerationJobRunner`. Always add the shaded jar from `plugins-external/pinot-batch-ingestion/pinot-batch-ingestion-spark-3/` and include `plugins-external` in `plugins.dir`.
+{% endhint %}
 
-```
-wget https://downloads.apache.org/spark/spark-3.2.0/spark-3.2.0-bin-hadoop2.7.tgz
-tar xvf spark-3.2.0-bin-hadoop2.7.tgz
-cd spark-3.2.0-bin-hadoop2.7
-./bin/spark-shell --master 'local[2]'
-```
+The example below runs Spark in **local mode** against the sample `airlineStats` data on the **local filesystem** (no S3/HDFS credentials). Download a Spark 3.x distribution and set `SPARK_HOME`, or use a pre-installed Spark.
 
-Build the latest Pinot distribution following the [local install guide](../../basics/getting-started/install/local.md#1-download-or-build-apache-pinot).
+Build or download a Pinot binary distribution following the [local install guide](../../basics/getting-started/install/local.md#1-download-or-build-apache-pinot).
 
-Below command shows how to use spark-submit command to submit a spark job using `pinot-all-${PINOT_VERSION}-jar-with-dependencies.jar`.
+### Local-FS Spark job spec
 
-Sample Spark ingestion job spec yaml, (also located at `examples/batch/airlineStats/sparkIngestionJobSpec.yaml`):
+Use `LocalPinotFS` for local paths. Spark 3 runner classes live in the `spark3` package. You can start from `examples/batch/airlineStats/sparkIngestionJobSpec.yaml` and align class names / FS as below:
 
 ```
 # executionFrameworkSpec: Defines ingestion jobs to be running.
@@ -266,14 +260,11 @@ executionFrameworkSpec:
   # name: execution framework name
   name: 'spark'
 
-  # segmentGenerationJobRunnerClassName: class name implements org.apache.pinot.spi.batch.ingestion.runner.SegmentGenerationJobRunner interface.
-  segmentGenerationJobRunnerClassName: 'org.apache.pinot.plugin.ingestion.batch.spark.SparkSegmentGenerationJobRunner'
-
-  # segmentTarPushJobRunnerClassName: class name implements org.apache.pinot.spi.batch.ingestion.runner.SegmentTarPushJobRunner interface.
-  segmentTarPushJobRunnerClassName: 'org.apache.pinot.plugin.ingestion.batch.spark.SparkSegmentTarPushJobRunner'
-
-  # segmentUriPushJobRunnerClassName: class name implements org.apache.pinot.spi.batch.ingestion.runner.SegmentUriPushJobRunner interface.
-  segmentUriPushJobRunnerClassName: 'org.apache.pinot.plugin.ingestion.batch.spark.SparkSegmentUriPushJobRunner'
+  # Spark 3 package: org.apache.pinot.plugin.ingestion.batch.spark3.*
+  segmentGenerationJobRunnerClassName: 'org.apache.pinot.plugin.ingestion.batch.spark3.SparkSegmentGenerationJobRunner'
+  segmentTarPushJobRunnerClassName: 'org.apache.pinot.plugin.ingestion.batch.spark3.SparkSegmentTarPushJobRunner'
+  segmentUriPushJobRunnerClassName: 'org.apache.pinot.plugin.ingestion.batch.spark3.SparkSegmentUriPushJobRunner'
+  segmentMetadataPushJobRunnerClassName: 'org.apache.pinot.plugin.ingestion.batch.spark3.SparkSegmentMetadataPushJobRunner'
 
   # extraConfigs: extra configs for execution framework.
   extraConfigs:
@@ -288,22 +279,16 @@ executionFrameworkSpec:
 #   'SegmentUriPush'
 #   'SegmentCreationAndTarPush'
 #   'SegmentCreationAndUriPush'
+#   'SegmentCreationAndMetadataPush'
 jobType: SegmentCreationAndTarPush
 
 # inputDirURI: Root directory of input data, expected to have scheme configured in PinotFS.
 inputDirURI: 'examples/batch/airlineStats/rawdata'
 
-# includeFileNamePattern: include file name pattern, supported glob pattern.
-# Sample usage:
-#   'glob:*.avro' will include all avro files just under the inputDirURI, not sub directories;
-#   'glob:**\/*.avro' will include all the avro files under inputDirURI recursively.
+# includeFileNamePattern / excludeFileNamePattern: Java NIO PathMatcher (glob: or regex:).
+# See configuration-reference/job-specification.md#file-name-patterns
 includeFileNamePattern: 'glob:**/*.avro'
-
-# excludeFileNamePattern: exclude file name pattern, supported glob pattern.
-# Sample usage:
-#   'glob:*.avro' will exclude all avro files just under the inputDirURI, not sub directories;
-#   'glob:**\/*.avro' will exclude all the avro files under inputDirURI recursively.
-# excludeFileNamePattern: ''
+# excludeFileNamePattern: 'glob:**/*.tmp'
 
 # outputDirURI: Root directory of output segments, expected to have scheme configured in PinotFS.
 outputDirURI: 'examples/batch/airlineStats/segments'
@@ -314,50 +299,21 @@ overwriteOutput: true
 # pinotFSSpecs: defines all related Pinot file systems.
 pinotFSSpecs:
 
-  - # scheme: used to identify a PinotFS.
-    # E.g. local, hdfs, dbfs, etc
+  - # Local filesystem — no cloud or HDFS credentials required for this recipe.
     scheme: file
-
-    # className: Class name used to create the PinotFS instance.
-    # E.g.
-    #   org.apache.pinot.spi.filesystem.LocalPinotFS is used for local filesystem
-    #   org.apache.pinot.plugin.filesystem.AzurePinotFS is used for Azure Data Lake
-    #   org.apache.pinot.plugin.filesystem.HadoopPinotFS is used for HDFS
-    className: org.apache.pinot.plugin.filesystem.HadoopPinotFS
+    className: org.apache.pinot.spi.filesystem.LocalPinotFS
 
 # recordReaderSpec: defines all record reader
 recordReaderSpec:
 
-  # dataFormat: Record data format, e.g. 'avro', 'parquet', 'orc', 'csv', 'json', 'thrift' etc.
   dataFormat: 'avro'
-
-  # className: Corresponding RecordReader class name.
-  # E.g.
-  #   org.apache.pinot.plugin.inputformat.avro.AvroRecordReader
-  #   org.apache.pinot.plugin.inputformat.csv.CSVRecordReader
-  #   org.apache.pinot.plugin.inputformat.parquet.ParquetRecordReader
-  #   org.apache.pinot.plugin.inputformat.json.JSONRecordReader
-  #   org.apache.pinot.plugin.inputformat.orc.ORCRecordReader
-  #   org.apache.pinot.plugin.inputformat.thrift.ThriftRecordReader
   className: 'org.apache.pinot.plugin.inputformat.avro.AvroRecordReader'
 
 # tableSpec: defines table name and where to fetch corresponding table config and table schema.
 tableSpec:
 
-  # tableName: Table name
   tableName: 'airlineStats'
-
-  # schemaURI: defines where to read the table schema, supports PinotFS or HTTP.
-  # E.g.
-  #   hdfs://path/to/table_schema.json
-  #   http://localhost:9000/tables/myTable/schema
   schemaURI: 'http://localhost:9000/tables/airlineStats/schema'
-
-  # tableConfigURI: defines where to reade the table config.
-  # Supports using PinotFS or HTTP.
-  # E.g.
-  #   hdfs://path/to/table_config.json
-  #   http://localhost:9000/tables/myTable
   # Note that the API to read Pinot table config directly from pinot controller contains a JSON wrapper.
   # The real table config is the object under the field 'OFFLINE'.
   tableConfigURI: 'http://localhost:9000/tables/airlineStats'
@@ -365,213 +321,136 @@ tableSpec:
 # segmentNameGeneratorSpec: defines how to init a SegmentNameGenerator.
 segmentNameGeneratorSpec:
 
-  # type: Current supported type is 'simple' and 'normalizedDate'.
   type: normalizedDate
-
-  # configs: Configs to init SegmentNameGenerator.
   configs:
     segment.name.prefix: 'airlineStats_batch'
     exclude.sequence.id: true
 
 # pinotClusterSpecs: defines the Pinot Cluster Access Point.
 pinotClusterSpecs:
-  - # controllerURI: used to fetch table/schema information and data push.
-    # E.g. http://localhost:9000
-    controllerURI: 'http://localhost:9000'
+  - controllerURI: 'http://localhost:9000'
 
 # pushJobSpec: defines segment push job related configuration.
 pushJobSpec:
 
-  # pushParallelism: push job parallelism, default is 1.
   pushParallelism: 2
-
-  # pushAttempts: number of attempts for push job, default is 1, which means no retry.
   pushAttempts: 2
-
-  # pushRetryIntervalMillis: retry wait Ms, default to 1 second.
   pushRetryIntervalMillis: 1000
 ```
 
-Ensure parameter `PINOT_ROOT_DIR` and `PINOT_VERSION` are set properly.
+### Local-mode spark-submit
+
+Ensure `PINOT_DISTRIBUTION_DIR` points at an unpacked binary distribution (contains `lib/`, `plugins/`, `plugins-external/`, and `examples/`).
 
 {% hint style="info" %}
-Ensure you set
+Required pieces:
 
-*   `spark.driver.extraJavaOptions =>`
-
-    `-Dplugins.dir=${PINOT_DISTRIBUTION_DIR}/plugins`
-
-Or put all the required plugins jars to CLASSPATH, then set `-Dplugins.dir=${CLASSPATH}`
-
-*   `spark.driver.extraClassPath =>`
-
-    `pinot-all-${PINOT_VERSION}-jar-with-depdencies.jar`
+* `plugins.dir` — semicolon-separated list including **both** `plugins` (record readers such as Avro) and `plugins-external` (Spark batch runners)
+* `spark.driver.extraClassPath` / `spark.executor.extraClassPath` — `pinot-batch-ingestion-spark-3-*-shaded.jar` **and** `pinot-all-*-jar-with-dependencies.jar`
 {% endhint %}
 
 ```
 export PINOT_VERSION=1.5.1 #set to the Pinot version you have installed
 export PINOT_DISTRIBUTION_DIR=${PINOT_ROOT_DIR}/build/
 cd ${PINOT_DISTRIBUTION_DIR}
+
+SPARK_BATCH_PLUGIN=${PINOT_DISTRIBUTION_DIR}/plugins-external/pinot-batch-ingestion/pinot-batch-ingestion-spark-3/pinot-batch-ingestion-spark-3-${PINOT_VERSION}-shaded.jar
+PINOT_ALL_JAR=${PINOT_DISTRIBUTION_DIR}/lib/pinot-all-${PINOT_VERSION}-jar-with-dependencies.jar
+
 ${SPARK_HOME}/bin/spark-submit \
   --class org.apache.pinot.tools.admin.command.LaunchDataIngestionJobCommand \
   --master "local[2]" \
   --deploy-mode client \
-  --conf "spark.driver.extraJavaOptions=-Dplugins.dir=${PINOT_DISTRIBUTION_DIR}/plugins -Dlog4j2.configurationFile=${PINOT_DISTRIBUTION_DIR}/conf/pinot-ingestion-job-log4j2.xml" \
-  --conf "spark.driver.extraClassPath=${PINOT_DISTRIBUTION_DIR}/lib/pinot-all-${PINOT_VERSION}-jar-with-dependencies.jar" \
-  local://${PINOT_DISTRIBUTION_DIR}/lib/pinot-all-${PINOT_VERSION}-jar-with-dependencies.jar \
+  --conf "spark.driver.extraJavaOptions=-Dplugins.dir=${PINOT_DISTRIBUTION_DIR}/plugins;${PINOT_DISTRIBUTION_DIR}/plugins-external -Dlog4j2.configurationFile=${PINOT_DISTRIBUTION_DIR}/conf/pinot-ingestion-job-log4j2.xml" \
+  --conf "spark.driver.extraClassPath=${SPARK_BATCH_PLUGIN}:${PINOT_ALL_JAR}" \
+  --conf "spark.executor.extraClassPath=${SPARK_BATCH_PLUGIN}:${PINOT_ALL_JAR}" \
+  local://${PINOT_ALL_JAR} \
   -jobSpecFile ${PINOT_DISTRIBUTION_DIR}/examples/batch/airlineStats/sparkIngestionJobSpec.yaml
 ```
 
+{% hint style="warning" %}
+**Troubleshooting `ClassNotFoundException`:** confirm the shaded jar under `plugins-external/pinot-batch-ingestion/pinot-batch-ingestion-spark-3/` exists for your `${PINOT_VERSION}`, is on both driver and executor classpaths, and that `plugins.dir` lists `plugins-external`. See also the [Spark batch ingestion](../../build-with-pinot/ingestion/batch-ingestion/spark.md) page FAQ.
+{% endhint %}
+
 ## Executing the job using Hadoop
 
-Below command shows how to use Hadoop jar command to run a Hadoop job using `pinot-all-${PINOT_VERSION}-jar-with-dependencies.jar`.
+{% hint style="warning" %}
+**`pinot-all` is not enough for MapReduce.** The Hadoop batch plugin lives under `plugins-external/pinot-batch-ingestion/pinot-batch-ingestion-hadoop/` and must be on `HADOOP_CLASSPATH`. Include `plugins-external` in `plugins.dir`.
+{% endhint %}
 
-Sample Hadoop ingestion job spec yaml(also located at `examples/batch/airlineStats/hadoopIngestionJobSpec.yaml`):
+Sample Hadoop ingestion job spec (also at `examples/batch/airlineStats/hadoopIngestionJobSpec.yaml`). For a **local filesystem** dry run, prefer `LocalPinotFS` as below (the checked-in sample may use `HadoopPinotFS` for HDFS-oriented pipelines):
 
 ```
 # executionFrameworkSpec: Defines ingestion jobs to be running.
 executionFrameworkSpec:
 
-  # name: execution framework name
   name: 'hadoop'
 
-  # segmentGenerationJobRunnerClassName: class name implements org.apache.pinot.spi.batch.ingestion.runner.SegmentGenerationJobRunner interface.
   segmentGenerationJobRunnerClassName: 'org.apache.pinot.plugin.ingestion.batch.hadoop.HadoopSegmentGenerationJobRunner'
-
-  # segmentTarPushJobRunnerClassName: class name implements org.apache.pinot.spi.batch.ingestion.runner.SegmentTarPushJobRunner interface.
   segmentTarPushJobRunnerClassName: 'org.apache.pinot.plugin.ingestion.batch.hadoop.HadoopSegmentTarPushJobRunner'
-
-  # segmentUriPushJobRunnerClassName: class name implements org.apache.pinot.spi.batch.ingestion.runner.SegmentUriPushJobRunner interface.
   segmentUriPushJobRunnerClassName: 'org.apache.pinot.plugin.ingestion.batch.hadoop.HadoopSegmentUriPushJobRunner'
+  segmentMetadataPushJobRunnerClassName: 'org.apache.pinot.plugin.ingestion.batch.hadoop.HadoopSegmentMetadataPushJobRunner'
 
-  # extraConfigs: extra configs for execution framework.
   extraConfigs:
-
-    # stagingDir is used in distributed filesystem to host all the segments then move this directory entirely to output directory.
     stagingDir: examples/batch/airlineStats/staging
 
-# jobType: Pinot ingestion job type.
-# Supported job types are:
-#   'SegmentCreation'
-#   'SegmentTarPush'
-#   'SegmentUriPush'
-#   'SegmentCreationAndTarPush'
-#   'SegmentCreationAndUriPush'
 jobType: SegmentCreationAndTarPush
 
-# inputDirURI: Root directory of input data, expected to have scheme configured in PinotFS.
 inputDirURI: 'examples/batch/airlineStats/rawdata'
-
-# includeFileNamePattern: include file name pattern, supported glob pattern.
-# Sample usage:
-#   'glob:*.avro' will include all avro files just under the inputDirURI, not sub directories;
-#   'glob:**\/*.avro' will include all the avro files under inputDirURI recursively.
 includeFileNamePattern: 'glob:**/*.avro'
-
-# excludeFileNamePattern: exclude file name pattern, supported glob pattern.
-# Sample usage:
-#   'glob:*.avro' will exclude all avro files just under the inputDirURI, not sub directories;
-#   'glob:**\/*.avro' will exclude all the avro files under inputDirURI recursively.
-# _excludeFileNamePattern: ''
-
-# outputDirURI: Root directory of output segments, expected to have scheme configured in PinotFS.
+# excludeFileNamePattern: 'glob:**/*.tmp'
 outputDirURI: 'examples/batch/airlineStats/segments'
-
-# overwriteOutput: Overwrite output segments if existed.
 overwriteOutput: true
 
-# pinotFSSpecs: defines all related Pinot file systems.
 pinotFSSpecs:
+  - scheme: file
+    className: org.apache.pinot.spi.filesystem.LocalPinotFS
 
-  - # scheme: used to identify a PinotFS.
-    # E.g. local, hdfs, dbfs, etc
-    scheme: file
-
-    # className: Class name used to create the PinotFS instance.
-    # E.g.
-    #   org.apache.pinot.spi.filesystem.LocalPinotFS is used for local filesystem
-    #   org.apache.pinot.plugin.filesystem.AzurePinotFS is used for Azure Data Lake
-    #   org.apache.pinot.plugin.filesystem.HadoopPinotFS is used for HDFS
-    className: org.apache.pinot.plugin.filesystem.HadoopPinotFS
-
-# recordReaderSpec: defines all record reader
 recordReaderSpec:
-
-  # dataFormat: Record data format, e.g. 'avro', 'parquet', 'orc', 'csv', 'json', 'thrift' etc.
   dataFormat: 'avro'
-
-  # className: Corresponding RecordReader class name.
-  # E.g.
-  #   org.apache.pinot.plugin.inputformat.avro.AvroRecordReader
-  #   org.apache.pinot.plugin.inputformat.csv.CSVRecordReader
-  #   org.apache.pinot.plugin.inputformat.parquet.ParquetRecordReader
-  #   org.apache.pinot.plugin.inputformat.json.JSONRecordReader
-  #   org.apache.pinot.plugin.inputformat.orc.ORCRecordReader
-  #   org.apache.pinot.plugin.inputformat.thrift.ThriftRecordReader
   className: 'org.apache.pinot.plugin.inputformat.avro.AvroRecordReader'
 
-# tableSpec: defines table name and where to fetch corresponding table config and table schema.
 tableSpec:
-
-  # tableName: Table name
   tableName: 'airlineStats'
-
-  # schemaURI: defines where to read the table schema, supports PinotFS or HTTP.
-  # E.g.
-  #   hdfs://path/to/table_schema.json
-  #   http://localhost:9000/tables/myTable/schema
   schemaURI: 'http://localhost:9000/tables/airlineStats/schema'
-
-  # tableConfigURI: defines where to reade the table config.
-  # Supports using PinotFS or HTTP.
-  # E.g.
-  #   hdfs://path/to/table_config.json
-  #   http://localhost:9000/tables/myTable
-  # Note that the API to read Pinot table config directly from pinot controller contains a JSON wrapper.
-  # The real table config is the object under the field 'OFFLINE'.
   tableConfigURI: 'http://localhost:9000/tables/airlineStats'
 
-# segmentNameGeneratorSpec: defines how to init a SegmentNameGenerator.
 segmentNameGeneratorSpec:
-
-  # type: Current supported type is 'simple' and 'normalizedDate'.
   type: normalizedDate
-
-  # configs: Configs to init SegmentNameGenerator.
   configs:
     segment.name.prefix: 'airlineStats_batch'
     exclude.sequence.id: true
 
-# pinotClusterSpecs: defines the Pinot Cluster Access Point.
 pinotClusterSpecs:
-  - # controllerURI: used to fetch table/schema information and data push.
-    # E.g. http://localhost:9000
-    controllerURI: 'http://localhost:9000'
+  - controllerURI: 'http://localhost:9000'
 
-# pushJobSpec: defines segment push job related configuration.
 pushJobSpec:
-
-  # pushParallelism: push job parallelism, default is 1.
   pushParallelism: 2
-
-  # pushAttempts: number of attempts for push job, default is 1, which means no retry.
   pushAttempts: 2
-
-  # pushRetryIntervalMillis: retry wait Ms, default to 1 second.
   pushRetryIntervalMillis: 1000
 ```
 
-Ensure parameter `PINOT_ROOT_DIR` and `PINOT_VERSION` are set properly.
+Ensure `PINOT_ROOT_DIR` and `PINOT_VERSION` are set properly.
 
 ```
 export PINOT_VERSION=1.5.1 #set to the Pinot version you have installed
 export PINOT_DISTRIBUTION_DIR=${PINOT_ROOT_DIR}/build/
-export HADOOP_CLIENT_OPTS="-Dplugins.dir=${PINOT_DISTRIBUTION_DIR}/plugins -Dlog4j2.configurationFile=${PINOT_DISTRIBUTION_DIR}/conf/pinot-ingestion-job-log4j2.xml"
-hadoop jar  \
-        ${PINOT_DISTRIBUTION_DIR}/lib/pinot-all-${PINOT_VERSION}-jar-with-dependencies.jar \
+
+HADOOP_BATCH_PLUGIN=${PINOT_DISTRIBUTION_DIR}/plugins-external/pinot-batch-ingestion/pinot-batch-ingestion-hadoop/pinot-batch-ingestion-hadoop-${PINOT_VERSION}-shaded.jar
+PINOT_ALL_JAR=${PINOT_DISTRIBUTION_DIR}/lib/pinot-all-${PINOT_VERSION}-jar-with-dependencies.jar
+
+export HADOOP_CLIENT_OPTS="-Dplugins.dir=${PINOT_DISTRIBUTION_DIR}/plugins;${PINOT_DISTRIBUTION_DIR}/plugins-external -Dlog4j2.configurationFile=${PINOT_DISTRIBUTION_DIR}/conf/pinot-ingestion-job-log4j2.xml"
+export HADOOP_CLASSPATH="${HADOOP_BATCH_PLUGIN}:${PINOT_ALL_JAR}:${HADOOP_CLASSPATH}"
+
+hadoop jar \
+        ${PINOT_ALL_JAR} \
         org.apache.pinot.tools.admin.command.LaunchDataIngestionJobCommand \
         -jobSpecFile ${PINOT_DISTRIBUTION_DIR}/examples/batch/airlineStats/hadoopIngestionJobSpec.yaml
 ```
+
+{% hint style="warning" %}
+**Troubleshooting `ClassNotFoundException`:** add `plugins-external` to `plugins.dir` and put `pinot-batch-ingestion-hadoop-*-shaded.jar` on `HADOOP_CLASSPATH`. See [Hadoop batch ingestion](../../build-with-pinot/ingestion/batch-ingestion/hadoop.md).
+{% endhint %}
 
 ## Executing a backfill ingestion job
 
@@ -595,12 +474,12 @@ For the full step-by-step workflow, supported options (including `-partitionColu
 You can set Environment Variable: `JAVA_OPTS` to modify:
 
 * Log4j2 file location with `-Dlog4j2.configurationFile`
-* Plugin directory location with `-Dplugins.dir=/opt/pinot/plugins`
+* Plugin directory location with `-Dplugins.dir=/opt/pinot/plugins` (standalone). For Spark/Hadoop batch jobs, use a semicolon-separated list that also includes `plugins-external`: `-Dplugins.dir=/opt/pinot/plugins;/opt/pinot/plugins-external`
 * JVM props, like `-Xmx8g -Xms4G`
 
 Note that you need to config above three all together in `JAVA_OPTS`. If you only config `JAVA_OPTS="-Xmx4g"` then `plugins.dir` is empty usually will cause job failure.
 
-E.g.
+E.g. standalone Docker job:
 
 ```
 docker run --rm -ti -e JAVA_OPTS="-Xms8G -Dlog4j2.configurationFile=/opt/pinot/conf/pinot-admin-log4j2.xml  -Dplugins.dir=/opt/pinot/plugins" --name pinot-data-ingestion-job apachepinot/pinot:latest LaunchDataIngestionJob -jobSpecFile /path/to/ingestion_job_spec.yaml


### PR DESCRIPTION
## Summary

Fixes batch ingestion onboarding docs so Spark/Hadoop runners load from `plugins-external` and local tutorials actually work without ClassNotFoundException.

**Issues:** Fixes apache/pinot#14234, Fixes apache/pinot#9923

---

## What is the problem?

1. **#14234 — wrong plugin directory:** Spark and Hadoop batch ingestion plugins ship under **`plugins-external/`** in the binary distribution (`pinot-assembly.xml`), not under plain `plugins/`. Docs and recipes that only set `plugins.dir` to `plugins` fail to load runners such as `SparkSegmentGenerationJobRunner` → classic **ClassNotFoundException** wall for new users.
2. **#9923 — broken local batch tutorial:** Tutorials implied `pinot-all-*-jar-with-dependencies.jar` alone was enough for batch jobs. It is not: external batch plugins are not embedded in `pinot-all`. Sample docs also still pointed at old `org.apache.pinot.plugin.ingestion.batch.spark.*` packages; current Spark 3 runners live under **`spark3`**.
3. Result: users cannot complete a local batch path without tribal knowledge, which blocks evaluation and DE onboarding.

---

## Why did I do this?

Batch ingestion is a primary data-engineering entry point. Fixing the classpath/`plugins.dir` story and giving a working local-FS recipe (no cloud credentials) is low effort relative to the number of people who hit ClassNotFound on day one. Source of truth is already in assembly layout + `PluginManager` (semicolon-separated plugin dirs).

---

## What is the implementation edit?

| File | Change |
|------|--------|
| `build-with-pinot/ingestion/batch-ingestion/spark.md` | `plugins.dir=${DIST}/plugins;${DIST}/plugins-external`; shaded spark-3 jar on classpath; `spark3.*` runners; ClassNotFound FAQ |
| `build-with-pinot/ingestion/batch-ingestion/hadoop.md` | Same pattern for Hadoop plugin + `HADOOP_CLASSPATH` |
| `build-with-pinot/ingestion/batch-ingestion/README.md` | Note that batch plugins are external |
| `tutorials/data-ingestion/batch-data-ingestion-in-practice.md` | Major rewrite: replace “pinot-all is enough”; local-FS Spark/Hadoop recipes; `LocalPinotFS`; path-pattern comments; troubleshooting |

**Design choices documented:**

- `PluginManager` splits `plugins.dir` on `;` so built-in formats **and** external batch runners load.
- Explicit shaded jars on Spark / `HADOOP_CLASSPATH` because **`pinot-all` does not embed batch external plugins**.
- Local recipes use `LocalPinotFS` + bundled `airlineStats` sample data.

**Intentionally not done:** changing `pinot-admin.sh` defaults; rewriting every S3 deep-store tutorial still on old package names (follow-up).

---

## What is the impact?

- **Users:** Can run local batch Spark/Hadoop segment generation without ClassNotFound.
- **Ops/DE:** Correct `plugins.dir` and package names reduce failed job submissions.
- **Risk:** Docs-only. Some pages still show older package names outside this file set — called out as leftover, not a regression of this PR.
- **Overlap:** `spark.md` / `hadoop.md` may also be touched by the path-matcher docs PR; both changes are meant to land (complementary sections).

---

## What is the testing edit?

- Docs validator on changed files — **PASS**.
- Manual consistency check against `pinot-assembly.xml` / plugin layout and current `spark3` package names in the Pinot tree.
- No multi-node Spark cluster E2E in CI for this docs PR (by design of the low-effort plan).

---

## Checklist

- [x] Draft for review
- [x] Issue links
- [ ] Optional maintainer pass on Spark 3.x version pins in examples
