### PR TITLE
docs: realtime segment flush threshold precedence (#7785)

### DIFF
--- a/operate-pinot/tuning/realtime.md
+++ b/operate-pinot/tuning/realtime.md
@@ -24,7 +24,51 @@ If you don't want to use memory-mapping, set `pinot.server.instance.realtime.all
 
 The number of rows in a consuming segment needs to be balanced. Having too many rows can result in memory pressure. On the other hand, having too few rows results in having too many small segments. Having too many segments can be detrimental to query performance, and also increase pressure on the Helix.
 
-The recommended way to do this is to use the `realtime.segment.flush.threshold.segment.size` setting as described in [StreamConfigs Section](../../reference/configuration-reference/table.md#real-time-table-config). You can run the administrative tool `pinot-admin.sh RealtimeProvisioningHelper` that will help you to come up with an optimal setting for the segment size.
+The recommended way to do this is to use the `realtime.segment.flush.threshold.segment.size` setting as described in [StreamConfigs Section](../../reference/configuration-reference/table.md#real-time-table-config) and the [flush threshold precedence](#realtime-segment-flush-threshold-precedence) section below. You can run the administrative tool `pinot-admin.sh RealtimeProvisioningHelper` that will help you to come up with an optimal setting for the segment size.
+
+### Realtime segment flush threshold precedence
+
+A consuming segment flushes (commits) when the **first** applicable end criterion is met. Under the hood Pinot only enforces two runtime checks on the server:
+
+1. **Rows threshold** — checked as rows are indexed. When the segment reaches its per-segment row limit, it flushes.
+2. **Time threshold** — checked periodically. When the segment has been consuming longer than `realtime.segment.flush.threshold.time` **and** at least one stream message has been fetched, it flushes. If no events have arrived yet, Pinot extends the time window rather than committing an empty segment.
+
+`realtime.segment.flush.threshold.segment.size` (desired completed-segment size) is **not** a third independent check on the server. The controller converts desired size into a **rows** threshold for the next consuming segment, using observed sizes from previous completions. That converted rows value then participates in the rows check above.
+
+#### How the controller chooses the rows threshold
+
+| Config | When it applies | Effect |
+| --- | --- | --- |
+| `realtime.segment.flush.threshold.rows` > `0` | Highest precedence | Fixed table-level rows budget. Each consuming segment on a server gets roughly `rows / maxPartitionsConsumedByServer`. **Desired size is ignored.** |
+| `realtime.segment.flush.threshold.segment.rows` > `0` (and table-level rows not > 0) | Next | Fixed per-segment rows threshold (not divided by partition count). Desired size is ignored. |
+| `realtime.segment.flush.threshold.rows` = `0` (or desired size is set while rows is unset/`0`) | Size-based autotune | Controller learns rows↔size from completed segments and sets the next segment's rows threshold to aim for `realtime.segment.flush.threshold.segment.size` (default **200M** when size-based mode is active and size is unset). |
+| None of the above | Fallback | Default table-level rows of **5,000,000**, divided across partitions on the server. |
+
+**Key exception:** desired size is effective only when the table-level rows threshold is `0` (or otherwise not positive). If you set rows to a positive value **and** a desired size, Pinot uses the rows path and does not autotune toward the size.
+
+#### Size-based autotune behavior
+
+When size-based mode is on:
+
+* The **first** segment starts from `realtime.segment.flush.autotune.initialRows` (default **100,000**), not from the final desired size.
+* After each successful completion, the controller updates a weighted rows-to-size ratio and ramps the next segment's rows threshold toward the desired size (with min/max guards so it does not jump wildly).
+* It can take several segment completions before completed sizes stabilize near the target.
+* Force-committed segments are skipped when updating the size ratio so an early operator-driven commit does not poison the estimate.
+* Time threshold still wins if it is hit first; when a segment hits time before rows, the controller may only slightly bump the next rows target.
+
+Always set a **time** threshold as a safety net, even when using size-based autotune. The time value must be smaller than the stream retention for the topic.
+
+#### Practical recommendation
+
+For most realtime tables:
+
+```json
+"realtime.segment.flush.threshold.rows": "0",
+"realtime.segment.flush.threshold.time": "24h",
+"realtime.segment.flush.threshold.segment.size": "200M"
+```
+
+Tune the time and size with `RealtimeProvisioningHelper` and production memory observations. See also the [ingestion stream config reference](../../reference/configuration-reference/ingestion.md#streamconfigmaps).
 
 ### Moving completed segments to different hosts
 

--- a/reference/configuration-reference/ingestion.md
+++ b/reference/configuration-reference/ingestion.md
@@ -88,14 +88,38 @@ In this example, Pinot converts `ts` to `LONG` before `toEpochDays(ts)` runs. It
 | `realtime.segment.offsetAutoReset.timeThresholdSeconds` | If positive, Pinot resets the next segment to the latest stream offset when the next offset is older than this many seconds at commit time. Pinot compares the next offset against the stream position at `now - threshold`. | Long. Default is `-1` (disabled). |
 | `stopOnDecodeError` | When set to `true`, consumption stops with an error if a decode error occurs. When set to `false` (default), decode errors are logged and the problematic row is silently dropped. | Boolean. Default is `false`. |
 
-{% hint style="info" %}
-The number of rows per segment is computed using the following formula: `realtime.segment.flush.threshold.rows / maxPartitionsConsumedByServer` For example, if you set `realtime.segment.flush.threshold.rows = 1000` and each server consumes 10 partitions, the rows per segment is `1000/10 = 100`.
+### Flush threshold precedence
+
+A consuming segment commits when the **first** of these runtime conditions is met:
+
+1. Its **rows** threshold (the per-segment value written into segment ZK metadata).
+2. Its **time** threshold (`realtime.segment.flush.threshold.time`), once at least one stream message has been fetched.
+
+Desired completed size is **not** checked independently on the server. When size-based mode is active, the controller translates `realtime.segment.flush.threshold.segment.size` into the next segment's **rows** threshold using observed completed-segment sizes. See [Realtime segment flush threshold precedence](../../operate-pinot/tuning/realtime.md#realtime-segment-flush-threshold-precedence) for the full operator guide.
+
+How the controller chooses the rows threshold:
+
+| Condition | Updater | Per-segment rows |
+| --- | --- | --- |
+| `realtime.segment.flush.threshold.rows` > `0` | Default | `rows / maxPartitionsConsumedByServer`. Desired size is ignored. |
+| `realtime.segment.flush.threshold.segment.rows` > `0` (and table-level rows not positive) | Fixed | Exactly `segment.rows` (not divided by partition count). Desired size is ignored. |
+| `realtime.segment.flush.threshold.rows` = `0` (legacy: size-based when rows is explicitly zero) or desired size is set while rows is not positive | Size-based | Autotuned toward `realtime.segment.flush.threshold.segment.size` (default **200M** in size-based mode). Starts from `realtime.segment.flush.autotune.initialRows` (default **100,000**) and ramps over completions. |
+| None set | Default | Table-level **5,000,000** rows, divided by partitions on the server. |
+
+{% hint style="warning" %}
+**Desired size requires non-positive table-level rows.** If `realtime.segment.flush.threshold.rows` is a **positive** value, Pinot never applies size-based autotune, regardless of `realtime.segment.flush.threshold.segment.size`. Size-based mode applies when rows is explicitly `0`, or when rows is unset and a desired segment size is set (see the table above). The usual recipe is still `rows=0` plus a time safety net and `segment.size`.
 {% endhint %}
 
 {% hint style="info" %}
-Since `release-1.2.0`, we introduced `realtime.segment.flush.threshold.segment.rows`, which is directly used as the number of rows per segment.
+Example for table-level rows: if you set `realtime.segment.flush.threshold.rows = 1000` and each server consumes 10 partitions, the rows per segment is `1000/10 = 100`.
+{% endhint %}
 
-Take the above example, if you set `realtime.segment.flush.threshold.segment.rows = 1000` and each server consumes 10 partitions, the rows per segment is `1000`.
+{% hint style="info" %}
+Since `release-1.2.0`, `realtime.segment.flush.threshold.segment.rows` is used directly as the number of rows per segment (not divided by partition count). With `segment.rows = 1000` and 10 partitions on a server, each segment still uses `1000`.
+{% endhint %}
+
+{% hint style="info" %}
+**Recommended starting point:** `rows=0`, a safety `time` (for example `24h`, less than stream retention), and `segment.size` around `200M`. Adjust with [RealtimeProvisioningHelper](../../operate-pinot/tuning/realtime.md) after you have a sample segment.
 {% endhint %}
 
 {% hint style="info" %}

--- a/reference/configuration-reference/table.md
+++ b/reference/configuration-reference/table.md
@@ -476,6 +476,10 @@ The examples below use some legacy configuration patterns for familiarity. In ne
 
 Here's an example table config for a real-time table. **All the fields from the offline table config are valid for the real-time table**. Additionally, real-time tables use **some extra fields**.
 
+{% hint style="info" %}
+Flush keys such as `realtime.segment.flush.threshold.rows`, `realtime.segment.flush.threshold.time`, and `realtime.segment.flush.threshold.segment.size` live under `ingestionConfig.streamIngestionConfig.streamConfigMaps`. The first threshold that is met flushes the consuming segment; desired size is used when table-level rows is **not positive** (explicit `0` or unset) and size-based autotune is selected. Full precedence and tuning guidance: [Realtime segment flush threshold precedence](../../operate-pinot/tuning/realtime.md#realtime-segment-flush-threshold-precedence) and [Ingestion stream configs](ingestion.md#streamconfigmaps).
+{% endhint %}
+
 {% code title="pinot-table-realtime.json" %}
 ```json
 "REALTIME": {


### PR DESCRIPTION
## Summary

Documents realtime segment flush threshold **precedence** so operators stop guessing which of rows / time / desired size wins.

**Issue:** Fixes apache/pinot#7785

---

## What is the problem?

Realtime tables expose multiple flush knobs:

- `realtime.segment.flush.threshold.rows`
- `realtime.segment.flush.threshold.time`
- `realtime.segment.flush.threshold.segment.size` (desired completed size; deprecated alias `desired.size`)

Operators set all three without knowing **which wins**. Wrong combinations cause:

- **Tiny segment storms** (too-low rows or time) → metadata pressure, poor query fan-out.
- **Huge memory / long flush pauses** (too-high rows or misunderstood desired size) → GC and consumption stalls.

Desired size is **not** a third independent server-side check; it is converted into a rows target by controller autotune, and only when table-level rows is non-positive. That nuance was missing or oversimplified in configuration reference pages.

---

## Why did I do this?

Maintainer answers already existed on the issue; the gap was structured, cross-linked operator docs. Flush tuning is core DE/ops work and a frequent source of production pain. Source anchors: `FlushThresholdUpdateManager`, size-based flush computer tests, and existing issue discussion.

---

## What is the implementation edit?

| File | Change |
|------|--------|
| `operate-pinot/tuning/realtime.md` | Canonical **precedence** section + practical recommendation (`rows=0`, time safety net, desired size e.g. `200M`) |
| `reference/configuration-reference/ingestion.md` | Flush threshold table under stream configs; warning aligned with code (desired size when rows **not positive**, not only literal `0`) |
| `reference/configuration-reference/table.md` | Info hint + cross-link from RT sample config |

**Behavioral facts documented:**

1. At runtime, **first of rows threshold or time threshold** flushes the consuming segment.
2. Desired size is controller autotune → rows, not a third server race.
3. Size-based path when rows is `0` **or** unset while size is set; positive rows disables size autotune.
4. Autotune starts around ~100k rows (`autotune.initialRows`) and ramps over completions; time is the safety net.

---

## What is the impact?

- **Ops:** Can pick a coherent default and understand why desired size “did nothing” when rows > 0.
- **Risk:** Docs-only. Wording carefully matches `FlushThresholdUpdateManager` (including unset rows = -1 path).
- **No code change.**

---

## What is the testing edit?

- Docs validator — **PASS**.
- Source-read verification against `FlushThresholdUpdateManager.getFlushThresholdUpdater`.
- No new unit tests (docs-only).

---

## Checklist

- [x] Draft
- [x] Cross-links between tuning + config reference
