### PR TITLE
docs: schema evolution runbook for consuming/upsert tables (#12652)

### DIFF
--- a/build-with-pinot/data-modeling/schema-evolution.md
+++ b/build-with-pinot/data-modeling/schema-evolution.md
@@ -16,18 +16,87 @@ Renaming a column, dropping a column, or changing a column type is not a small s
 
 ## Typical flow
 
-1. Add the new column to the schema.
-2. Update the table config or ingestion config if the new field needs transforms.
-3. Reload the affected segments.
-4. Backfill historical data if the use case needs it.
+1. Add the new column to the schema (with an appropriate `defaultNullValue` when older rows should show a default).
+2. Update the table config or ingestion config if the new field needs transforms, indexes, or upsert strategy entries.
+3. Ensure **new consuming segments** start with the updated schema. For an explicit barrier, call [forceCommit](../../reference/api-reference/controller-api.md#post-tablestablenameforcecommit) and poll its status; for transform changes, prefer the pause procedure below.
+4. Reload completed segments after that boundary so the segments committed under the old plan also expose the new column metadata (filled with `defaultNullValue` unless you backfill).
+5. Backfill historical data if the use case needs real values instead of defaults (offline / hybrid path).
+
+## Realtime consuming segments: when to pause, reload, or force commit
+
+Older docs sometimes said “always pause consumption when adding a column.” That is stronger than necessary. Consuming segments are built with the schema and table config that were current when the mutable segment started. Rows already indexed in that mutable segment are not rewritten in place when you change the schema. The practical goal is:
+
+* **Completed (immutable) segments** — reload so the new column appears (typically as `defaultNullValue`).
+* **In-flight consuming segments** — commit them and start new consumers that load the latest schema/config.
+* **Transforms / derived columns** — stop the old consumer from continuing with the transform plan it loaded when the mutable segment started.
+
+Server reload of a consuming segment **requests a force commit** when `pinot.server.instance.reload.consumingSegment` is `true` (the default). The consumer seals asynchronously and a replacement consumer then starts with the latest schema and table config. Reload job completion is not a hard barrier that new consumers are already ONLINE. For an explicit barrier, call `POST /tables/{tableName}/forceCommit` and poll status; see the [force commit API](../../reference/api-reference/controller-api.md#post-tablestablenameforcecommit).
+
+### Decision table (add a column on an existing table)
+
+| Table situation | Risk if you only update schema and wait | Recommended steps |
+| --- | --- | --- |
+| **OFFLINE only** | None for stream consumers | Update schema → [reload segments](../../operate-pinot/segment-reload.md) → backfill/repush if you need non-default values. |
+| **Realtime, plain column** (present in the stream or filled only via `defaultNullValue`; no new transform) | Current consuming segment keeps the old schema until it commits; queries on that mutable segment may omit the column or use a virtual default | 1) Update schema 2) `POST /segments/{table}/reload` (consuming reload requests a force commit when enabled) **or** `POST /tables/{table}/forceCommit` and poll it 3) Reload completed segments when they need physical column metadata or new indexes 4) Optional offline backfill for history |
+| **Realtime with ingestion transforms** (new column populated by `transformConfigs` / Groovy / built-ins, or transform logic changes) | High: the active consumer keeps using its old transform plan, so the segment can contain incorrect or missing derived values | 1) Prefer **pause and wait for completion** → apply schema + table config → reload completed segments → **resume** (clean boundary), **or** 2) apply schema/config → **forceCommit and poll** → reload the segments committed under the old plan 3) Do not assume rows already indexed by the old consumer are repaired in place |
+| **Realtime full upsert** | Same consumer-boundary issue as plain RT for an additive column; standard full-upsert metadata remains valid across a normal force commit | Follow the plain-RT steps for an additive schema change. Do **not** treat restart as a migration path for immutable upsert settings such as mode, primary/comparison columns, hash function, or delete/out-of-order fields; create a new table and reingest instead. |
+| **Realtime partial upsert** | Same column/transform issues as above, plus force commit / reload-consuming is **blocked or skipped** in the default `RESTRICTED` mode because replicas can diverge on winner selection | 1) Update the additive schema/config 2) Before pause, force commit, or reload-consuming, set Helix **cluster config** `pinot.server.consuming.segment.consistency.mode=PROTECTED` (via controller cluster configs — not `pinot-server.conf`; see [Consuming Segment Consistency Mode](../ingestion/upsert-and-dedup/upsert.md#consuming-segment-consistency-mode)) 3) Use a maintenance window and verify upsert results 4) Allowed `partialUpsertStrategies` / `defaultPartialUpsertStrategy` changes require a controlled server restart and are not retroactive 5) Immutable core upsert settings require a new table and reingestion |
+| **Hybrid (OFFLINE + REALTIME)** | Offline and realtime can disagree until both sides are updated | Evolve schema once → reload offline segments (and backfill) → treat the realtime side with the matching row in this table |
+
+### Why incorrect values can appear
+
+* A **consuming** segment’s mutable index is created with a fixed schema/transform pipeline at start. Adding a column or transform mid-segment does not retroactively recompute earlier rows in that mutable segment.
+* **Completed** segments only gain the new column through reload (defaults) or rebuild/backfill (real values).
+* **Upsert / dedup** keep cross-segment state inside the server table data manager. Allowed partial-upsert strategy changes require a controlled server restart and are not retroactive. Core upsert/dedup identity and ordering settings are immutable; use a new table and reingest instead of relying on restart.
+
+### Minimal realtime runbook (additive column)
+
+For a plain additive column:
+
+```bash
+# 1) Upload updated schema
+curl -F schemaName=@myTable.schema http://localhost:9000/schemas
+
+# 2) If transforms/indexes changed, PATCH/PUT the table config as well
+
+# 3) For an explicit consumer barrier, force commit and poll
+curl -X POST "http://localhost:9000/tables/myTable/forceCommit"
+curl -X GET  "http://localhost:9000/tables/forceCommitStatus/<forceCommitJobId>"
+# wait until numberOfSegmentsYetToBeCommitted == 0
+
+# 4) If physical metadata/indexes are required, reload the completed segments.
+# Use segment-specific reloads to avoid force-committing the replacement consumer.
+curl -X POST "http://localhost:9000/segments/myTable/<committedSegmentName>/reload"
+```
+
+For a transform change, use a clean pause boundary:
+
+```bash
+# 1) Pause; pauseConsumption force-commits the current consumers
+curl -X POST "http://localhost:9000/tables/myTable/pauseConsumption"
+curl -X GET  "http://localhost:9000/tables/myTable/pauseStatus"
+# wait until the consuming segments have committed
+
+# 2) Upload the schema and table config
+
+# 3) Reload completed segments while the table is paused
+curl -X POST "http://localhost:9000/segments/myTable/reload?type=REALTIME"
+
+# 4) Resume with consumers built from the new schema/config
+curl -X POST "http://localhost:9000/tables/myTable/resumeConsumption"
+```
 
 ## Reference material
 
-The detailed walkthrough still lives in [Schema Evolution tutorial](../../tutorials/data-ingestion/schema-evolution.md).
+Step-by-step offline quickstart walkthrough: [Schema Evolution tutorial](../../tutorials/data-ingestion/schema-evolution.md).
+
+Operational APIs: [Segment reload](../../operate-pinot/segment-reload.md), [Force commit](../../reference/api-reference/controller-api.md#post-tablestablenameforcecommit), [Pause stream ingestion](../ingestion/stream-ingestion/README.md#pause-stream-ingestion).
 
 ## What this page covered
 
-This page covered the additive schema-evolution path and the cases where a new table is safer.
+- The additive schema-evolution path and the cases where a new table is safer.
+- When pause, reload, and forceCommit are required for realtime consumers.
+- Upsert-specific limits (config changes vs schema adds).
 
 ## Next step
 
@@ -38,4 +107,6 @@ Read the ingestion pages to see how schema design affects batch and stream pipel
 - [Data Modeling](README.md)
 - [Schema and Table Shape](schema.md)
 - [Logical Tables](logical-tables.md)
+- [Ingestion transformations](../ingestion/ingestion-level-transformations.md)
+- [Upsert](../ingestion/upsert-and-dedup/upsert.md)
 - [Original Schema Evolution Tutorial](../../tutorials/data-ingestion/schema-evolution.md)

--- a/build-with-pinot/ingestion/ingestion-level-transformations.md
+++ b/build-with-pinot/ingestion/ingestion-level-transformations.md
@@ -11,7 +11,7 @@ For simple transformations, this can result in inconsistencies in the batch/stre
 To make things easier, Pinot supports transformations that can be applied via the [table config](../../reference/configuration-reference/table.md).
 
 {% hint style="warning" %}
-If a **new column is added to your table or schema configuration during ingestion**, incorrect data may appear in the consuming segment(s). To ensure accurate values are reloaded, see how to [add a new column during ingestion](ingestion-level-transformations.md#add-a-new-column-during-ingestion).
+If you **add or change a transformed column** while realtime consumers are running, the current consuming segment can keep using the old transform plan until it commits. Use the [add a new column during ingestion](ingestion-level-transformations.md#add-a-new-column-during-ingestion) steps (or the [schema evolution decision table](../data-modeling/schema-evolution.md#decision-table-add-a-column-on-an-existing-table)) — pause is recommended for transform changes, but plain default-only columns often only need reload / forceCommit.
 {% endhint %}
 
 ## Transformation functions
@@ -517,13 +517,44 @@ For full syntax including `WITH ORDINALITY`, filtering, and aggregation after un
 
 ## Add a new column during ingestion
 
-If a new column is added to table or schema configuration during ingestion, incorrect data may appear in the consuming segment(s).
+This section applies when the new or changed column is populated through **ingestion transforms** (or you change transform logic) on a **realtime** table. The active consuming segment builds its transform pipeline when the mutable segment starts. Mid-segment schema/config updates do not rewrite rows already indexed in that consumer, so values in the current consuming segment can be wrong or missing until you start a new consumer.
 
-To ensure accurate values are reloaded, do the following:
+You do **not** always need a full pause for every schema add. Use the [schema evolution decision table](../data-modeling/schema-evolution.md#decision-table-add-a-column-on-an-existing-table):
 
-1. Pause consumption (and wait for pause status success):\
-   $ curl -X POST {controllerHost}/tables/{tableName}/pauseConsumption
+| Change | Typical action |
+| --- | --- |
+| Plain column / `defaultNullValue` only | Update schema, then reload (consuming reload requests a force commit when allowed) or use [forceCommit](../../reference/api-reference/controller-api.md#post-tablestablenameforcecommit) and poll it |
+| New or changed **transform** | Prefer pause → apply schema + table config → reload completed segments → resume; or apply schema/config → forceCommit and poll → reload the segments committed under the old plan |
+| Partial-upsert strategy for the new column | Update schema and strategy config together, then use a controlled server restart; immutable core upsert settings require a new table and reingestion. See [schema evolution](../data-modeling/schema-evolution.md). |
+
+### Transform-safe procedure (pause boundary)
+
+To ensure accurate transformed values with a clean consumer boundary:
+
+1. Pause consumption (and wait for pause status success):
+
+   ```bash
+   curl -X POST {controllerHost}/tables/{tableName}/pauseConsumption
+   curl -X GET  {controllerHost}/tables/{tableName}/pauseStatus
+   ```
+
 2. Apply new table or schema configurations.
+
 3. [Reload segments](../../operate-pinot/segment-reload.md) using the [Pinot Controller API](../../operate-pinot/segment-reload.md#use-the-pinot-controller-api-to-reload-segments) or [Pinot Admin Console](../../operate-pinot/segment-reload.md#use-the-pinot-admin-console-to-reload-segments).
-4. Resume consumption:\
-   $ curl -X POST {controllerHost}/tables/{tableName}/resumeConsumption
+
+4. Resume consumption:
+
+   ```bash
+   curl -X POST {controllerHost}/tables/{tableName}/resumeConsumption
+   ```
+
+### Alternative: force commit without a long pause
+
+After applying the new schema and table config, if you can tolerate committing current consumers immediately:
+
+```bash
+curl -X POST {controllerHost}/tables/{tableName}/forceCommit
+curl -X GET  {controllerHost}/tables/forceCommitStatus/{jobId}
+```
+
+Wait until `numberOfSegmentsYetToBeCommitted` is `0`, then reload the segments committed under the old transform plan so Pinot recomputes the new column. Details: [Force commit API](../../reference/api-reference/controller-api.md#post-tablestablenameforcecommit).

--- a/build-with-pinot/ingestion/upsert-and-dedup/upsert.md
+++ b/build-with-pinot/ingestion/upsert-and-dedup/upsert.md
@@ -831,7 +831,7 @@ This divergence is generally safe for FULL Upsert tables because replicas eventu
 
 - Full upsert tables with dropOutOfOrderRecord=true or outOfOrderRecordColumn: Out-of-order detection relies on the current location; wrong metadata can cause incorrect acceptance or rejection.
 
-To mitigate that, we added a server config: `pinot.server.consuming.segment.consistency.mode` which has three modes:
+To mitigate that, we added a **Helix cluster config** (not a per-process `pinot-server.conf` key): `pinot.server.consuming.segment.consistency.mode`, with three modes:
 
 #### RESTRICTED (default)
 
@@ -1080,15 +1080,15 @@ If the table-level flag is left at its default `false`, the server-level fallbac
 
 ### Consuming Segment Consistency Mode
 
-For partial upsert tables or tables with `dropOutOfOrder=true`, configure how the server handles segment reloads and force commits via `pinot.server.consuming.segment.consistency.mode` in `pinot-server.conf`:
+For partial upsert tables or tables with `dropOutOfOrderRecord=true` or `outOfOrderRecordColumn` configured, configure how controllers and servers handle segment reloads and force commits via the **Helix cluster config** key `pinot.server.consuming.segment.consistency.mode` (set with the controller cluster-config API / UI, for example `POST /cluster/configs`). Putting this key only in `pinot-server.conf` does **not** take effect — both controller and server load it from cluster config through `ConsumingSegmentConsistencyModeListener`.
 
 | Mode | Description |
 |---|---|
-| `RESTRICTED` | *(Default for partial upsert tables with RF > 1)* Disables segment reloads and force commits to prevent data inconsistency. |
+| `RESTRICTED` | *(Default)* Skips consuming-segment reload and rejects explicit force commit for partial-upsert tables and upsert tables with `dropOutOfOrderRecord` or `outOfOrderRecordColumn` configured. |
 | `PROTECTED` | Enables reloads/force commits with upsert metadata reversion during segment replacements. Requires `ParallelSegmentConsumptionPolicy` set to `DISALLOW_ALWAYS` or `ALLOW_DURING_BUILD_ONLY`. |
 | `UNSAFE` | Allows reloads without metadata reversion. Use only if inconsistency is acceptable or handled externally. |
 
-> **Note:** This is a server-level property distinct from the table-level `upsertConfig.consistencyMode` setting.
+> **Note:** This cluster config is distinct from the table-level `upsertConfig.consistencyMode` setting (SYNC / SNAPSHOT / NONE), which controls query-vs-upsert concurrency on a single server.
 
 ## Migrating from deprecated config fields
 
@@ -1134,6 +1134,10 @@ An example for partial upsert is shown below, each of the event\_id kept being u
 To see the difference from the non-upsert table, you can use a query option `skipUpsert` to skip the upsert effect in the query result.
 
 ### FAQ
+
+**Can I add a schema column to an existing upsert table without recreating it?**
+
+Yes for **additive** columns. Update the schema, then reload and/or [forceCommit](../../../reference/api-reference/controller-api.md#post-tablestablenameforcecommit) so new consuming segments pick up the column. Partial-upsert tables and upsert tables with out-of-order handling configured restrict force commit unless the Helix **cluster config** `pinot.server.consuming.segment.consistency.mode` allows it (see [Consuming Segment Consistency Mode](#consuming-segment-consistency-mode) — not `pinot-server.conf`). Changing upsert **configuration** is different: allowed partial-upsert strategy changes require a controlled restart and are not retroactive, while immutable settings such as primary/comparison columns and mode require a new table and reingestion. See the [schema evolution decision table](../../data-modeling/schema-evolution.md#decision-table-add-a-column-on-an-existing-table).
 
 **Can I change configs like primary key columns and comparison columns in existing upsert table?**
 

--- a/operate-pinot/segment-reload.md
+++ b/operate-pinot/segment-reload.md
@@ -7,8 +7,9 @@ description: Reload a table segment in Apache Pinot.
 When Pinot writes data to segments in a table, it saves those segments to a deep store location specified in your [table configuration](../reference/configuration-reference/table.md), such as a storage drive or Amazon S3 bucket.
 
 {% hint style="info" %}
-If a **new column is added to your table or schema configuration during ingestion**, incorrect data may appear in the consuming segment(s). To ensure accurate values are reloaded, see how to [add a new column during ingestion](../build-with-pinot/ingestion/ingestion-level-transformations.md#add-a-new-column-during-ingestion).&#x20;
+Schema and transform changes on **realtime** tables need a plan for consuming segments. When `pinot.server.instance.reload.consumingSegment` is `true` (default), reload of a consuming segment **requests a force commit** (sets a flag on the consumer); the segment seals asynchronously in the consumption loop and a replacement consumer then starts on the latest schema. Reload job success is **not** the same as “new consumers are ONLINE” — for a hard barrier, use [forceCommit](../reference/api-reference/controller-api.md#post-tablestablenameforcecommit) and poll `forceCommitStatus`, or wait until consuming segment generations advance. Transform-heavy changes may still want a pause boundary. See the [schema evolution decision table](../build-with-pinot/data-modeling/schema-evolution.md#decision-table-add-a-column-on-an-existing-table) and [add a new column during ingestion](../build-with-pinot/ingestion/ingestion-level-transformations.md#add-a-new-column-during-ingestion).
 {% endhint %}
+
 
 ## Use the Pinot Controller API to reload segments
 
@@ -40,6 +41,11 @@ Supported query parameters:
 | `forceDownload` | Re-download immutable segments from deep store before reloading. Defaults to `false`. |
 | `targetInstance` | Send reload messages only to the specified server instance. |
 | `instanceToSegmentsMap` | JSON map of server instance to segment list. When present, Pinot reloads only the listed segments on the listed servers. |
+
+{% hint style="info" %}
+**Consuming segments:** there is no separate `includingConsuming` query flag on this API. Whether consuming segments are included is controlled by the server config `pinot.server.instance.reload.consumingSegment` (default `true`). When enabled and allowed by [consuming-segment consistency mode](../build-with-pinot/ingestion/upsert-and-dedup/upsert.md#consuming-segment-consistency-mode), each consuming segment reload requests a force commit on that consumer; sealing and starting the replacement consumer are asynchronous and are **not** tracked by the reload job id. To commit consumers without reloading every completed segment, and to poll completion, call [POST /tables/\{tableName\}/forceCommit](../reference/api-reference/controller-api.md#post-tablestablenameforcecommit) and [GET /tables/forceCommitStatus/\{jobId\}](../reference/api-reference/controller-api.md#get-tablesforcecommitstatusjobid) instead.
+{% endhint %}
+
 
 Example:
 

--- a/tutorials/data-ingestion/schema-evolution.md
+++ b/tutorials/data-ingestion/schema-evolution.md
@@ -56,10 +56,10 @@ $ curl -F schemaName=@baseballStats.schema localhost:9000/schemas
 
 ## Reload table segments
 
-After you add the new column to your schema, reload the consuming segments.
+After you add the new column to your schema, reload the table segments so completed segments expose the new field and realtime consumers pick up the schema on a fresh consuming segment.
 
-1. (Real-time tables only): Open [Server config](../../reference/configuration-reference/server.md), and set `pinot.server.instance.reload.consumingSegment` to `true`.
-2. To ensure the `baseballStats` column shows up, run the following command to reload the table segments--**be sure to replace** **the accurate** `reloadJobId` **for your schema:**
+1. (Real-time tables) Keep `pinot.server.instance.reload.consumingSegment` at its default `true` (see [Server config](../../reference/configuration-reference/server.md)) so reload requests a force commit for consuming segments when consistency mode allows it. Servers then seal the current mutable segment asynchronously and start a new consumer with the latest schema/table config. You can also call `POST /tables/{tableName}/forceCommit` explicitly and poll it; see the [force commit API](../../reference/api-reference/controller-api.md#post-tablestablenameforcecommit).
+2. To ensure the new `baseballStats` column shows up on completed segments, reload the table — **replace** the sample `reloadJobId` below with yours when polling status:
 
 **Command**&#x20;
 
@@ -106,9 +106,10 @@ $ curl -X GET localhost:9000/segments/segmentReloadStatus/c3989a04-9fd1-46af-85e
 ```
 
 {% hint style="info" %}
-* For real-time consuming segments, the reload is performed as force commit, which commits the current consuming segment and loads it as an immutable segment. A new consuming segment is created after the current one is committed, and picks up the changes in the table config and schema.
-* Upsert and dedup config change cannot be applied via reload because they will change the table level (cross segments) metadata management. To apply these changes, server needs to be restarted.
-* In some cases, for example, if the transform function evaluation fails or references a column that isn't part of the segment being reloaded, the reload operation may not succesfully apply the transform. In these cases, the reload status API will still report sucess, but querying the new columns may not work. Review server reload logs to identify these cases.
+* For real-time **consuming** segments, reload is performed as a **force commit** when `pinot.server.instance.reload.consumingSegment` is true: the current consuming segment is committed as immutable, and a new consuming segment starts with the updated table config and schema.
+* Not every column add requires `pauseConsumption`. Plain default-only columns usually need schema update + reload/forceCommit. **Ingestion transform** changes are safer with a pause boundary or an immediate forceCommit so no consumer keeps the old transform plan. See the [schema evolution decision table](../../build-with-pinot/data-modeling/schema-evolution.md#decision-table-add-a-column-on-an-existing-table).
+* Upsert and dedup keep table-level (cross-segment) metadata inside the server table data manager. Allowed partial-upsert strategy changes require a controlled server restart and are not retroactive. Core identity and ordering settings are immutable; create a new table and reingest instead of relying on reload or restart. Adding a null-default column on a full-upsert table still follows the reload/forceCommit path above; partial-upsert tables and upsert tables with out-of-order handling configured restrict force commit unless consuming-segment consistency mode allows it.
+* In some cases, for example if the transform function evaluation fails or references a column that isn't part of the segment being reloaded, the reload operation may not successfully apply the transform. The reload status API can still report success while querying the new column fails — check server reload logs.
 {% endhint %}
 
 ## **Query and backfill data**
@@ -136,6 +137,4 @@ Result: {"resultTable":{"dataSchema":{"columnNames":["playerID","yearsOfExperien
 {% hint style="warning" %}
 Backfilling data does not work for real-time tables. You can convert a real-time table to a hybrid table by adding an offline table that uses the same counterpart, and then backfilling the offline table to fill in values for the newly added column. For more information, see [hybrid tables](../../basics/components/table/README.md#hybrid-table).
 {% endhint %}
-
-
 


### PR DESCRIPTION
## Summary

Adds a decision-table runbook for schema evolution on consuming / upsert / hybrid tables, and corrects consuming-reload + consistency-mode guidance to match current code.

**Issue:** Fixes apache/pinot#12652 (cross-links forceCommit #11212)

---

## What is the problem?

Guidance was vague (“always pause when adding a column”), which caused either:

- **Unnecessary downtime** (pause when a forceCommit/reload would have been enough), or
- **Bad values in consuming segments** (old transform plan mid-segment; schema not on mutable segment).

Additionally:

- Issue text mentioned `includingConsuming` on reload; **current controller reload API has no such query param**. Behavior is server config `pinot.server.instance.reload.consumingSegment` (default `true`), which **requests** force-commit on consuming segments.
- Partial-upsert force-commit/reload is gated by Helix **cluster config** `pinot.server.consuming.segment.consistency.mode` (default `RESTRICTED`). Some docs said `pinot-server.conf`, which **does not take effect**.

---

## Why did I do this?

Schema evolution is a recurring production operation. A type-by-type decision table (offline / plain RT / transforms / full upsert / partial upsert / hybrid) plus correct config surfaces prevents outages and stuck forceCommits. Source anchors: server reload path, `ConsumingSegmentConsistencyModeListener`, forceCommit validation.

---

## What is the implementation edit?

| File | Change |
|------|--------|
| `build-with-pinot/data-modeling/schema-evolution.md` | Decision table + RT runbook + curl examples; cluster-config wording for partial upsert |
| `tutorials/data-ingestion/schema-evolution.md` | Reload/forceCommit wording aligned to code |
| `build-with-pinot/ingestion/ingestion-level-transformations.md` | Safer transform guidance (don’t leave old plan mid-segment); also used by geo PR content where shared |
| `operate-pinot/segment-reload.md` | Consuming reload = **async force-commit request**; reload job ≠ new consumers ONLINE; no `includingConsuming` param |
| `build-with-pinot/ingestion/upsert-and-dedup/upsert.md` | FAQ + **Consuming Segment Consistency Mode** corrected to Helix cluster config (not server conf) |

---

## What is the impact?

- **Ops:** Clear path per table type; fewer wrong pauses and fewer “forceCommit 500” surprises on partial upsert.
- **Risk:** Docs-only but high operational leverage. Correcting cluster vs server conf is a critical accuracy fix.
- Related forceCommit API details live in the forceCommit docs PR.

---

## What is the testing edit?

- Docs validator — **PASS**.
- Verified against `DEFAULT_RELOAD_CONSUMING_SEGMENT`, reload consuming path, and `ConsumingSegmentConsistencyModeListener` (cluster config listener on controller + server).
- No new code tests.

---

## Checklist

- [x] Draft
- [x] Cluster config callout for consistency mode
- [x] Async reload barrier called out
