### PR TITLE
docs: document forceCommit controller API (#11212)

### DIFF
--- a/build-with-pinot/ingestion/stream-ingestion/README.md
+++ b/build-with-pinot/ingestion/stream-ingestion/README.md
@@ -501,6 +501,13 @@ There is another feature called `Force Commit` which utilizes the primitives of 
 $ curl -X POST {controllerHost}/tables/{tableName}/forceCommit
 ```
 
+Optional filters and batching (do not combine `partitions` and `segments`):
+
+```bash
+$ curl -X POST "{controllerHost}/tables/{tableName}/forceCommit?partitions=0,1&batchSize=50&batchStatusCheckIntervalSec=5&batchStatusCheckTimeoutSec=180"
+$ curl -X POST "{controllerHost}/tables/{tableName}/forceCommit?segments=table__0__12__20250610T2140Z,table__1__12__20250610T2140Z"
+```
+
 Real-time tables can also be paused automatically by Pinot itself. In particular, when a table exceeds `quota.storage`, the controller marks it paused with reason code `STORAGE_QUOTA_EXCEEDED` and stops creating new consuming segments during periodic validation. Once the table is back within quota, Pinot clears that pause state and allows segment creation to resume. If you want to resume sooner after fixing the quota issue, you can still call `resumeConsumption` manually.
 
 (v 0.12.0+) Once submitted, the forceCommit API returns a jobId that can be used to get the current progress of the forceCommit operation. A sample response and status API call:
@@ -526,9 +533,13 @@ $ curl -X GET {controllerHost}/tables/forceCommitStatus/6757284f-b75b-45ce-91d8-
 ```
 
 {% hint style="info" %}
-The forceCommit request just triggers a regular commit before the consuming segments reaching the end criteria, so it follows the same mechanism as regular commit. It is one-time shot request, and not retried automatically upon failure. But it is idempotent so one may keep issuing it till success if needed.
+The forceCommit request just triggers a regular commit before the consuming segments reach the end criteria, so it follows the same mechanism as regular commit. It is a one-shot request and is not retried automatically upon failure. It is idempotent enough that you may keep issuing it until success if needed.
 
-This API is async, as it doesn't wait for the segment commit to complete. But a status entry is put in ZK to track when the request is issued and the consuming segments included. The consuming segments tracked in the status entry are compared with the latest IdealState to indicate the progress of forceCommit. However, this status is not updated or deleted upon commit success or failure, so that it could become stale. Currently, the most recent 100 status entries are kept in ZK, and the oldest ones only get deleted when the total number is about to exceed 100.
+**HTTP 200 is async acceptance**, not proof that commits finished. `forceCommitStatus=SUCCESS` means the controller initiated the operation; wait until `numberOfSegmentsYetToBeCommitted` is `0` on the status API. `jobMetaZKWriteStatus=FAILED` means commit may still run but Pinot could not persist a trackable job id.
+
+A ZK status entry records submission time and the consuming segments included. Pending progress is derived by comparing that list to the latest IdealState / metadata. The status entry is not deleted on success or failure and can become stale; Pinot keeps a bounded number of force-commit jobs in ZK (default 100 via `controller.force.commit.maxJobsInZK`).
+
+Full parameter tables, mutual exclusion of `partitions` vs `segments`, and failure modes: [Force commit API](../../../reference/api-reference/controller-api.md#post-tablestablenameforcecommit).
 {% endhint %}
 
 For incompatible parameter changes, an option is added to the resume request to handle the case of a completely new set of offsets. Operators can now follow a three-step process: First, issue a pause request. Second, change the consumption parameters. Finally, issue the resume request with the appropriate option. These steps will preserve the old data and allow the new data to be consumed immediately. All through the operation, queries will continue to be served.

--- a/operate-pinot/segment-lifecycle-and-repair.md
+++ b/operate-pinot/segment-lifecycle-and-repair.md
@@ -140,20 +140,23 @@ For real-time tables, consider running a [force commit](#force-commit-consuming-
 
 ## Force commit consuming segments
 
-**What it does.** Forces all (or selected) consuming segments on a real-time table to seal and commit as completed segments, then restarts consumption from the stream at the current offset. The operation is asynchronous and returns a job ID.
+**What it does.** Forces all (or selected) consuming segments on a real-time table to seal and commit as completed segments, then restarts consumption from the stream at the current offset. The operation is asynchronous: HTTP 200 means the controller accepted the request and (usually) wrote a job id, not that every segment has finished committing.
 
 **When to use it.** Use force commit in two main scenarios:
 
-1. **After a schema or table-config change on a real-time table.** Consuming segments were built with the old config. Force-committing them and allowing fresh consuming segments to start ensures new data is ingested under the updated schema.
+1. **After a schema or table-config change on a real-time table.** Consuming segments were built with the old config. Force-committing them and allowing fresh consuming segments to start ensures new data is ingested under the updated schema. See [Schema evolution](../build-with-pinot/data-modeling/schema-evolution.md).
 2. **Before a rebalance of a real-time table.** Rebalance works on completed segments. Force commit converts consuming segments so they are included in the rebalance plan.
 
 **API.**
 
 ```
 POST /tables/{tableName}/forceCommit
+GET  /tables/forceCommitStatus/{jobId}
 ```
 
-Optional query parameters: `partitions`, `segments`, `batchSize`.
+Optional query parameters on `forceCommit`: `partitions`, `segments` (mutually exclusive), `batchSize`, `batchStatusCheckIntervalSec`, `batchStatusCheckTimeoutSec`.
+
+Poll until `numberOfSegmentsYetToBeCommitted` is `0`. Full request/response fields and failure modes: [Force commit API](../reference/api-reference/controller-api.md#post-tablestablenameforcecommit).
 
 ## Purge records from segments
 

--- a/reference/api-reference/controller-api.md
+++ b/reference/api-reference/controller-api.md
@@ -1625,6 +1625,129 @@ curl -X GET "http://localhost:9000/tables/myTable/pauseStatus" -H "accept: appli
 }
 ```
 
+### POST /tables/\<tableName>/forceCommit
+
+Force the current **CONSUMING** segments of a realtime table to commit immediately and start new consuming segments. Use this after compatible schema or table-config changes so the next consuming segments pick up the new settings, or before a rebalance when you want consuming segments sealed first.
+
+{% hint style="warning" %}
+**HTTP 200 means the request was accepted**, not that every segment has finished committing. Force commit is asynchronous. Use [GET /tables/forceCommitStatus/\{jobId\}](#get-tablesforcecommitstatusjobid) to track progress.
+{% endhint %}
+
+| Query parameter | Type | Meaning |
+| --- | --- | --- |
+| `partitions` | string | Optional comma-separated partition group IDs. Only consuming segments for those partitions are force-committed. |
+| `segments` | string | Optional comma-separated consuming segment names. Only those segments are force-committed (non-consuming names are ignored with a warning in controller logs). |
+| `batchSize` | integer | Maximum number of consuming segments to commit per batch. Default: all target segments in one batch (`Integer.MAX_VALUE`). Must be > `0`. |
+| `batchStatusCheckIntervalSec` | integer | How often, in seconds, the controller checks whether the current batch has finished before starting the next batch. Default: `5`. Must be > `0`. |
+| `batchStatusCheckTimeoutSec` | integer | How long, in seconds, the controller waits for a batch to finish before failing the in-progress batch wait. Default: `180`. Must be > `0`. |
+
+**Mutual exclusion:** do **not** pass `partitions` and `segments` together. Pinot returns `400 Bad Request` with `Cannot specify both partitions and segments to commit`.
+
+When neither filter is set, Pinot force-commits **all** consuming segments for the table. With `batchSize` smaller than the number of targets, the controller commits segments in sequential batches (spread across servers) and waits for each batch using the interval/timeout above. That batch wait runs **asynchronously after** the HTTP accept (on a background executor); the POST still returns immediately with a `forceCommitJobId` — use forceCommitStatus to observe completion.
+
+**Request**
+
+```bash
+curl -X POST "http://localhost:9000/tables/myTable/forceCommit" -H "accept: application/json"
+```
+
+Partition filter:
+
+```bash
+curl -X POST "http://localhost:9000/tables/myTable/forceCommit?partitions=0,1,2" \
+  -H "accept: application/json"
+```
+
+Segment filter with batching:
+
+```bash
+curl -X POST "http://localhost:9000/tables/myTable/forceCommit?segments=myTable__0__12__20250610T2140Z,myTable__1__12__20250610T2140Z&batchSize=50&batchStatusCheckIntervalSec=5&batchStatusCheckTimeoutSec=180" \
+  -H "accept: application/json"
+```
+
+**Success response fields**
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `forceCommitStatus` | string | `SUCCESS` when the controller successfully initiated force commit (messages sent / batches scheduled). Does **not** mean all segments are already ONLINE. |
+| `jobMetaZKWriteStatus` | string | `SUCCESS` if Pinot wrote force-commit job metadata to ZooKeeper; `FAILED` if commit was initiated but the ZK job record could not be stored (you will not get a trackable `forceCommitJobId`). |
+| `forceCommitJobId` | string | UUID used with the status API. Present only when `jobMetaZKWriteStatus` is `SUCCESS`. |
+
+**Example response**
+
+```json
+{
+  "forceCommitJobId": "6757284f-b75b-45ce-91d8-a277bdbc06ae",
+  "forceCommitStatus": "SUCCESS",
+  "jobMetaZKWriteStatus": "SUCCESS"
+}
+```
+
+**Failure modes**
+
+| Situation | Typical HTTP status | Notes |
+| --- | --- | --- |
+| Table missing or no IdealState | `404` | `Table {name}_REALTIME not found!` |
+| Table disabled | `400` | Table exists but is disabled. |
+| Both `partitions` and `segments` set | `400` | Conflicting filters. |
+| Non-positive `batchSize` / interval / timeout | `400` | `Invalid batch config`. |
+| Partial-upsert tables, or upsert tables with out-of-order drop/column settings, when cluster consistency mode disallows force commit | `500` | Controller rejects force commit to avoid inconsistent upsert metadata unless `pinot.server.consuming.segment.consistency.mode` allows it (for example `PROTECTED`). |
+| No force-commit message could be sent | `500` | Internal error from the realtime segment manager. |
+| ZK job metadata write fails | `200` with `jobMetaZKWriteStatus=FAILED` | Commit may still be in flight; progress tracking via job id is unavailable. |
+
+Force commit is a one-shot request (not auto-retried). It is idempotent enough that you can re-issue it if needed. It triggers the same commit path as a normal end-of-segment commit, just earlier than the rows/time thresholds.
+
+For operational context (pause/resume interaction, schema evolution), see [Pause stream ingestion](../../build-with-pinot/ingestion/stream-ingestion/README.md#pause-stream-ingestion) and [Schema evolution](../../build-with-pinot/data-modeling/schema-evolution.md).
+
+### GET /tables/forceCommitStatus/\{jobId\}
+
+Return progress for a force-commit job previously accepted by `POST /tables/{tableName}/forceCommit`.
+
+**Request**
+
+```bash
+curl -X GET "http://localhost:9000/tables/forceCommitStatus/6757284f-b75b-45ce-91d8-a277bdbc06ae" \
+  -H "accept: application/json"
+```
+
+**Response fields**
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `jobId` | string | Force-commit job UUID. |
+| `tableName` | string | Realtime table name with type (for example `myTable_REALTIME`). |
+| `jobType` | string | `FORCE_COMMIT`. |
+| `submissionTimeMs` | string | Epoch millis when the controller accepted the job. |
+| `segmentsForceCommitted` | string (JSON array) | Snapshot of consuming segment names for which commit was **initiated** at submission time. |
+| `segmentsYetToBeCommitted` | array of strings | Subset of the tracked segments that are **still** pending commit when you poll. Empty means all tracked segments have left the pending set. |
+| `numberOfSegmentsYetToBeCommitted` | integer | Count of `segmentsYetToBeCommitted`. Use this as the primary progress signal (`0` ≈ complete for the segments this job tracks). |
+
+**How pending is computed:** the controller compares the job's segment list with the current IdealState / segment metadata. Segments that have not yet finished committing remain in `segmentsYetToBeCommitted`. Successful polls may persist an updated pending list back to ZK.
+
+{% hint style="info" %}
+Job metadata is **not** deleted when the commit finishes. Entries can look stale if you inspect them long after completion. Pinot retains a bounded number of force-commit job records in ZK (default **100**, controlled by `controller.force.commit.maxJobsInZK`); older entries are evicted when the limit would be exceeded.
+{% endhint %}
+
+**Example response (in progress)**
+
+```json
+{
+  "jobId": "6757284f-b75b-45ce-91d8-a277bdbc06ae",
+  "segmentsForceCommitted": "[\"myTable__0__12__20250610T2140Z\",\"myTable__1__12__20250610T2140Z\"]",
+  "submissionTimeMs": "1674111682977",
+  "numberOfSegmentsYetToBeCommitted": 1,
+  "jobType": "FORCE_COMMIT",
+  "segmentsYetToBeCommitted": ["myTable__1__12__20250610T2140Z"],
+  "tableName": "myTable_REALTIME"
+}
+```
+
+**Failure modes**
+
+| Situation | Typical HTTP status | Notes |
+| --- | --- | --- |
+| Unknown `jobId` | `404` | `Failed to find controller job id: ...` (never written, already evicted, or ZK write failed at submit time). |
+
 ### GET /tables/\<tableName>/badLLCSegmentsPerPartition
 
 Return the bad LLC segments for a realtime table, grouped by partition ID. Pinot sorts the segment names within each partition by increasing sequence number, which makes this endpoint useful before calling repair workflows such as `deleteSegmentsFromSequenceNum`.


### PR DESCRIPTION
## Summary

Adds user-facing documentation for the realtime **forceCommit** controller API (parameters, async semantics, status polling, failure modes).

**Issue:** Fixes apache/pinot#11212

---

## What is the problem?

Force-commit is central when applying schema/config changes on consuming tables (seal mutable segments so new consumers pick up the latest plan). The API existed in controller code (`PinotRealtimeTableResource`) without complete user-facing docs of:

- Query parameters and mutual exclusion (`partitions` vs `segments`)
- That **HTTP 200 is async accept**, not “all segments committed”
- How to poll `forceCommitStatus/{jobId}`
- Failure modes (missing table, bad batch config, ZK issues, partial-upsert consistency gates)

Operators either avoided the API or misread 200 as completion.

---

## Why did I do this?

Schema evolution and ops runbooks depend on force-commit. Documenting the real async contract prevents premature “done” signals and partial schema rollouts. Low effort: transcription from annotations + manager behavior already in tree.

---

## What is the implementation edit?

| File | Change |
|------|--------|
| `reference/api-reference/controller-api.md` | Full `POST /tables/{tableName}/forceCommit` + `GET /tables/forceCommitStatus/{jobId}` docs; params table; response fields; failure modes; note that batch waits run on a background executor after accept |
| `build-with-pinot/ingestion/stream-ingestion/README.md` | Ops section expanded + API link |
| `operate-pinot/segment-lifecycle-and-repair.md` | Params/status cross-link |

**Documented surface:**

- Params: `partitions`, `segments`, `batchSize`, `batchStatusCheckIntervalSec`, `batchStatusCheckTimeoutSec`
- Mutual exclusion: partitions vs segments
- Response: `forceCommitStatus`, `jobMetaZKWriteStatus`, `forceCommitJobId`

---

## What is the impact?

- **Ops:** Correct async mental model; status polling path is discoverable.
- **Risk:** Docs-only; verified against `PinotRealtimeTableResource` / LLC manager behavior.
- Complements schema-evolution docs (separate PR) that link here.

---

## What is the testing edit?

- Docs validator — **PASS**.
- Source consistency check against controller resource annotations and force-commit status endpoint.
- No new automated API tests in this docs PR.

---

## Checklist

- [x] Draft
- [x] Async 200 called out prominently
