### PR TITLE
docs: fix tenant creation examples and CLI flags (#10580)

### DIFF
--- a/basics/components/cluster/tenant.md
+++ b/basics/components/cluster/tenant.md
@@ -43,78 +43,132 @@ In the above example:
 
 ## Create a tenant
 
+`POST /tenants` creates a tenant by tagging **currently untagged** broker or server instances. The JSON body maps to the `Tenant` config:
+
+| Field | Broker | Server | Notes |
+| --- | --- | --- | --- |
+| `tenantRole` | required (`BROKER`) | required (`SERVER`) | Role selects which instance pool is tagged. |
+| `tenantName` | required | required | Logical tenant name (Helix tags use `_BROKER`, `_OFFLINE`, `_REALTIME` suffixes). |
+| `numberOfInstances` | required | required | Total untagged instances to allocate for this tenant. Defaults to `0` if omitted, which causes server create to fail with errors such as `Cannot request more offline instances ... than total instances: 0`. |
+| `offlineInstances` | n/a | required for server tenants | How many of the allocated servers receive the `{tenant}_OFFLINE` tag. |
+| `realtimeInstances` | n/a | required for server tenants | How many of the allocated servers receive the `{tenant}_REALTIME` tag. |
+
+For **server** tenants, Pinot validates:
+
+* `numberOfInstances >= offlineInstances`
+* `numberOfInstances >= realtimeInstances`
+
+Those checks are **per tag type**, not against `offlineInstances + realtimeInstances`. When `offlineInstances + realtimeInstances > numberOfInstances` but each count still fits in `numberOfInstances`, Pinot co-locates tags: the same physical server can receive both `{tenant}_OFFLINE` and `{tenant}_REALTIME`. Creation still needs at least `numberOfInstances` **untagged** online servers (or brokers for broker tenants). Already-tagged instances are not reassigned by `POST /tenants`.
+
 ### Broker tenant
 
-Here's a sample broker tenant config. This will create a broker tenant `sampleBrokerTenant` by tagging three untagged broker nodes as `sampleBrokerTenant_BROKER`.
+Here's a sample broker tenant config. This creates broker tenant `sampleBrokerTenant` by tagging three untagged broker nodes as `sampleBrokerTenant_BROKER`.
 
 {% code title="sample-broker-tenant.json" %}
 ```javascript
 {
-     "tenantRole" : "BROKER",
-     "tenantName" : "sampleBrokerTenant",
-     "numberOfInstances" : 3
+  "tenantRole": "BROKER",
+  "tenantName": "sampleBrokerTenant",
+  "numberOfInstances": 3
 }
 ```
 {% endcode %}
 
-To create this tenant use the following command. The creation will fail if number of untagged broker nodes is less than `numberOfInstances`.
+Creation fails if the number of untagged broker nodes is less than `numberOfInstances`.
 
 {% tabs %}
 {% tab title="pinot-admin.sh" %}
-Follow instructions in [Getting Pinot](../../getting-started/install/local.md#1-download-or-build-apache-pinot) to get Pinot locally, and then
+Follow instructions in [Getting Pinot](../../getting-started/install/local.md#1-download-or-build-apache-pinot) to get Pinot locally, and then:
 
 ```bash
 bin/pinot-admin.sh AddTenant \
-    -name sampleBrokerTenant 
-    -role BROKER 
-    -instanceCount 3 -exec
+    -name sampleBrokerTenant \
+    -role BROKER \
+    -instanceCount 3 \
+    -exec
 ```
 {% endtab %}
 
 {% tab title="curl" %}
-```
-curl -i -X POST -H 'Content-Type: application/json' -d @sample-broker-tenant.json localhost:9000/tenants
+```bash
+curl -i -X POST -H 'Content-Type: application/json' \
+  -d @sample-broker-tenant.json \
+  http://localhost:9000/tenants
 ```
 {% endtab %}
 {% endtabs %}
 
-Check out the table config in the [Rest API](http://localhost:9000/help#!/Tenant/getAllTenants) to make sure it was successfully uploaded.
+Check out the tenants list in the [Rest API](http://localhost:9000/help#!/Tenant/getAllTenants) to make sure the tenant was created.
 
 ### Server tenant
 
-Here's a sample server tenant config. This will create a server tenant `sampleServerTenant` by tagging 1 untagged server node as `sampleServerTenant_OFFLINE` and 1 untagged server node as `sampleServerTenant_REALTIME`.
+Here's a sample server tenant config. With `numberOfInstances: 2`, this tags one untagged server as `sampleServerTenant_OFFLINE` and another as `sampleServerTenant_REALTIME`.
 
 {% code title="sample-server-tenant.json" %}
 ```javascript
 {
-     "tenantRole" : "SERVER",
-     "tenantName" : "sampleServerTenant",
-     "offlineInstances" : 1,
-     "realtimeInstances" : 1
+  "tenantRole": "SERVER",
+  "tenantName": "sampleServerTenant",
+  "numberOfInstances": 2,
+  "offlineInstances": 1,
+  "realtimeInstances": 1
 }
 ```
 {% endcode %}
 
-To create this tenant use the following command. The creation will fail if number of untagged server nodes is less than `offlineInstances` + `realtimeInstances`.
+**Co-located offline and realtime on one server** (one untagged server receives both tags):
+
+{% code title="sample-server-tenant-colocated.json" %}
+```javascript
+{
+  "tenantRole": "SERVER",
+  "tenantName": "sampleServerTenant",
+  "numberOfInstances": 1,
+  "offlineInstances": 1,
+  "realtimeInstances": 1
+}
+```
+{% endcode %}
+
+Creation fails if there are fewer than `numberOfInstances` untagged server nodes, or if `offlineInstances` or `realtimeInstances` is greater than `numberOfInstances`.
 
 {% tabs %}
 {% tab title="pinot-admin.sh" %}
-Follow instructions in [Getting Pinot](../../getting-started/install/local.md#1-download-or-build-apache-pinot) to get Pinot locally, and then
+Follow instructions in [Getting Pinot](../../getting-started/install/local.md#1-download-or-build-apache-pinot) to get Pinot locally, and then:
 
 ```bash
 bin/pinot-admin.sh AddTenant \
     -name sampleServerTenant \
     -role SERVER \
+    -instanceCount 2 \
     -offlineInstanceCount 1 \
-    -realtimeInstanceCount 1 -exec
+    -realTimeInstanceCount 1 \
+    -exec
 ```
+
+`-instanceCount` is required for every `AddTenant` call. For `SERVER` role, `-offlineInstanceCount` and `-realTimeInstanceCount` are also required (note the capital `T` in `-realTimeInstanceCount`).
 {% endtab %}
 
 {% tab title="curl" %}
-```
-curl -i -X POST -H 'Content-Type: application/json' -d @sample-server-tenant.json localhost:9000/tenants
+```bash
+curl -i -X POST -H 'Content-Type: application/json' \
+  -d @sample-server-tenant.json \
+  http://localhost:9000/tenants
 ```
 {% endtab %}
 {% endtabs %}
 
-Check out the table config in the [Rest API](http://localhost:9000/help#!/Tenant/getAllTenants) to make sure it was successfully uploaded.
+Check out the tenants list in the [Rest API](http://localhost:9000/help#!/Tenant/getAllTenants) to make sure the tenant was created.
+
+### Tagging instances without untagged capacity
+
+`POST /tenants` only consumes the untagged broker/server pools. If servers are already tagged (for example with `DefaultTenant_OFFLINE`) and you want to move or add tenant tags on those instances, update the instance tags directly instead of expecting `POST /tenants` to re-tag them:
+
+```bash
+curl -i -X PUT \
+  "http://localhost:9000/instances/Server_host1_8098/updateTags?tags=sampleServerTenant_OFFLINE,sampleServerTenant_REALTIME"
+```
+
+You can also set tags when adding or updating an instance via the Instances APIs. A server may hold more than one tag (for example both `_OFFLINE` and `_REALTIME`, or tags for more than one tenant) when your isolation model allows it.
+
+To grow or shrink an existing tenant after creation, use `PUT /tenants` with the same `Tenant` payload shape (including `numberOfInstances` for both roles, and offline/realtime counts for servers).

--- a/playbooks/multi-tenant-analytics.md
+++ b/playbooks/multi-tenant-analytics.md
@@ -112,7 +112,24 @@ When `tenantId` is the sorted column, all rows for a single tenant are physicall
 
 ### Assigning servers to tenants
 
-Tag servers when adding them to the cluster:
+Create tenants from untagged instances with `POST /tenants` (server payloads must include `numberOfInstances` as well as offline/realtime counts), or set tags on instances directly:
+
+```bash
+# Create a server tenant from untagged instances (numberOfInstances is required)
+curl -i -X POST -H 'Content-Type: application/json' -d '{
+  "tenantRole": "SERVER",
+  "tenantName": "PremiumTenant",
+  "numberOfInstances": 2,
+  "offlineInstances": 2,
+  "realtimeInstances": 2
+}' http://localhost:9000/tenants
+
+# Or retag a specific instance (servers may hold multiple tags)
+curl -i -X PUT \
+  "http://localhost:9000/instances/Server_host1_8098/updateTags?tags=PremiumTenant_OFFLINE,PremiumTenant_REALTIME"
+```
+
+You can also pass tags when adding an instance:
 
 ```
 PUT /instances/Server_host1_8098
@@ -133,7 +150,7 @@ Then assign high-value customers' tables to the `PremiumTenant`:
 }
 ```
 
-Other customers share a `SharedTenant` pool. See [Tenant](../basics/components/cluster/tenant.md) for setup details.
+Other customers share a `SharedTenant` pool. See [Tenant](../basics/components/cluster/tenant.md) for the full `POST /tenants` payload, CLI flags, and co-location rules.
 
 ### Workload-based query isolation
 


### PR DESCRIPTION
## Summary

Corrects tenant creation docs so server tenant examples include required fields and the CLI flag casing matches the code.

**Issue:** Fixes apache/pinot#10580

---

## What is the problem?

1. Server tenant create examples omitted **`numberOfInstances`**, which defaults to `0` → cryptic failures like `Cannot request more offline instances ... than total instances: 0`.
2. CLI flag is **`-realTimeInstanceCount`** (capital **T**), easy to mistype as `-realtimeInstanceCount`.
3. Validation is `numberOfInstances >= offline` **and** `>= realtime` (not sum); co-location is allowed when both tags share instances. Creation still needs enough **untagged** instances. Docs did not explain this clearly.

---

## Why did I do this?

Multi-tenant setup is a first-hour ops task. Wrong examples waste time on avoidable Helix/tenant API errors. Source anchors: `Tenant.java`, `AddTenantCommand.java`, `PinotHelixResourceManager`, tenant REST resource.

---

## What is the implementation edit?

| File | Change |
|------|--------|
| `basics/components/cluster/tenant.md` | Field table; complete broker/server JSON; CLI with correct flags; updateTags / grow-shrink notes |
| `playbooks/multi-tenant-analytics.md` | Complete server create payload + updateTags example |

**Correct CLI shape (server):**

```bash
bin/pinot-admin.sh AddTenant \
  -name <tenant> \
  -role SERVER \
  -instanceCount <n> \
  -offlineInstanceCount <n> \
  -realTimeInstanceCount <n> \
  -exec
```

---

## What is the impact?

- **Ops:** Working create examples; fewer zero-instance failures.
- **Risk:** Docs-only.

---

## What is the testing edit?

- Docs validator — **PASS**.
- Cross-checked flag names and validation rules against AddTenant command / tenant model.
- No new tests.

---

## Checklist

- [x] Draft
- [x] Capital-T realtime flag called out
