### PR TITLE
docs: document group-by quirks and query option naming (#7465)

### DIFF
--- a/build-with-pinot/querying-and-sql/grouping-algorithm.md
+++ b/build-with-pinot/querying-and-sql/grouping-algorithm.md
@@ -60,9 +60,13 @@ Default value of `minBrokerGroupTrimSize` is set to 5000. This can be adjusted b
 
 ## GROUP BY behavior
 
-Pinot sets a default `LIMIT` of 10 if one isn't defined and this applies to `GROUP BY` queries as well. Therefore, if no limit is specified, Pinot will return 10 groups.
+Pinot sets a default `LIMIT` of 10 if one isn't defined and this applies to SSE `GROUP BY` queries as well. Therefore, if no limit is specified on SSE, Pinot will return 10 groups. MSE does not apply that same implicit 10-row result limit; still set `LIMIT` explicitly when you care about result size. See also [Querying Pinot](querying-pinot.md#group-by-quirks-default-limit-trimming-order-by).
 
 Pinot will trim tail groups based on the `ORDER BY` clause to reduce the memory footprint and improve the query performance. It keeps at least `5 * LIMIT` groups so that the results give good enough approximation in most cases. The configurable min trim size can be used to increase the groups kept to improve the accuracy but has a larger extra memory footprint.
+
+**Without `ORDER BY`**, SSE group-by does not define a ranking. By default, result tables stop admitting unseen group keys after they reach the requested result size, so processing order can affect which keys survive. Do not treat `GROUP BY ... LIMIT N` as a top-N query.
+
+Set `accurateGroupByWithoutOrderBy=true` when you need a deterministic subset: Pinot retains the lexicographically smallest group keys during server and broker reduction. This does not rank groups by an aggregate, and it cannot recover keys dropped by `numGroupsLimit`; use `ORDER BY` for top-N results. See [Query options](query-execution-controls/query-options.md).
 
 ## HAVING behavior
 

--- a/build-with-pinot/querying-and-sql/query-execution-controls/query-options.md
+++ b/build-with-pinot/querying-and-sql/query-execution-controls/query-options.md
@@ -13,6 +13,7 @@ Query options are per-query switches that let you choose the execution engine, c
 - `clientQueryId` gives the query a stable identifier for tracking and cancellation.
 - `explainPlanVerbose` asks Pinot for richer plan output.
 - `maxExecutionThreads` limits concurrency for expensive queries.
+- Group-by memory/accuracy knobs such as `numGroupsLimit`, `minSegmentGroupTrimSize`, `minServerGroupTrimSize`, and `accurateGroupByWithoutOrderBy` (see [Grouping algorithm](../grouping-algorithm.md)).
 
 ```sql
 SET useMultistageEngine = true;
@@ -23,6 +24,14 @@ FROM stores
 GROUP BY city
 LIMIT 10;
 ```
+
+## Option names
+
+Documented keys use **canonical camelCase** (for example `timeoutMs`, `useMultistageEngine`, `minSegmentGroupTrimSize`). Pinot resolves recognized option names **case-insensitively** to those canonical forms when parsing `SET` / `OPTION` clauses, so `SET timeoutms = 5000` is treated like `timeoutMs`.
+
+Prefer the canonical names from the table below. An unrecognized option can remain in the options map without producing a parse error, and consumers that do not know the key may ignore it. Do not treat an accepted query as proof that an option name is valid.
+
+For default `LIMIT` behavior, group-by tail trim, and `ORDER BY` vs unordered group-by, see [Querying Pinot](../querying-pinot.md#group-by-quirks-default-limit-trimming-order-by).
 
 ## When to reach for options
 
@@ -115,7 +124,7 @@ description: This document contains all the available query options
 | **sampler** | Selects a named table sampler from the table config. Use this to run a query against a sampled subset of segments, for example `SET sampler='small'`. See [Table](../../../reference/configuration-reference/table.md#table-samplers) for the table-level configuration. | `null/empty` (normal routing, no table sampler) |
 | **clientQueryId** | Set to define a [custom correlation ID](query-correlation-id.md) for a query and to [cancel queries](query-cancellation.md). | `null/empty` |
 | **applicationName** | Assign the query to a named application for application-level query quotas. Use this with the [Query Quotas](query-quotas.md) APIs when you want Pinot to rate-limit queries from a specific caller or workload. If no per-application quota is configured for the name, Pinot can fall back to the global application quota default when one exists. | `null/empty` (no application name) |
-| **accurateGroupByWithoutOrderBy** | Improves correctness of group-by queries with LIMIT but without ORDER BY by applying better trimming on servers. See PR #15844. Set `accurateGroupByWithoutOrderBy=true` to enable | `false` (disabled) |
+| **accurateGroupByWithoutOrderBy** | For SSE `GROUP BY ... LIMIT` without `ORDER BY` or `HAVING`, retain a deterministic subset by keeping the lexicographically smallest group keys during server and broker reduction. This does not rank by an aggregate and does not override `numGroupsLimit`; use `ORDER BY` for top-N results. | `false` (processing order can affect which group keys survive) |
 | **traceRuleProductions** | Trace planner rule productions. Specify `SET traceRuleProductions=true` to collect and return planner rules that successfully produced new relations and the relation subtree before and after the production in time order along with rule attempt timing. Useful for debugging query planning. | `false` |
 | **excludeVirtualColumns** | When you want to ignore virtual columns (those starting with $) in a query — such as a NATURAL JOIN where they shouldn't be participating in join condition matching. This option helps remove all virtual columns from the schema during query planning and execution making NATURAL JOIN successful. This is currently implemented in MSE. | `false` (virtual columns are included by default for all queries during join-match) |
 | **useSpools** | Enable stage-level spooling for multi-stage queries. When enabled, Pinot can reuse equivalent stages within a query plan instead of executing them repeatedly. See [stage-level-spooling.md](../multi-stage-query/stage-level-spooling.md) for the feature behavior and limitations. | Broker level config (default `false`) |

--- a/build-with-pinot/querying-and-sql/querying-pinot.md
+++ b/build-with-pinot/querying-and-sql/querying-pinot.md
@@ -29,6 +29,7 @@ If you are debugging a slow or surprising query, the most useful follow-up pages
 
 - [SQL syntax](sql-syntax.md)
 - [Query options](query-execution-controls/query-options.md)
+- [Grouping algorithm](grouping-algorithm.md)
 - [Query quotas](query-execution-controls/query-quotas.md)
 - [Query cancellation](query-execution-controls/query-cancellation.md)
 - [Cursor pagination](query-execution-controls/query-using-cursors.md)
@@ -36,6 +37,99 @@ If you are debugging a slow or surprising query, the most useful follow-up pages
 - [Explain plan](query-execution-controls/explain-plan.md)
 - [Multi-stage explain plan](query-execution-controls/explain-plan-multi-stage.md)
 - [SSE vs MSE](sse-vs-mse.md)
+
+## Group-by quirks (default LIMIT, trimming, ORDER BY)
+
+These behaviors catch many users by surprise. Details and tuning knobs live in [Grouping algorithm](grouping-algorithm.md) and [Query options](query-execution-controls/query-options.md).
+
+### Default LIMIT is 10
+
+On the **single-stage engine (SSE)**, if a query omits `LIMIT`, the broker applies a default of **10** rows (`pinot.broker.default.query.limit`). This applies to selection queries and `GROUP BY` queries, so an SSE group-by without an explicit `LIMIT` returns at most 10 groups.
+
+```sql
+-- SSE: returns at most 10 groups even if many cities exist
+SELECT city, COUNT(*) AS cnt
+FROM stores
+GROUP BY city;
+```
+
+The **multi-stage engine (MSE)** does not apply this broker default. Still set an explicit `LIMIT` whenever you care about result size or want intentional truncation.
+
+### Tail trimming on GROUP BY
+
+For SSE group-by with `ORDER BY`, Pinot may **trim tail groups** while aggregating so servers stay within memory limits. Where trimming is enabled, the candidate size is based on `max(minTrimSize, 5 * LIMIT)`; segment trimming is disabled by default, while server and broker reduction have their own defaults. Pinot ranks candidates using the query's `ORDER BY`. See [Grouping algorithm](grouping-algorithm.md) for the stage-specific settings.
+
+Implications:
+
+- Results can be approximate when cardinality is high relative to `LIMIT` and trim thresholds.
+- `numGroupsLimitReached=true` means a group operator reached its hard group cap; increasing a trim size cannot recover groups already dropped at that cap.
+- Raise the relevant trim sizes when you need a larger candidate set, or raise `LIMIT` when you also need more rows returned. Both choices increase memory use.
+
+### GROUP BY with ORDER BY vs without ORDER BY
+
+| Pattern | Execution behavior |
+| --- | --- |
+| `GROUP BY ... ORDER BY ... LIMIT N` | Each trim stage ranks candidate groups by the `ORDER BY` expressions and drops lower-ranked candidates. This is the intended top-N shape, although distributed trimming can still make results approximate when candidate sets are too small. |
+| `GROUP BY ... LIMIT N` (**no** `ORDER BY`) | There is no ranking. By default, SSE result tables stop admitting unseen group keys after reaching their result size, so processing order can affect which N keys survive. |
+
+```sql
+-- Ordered top-N cities by count (trim keeps high counts when ORDER BY matches the ranking)
+SELECT city, COUNT(*) AS cnt
+FROM stores
+GROUP BY city
+ORDER BY cnt DESC
+LIMIT 20;
+
+-- Unordered: at most 20 groups, but not a defined "top" set
+SELECT city, COUNT(*) AS cnt
+FROM stores
+GROUP BY city
+LIMIT 20;
+```
+
+Do **not** assume a stable or ranked group set without `ORDER BY`. For a deterministic subset, set `accurateGroupByWithoutOrderBy=true`; SSE then keeps the lexicographically smallest group keys during server and broker reduction. This does not rank by an aggregate and cannot recover keys dropped by `numGroupsLimit`. See [Query options](query-execution-controls/query-options.md).
+
+### HAVING and post-aggregation
+
+On SSE, `HAVING` filters the merged group candidates **after** aggregation and any earlier group trimming. If `HAVING` prefers groups that trimming already dropped (for example `HAVING SUM(x) < 100` with `ORDER BY SUM(x) DESC`), matching groups may be missing—increase trim sizes or adjust ordering.
+
+```sql
+SELECT city, COUNT(*) AS cnt, SUM(revenue) AS total
+FROM stores
+GROUP BY city
+HAVING COUNT(*) > 100
+ORDER BY total DESC
+LIMIT 50;
+```
+
+**Post-aggregation** expressions combine aggregated values (and group keys) in `SELECT`, `HAVING`, or `ORDER BY` after the aggregates are computed:
+
+```sql
+SELECT
+  city,
+  SUM(revenue) AS total,
+  COUNT(*) AS cnt,
+  SUM(revenue) / COUNT(*) AS avg_revenue
+FROM stores
+GROUP BY city
+HAVING SUM(revenue) / COUNT(*) > 10
+ORDER BY avg_revenue DESC
+LIMIT 50;
+```
+
+### Query options (names and syntax)
+
+Use `SET` statements or `OPTION (...)` to pass per-query options. Recognized keys resolve **case-insensitively** to the canonical camelCase names listed in [Query options](query-execution-controls/query-options.md) (for example `timeoutMs`, `numGroupsLimit`, `minSegmentGroupTrimSize`, `useMultistageEngine`). Prefer canonical spelling: unknown names can be accepted but ignored.
+
+```sql
+SET timeoutMs = 5000;
+SET minSegmentGroupTrimSize = 5000;
+SELECT city, COUNT(*) AS cnt
+FROM stores
+GROUP BY city
+ORDER BY cnt DESC
+LIMIT 100;
+```
 
 ## When to use which engine
 
@@ -58,6 +152,8 @@ Read [SQL syntax](sql-syntax.md) for the query language itself, then move to [Qu
 
 - [Querying & SQL controls](query-execution-controls/README.md)
 - [SQL syntax](sql-syntax.md)
+- [Query options](query-execution-controls/query-options.md)
+- [Grouping algorithm](grouping-algorithm.md)
 - [Explain plan](query-execution-controls/explain-plan.md)
 - [Multi-stage explain plan](query-execution-controls/explain-plan-multi-stage.md)
 - [SSE vs MSE](sse-vs-mse.md)
@@ -114,6 +210,10 @@ GROUP BY bar, baz
 LIMIT 50
 ```
 
+{% hint style="info" %}
+On the single-stage engine, omitting `LIMIT` defaults to **10 groups**. Without `ORDER BY`, which group keys survive a small result size can depend on processing order. See [Group-by quirks](#group-by-quirks-default-limit-trimming-order-by).
+{% endhint %}
+
 ### Ordering on Aggregation
 
 ```sql
@@ -121,6 +221,27 @@ SELECT MIN(foo), MAX(foo), SUM(foo), AVG(foo), bar, baz
 FROM myTable
 GROUP BY bar, baz 
 ORDER BY bar, MAX(foo) DESC 
+LIMIT 50
+```
+
+### Filtering groups with HAVING
+
+```sql
+SELECT bar, SUM(foo) AS total
+FROM myTable
+GROUP BY bar
+HAVING SUM(foo) > 1000
+ORDER BY total DESC
+LIMIT 50
+```
+
+### Post-aggregation expressions
+
+```sql
+SELECT bar, SUM(foo) AS total, COUNT(*) AS cnt, SUM(foo) / COUNT(*) AS avg_foo
+FROM myTable
+GROUP BY bar
+ORDER BY avg_foo DESC
 LIMIT 50
 ```
 

--- a/build-with-pinot/querying-and-sql/sql-reference.md
+++ b/build-with-pinot/querying-and-sql/sql-reference.md
@@ -378,6 +378,19 @@ GROUP BY city
 HAVING COUNT(*) > 100
 ```
 
+On SSE, `HAVING` runs on the merged group candidates after any earlier group trim. If trimming already dropped groups that would match `HAVING`, those groups do not reappear. See [Grouping algorithm](grouping-algorithm.md#having-behavior) and [Querying Pinot](querying-pinot.md#group-by-quirks-default-limit-trimming-order-by).
+
+You can use **post-aggregation** expressions (arithmetic or functions over aggregates and group keys) in `SELECT`, `HAVING`, and `ORDER BY`:
+
+```sql
+SELECT city, SUM(amount) AS total, COUNT(*) AS cnt, SUM(amount) / COUNT(*) AS avg_amount
+FROM orders
+GROUP BY city
+HAVING SUM(amount) / COUNT(*) > 25
+ORDER BY avg_amount DESC
+LIMIT 50
+```
+
 ---
 
 ## ORDER BY
@@ -390,6 +403,8 @@ FROM orders
 GROUP BY city
 ORDER BY total DESC
 ```
+
+Without `ORDER BY`, Pinot does not guarantee row or group order. For SSE `GROUP BY` without `ORDER BY`, result tables can also stop admitting unseen group keys after reaching a small `LIMIT`, so processing order can affect which keys survive. See [Querying Pinot](querying-pinot.md#group-by-quirks-default-limit-trimming-order-by).
 
 ### Ordering Direction
 
@@ -419,7 +434,7 @@ Restricts the number of rows returned:
 SELECT * FROM orders LIMIT 50
 ```
 
-If no `LIMIT` is specified, Pinot defaults to returning 10 rows for selection queries.
+On the **single-stage engine**, if no `LIMIT` is specified, the broker defaults to returning 10 rows (`pinot.broker.default.query.limit`); this also caps SSE `GROUP BY` results at 10 groups. The multi-stage engine does not apply this broker default. Prefer an explicit `LIMIT` on every production query. See [Grouping algorithm](grouping-algorithm.md#group-by-behavior) and [Querying Pinot](querying-pinot.md#group-by-quirks-default-limit-trimming-order-by).
 
 ### OFFSET
 


### PR DESCRIPTION
## Summary

Documents current group-by behavior for Pinot’s single-stage engine (SSE), including the implicit result limit, ordered trimming, unordered group selection, `HAVING`, post-aggregation, and query-option naming.

**Issue:** Fixes apache/pinot#7465

## Reader-facing changes

- Explains that `pinot.broker.default.query.limit` defaults SSE queries to 10 rows/groups when `LIMIT` is omitted; MSE does not apply this broker default.
- Distinguishes ordered top-N candidate trimming from unordered group admission.
- Documents that `accurateGroupByWithoutOrderBy=true` retains a deterministic lexicographic subset; it does not rank by an aggregate or override `numGroupsLimit`.
- Clarifies that `HAVING` can only filter group candidates that survived earlier SSE trimming.
- Adds examples for `HAVING` and post-aggregation expressions.
- Explains that recognized query-option names resolve case-insensitively to canonical camelCase. Unknown keys can still be accepted and ignored; apache/pinot#7207 remains open.

## Files changed

| File | Change |
| --- | --- |
| `build-with-pinot/querying-and-sql/querying-pinot.md` | Practical group-by behavior and examples |
| `build-with-pinot/querying-and-sql/query-execution-controls/query-options.md` | Option-name handling and exact unordered-group option semantics |
| `build-with-pinot/querying-and-sql/grouping-algorithm.md` | SSE/MSE limit distinction and unordered behavior |
| `build-with-pinot/querying-and-sql/sql-reference.md` | `LIMIT`, `ORDER BY`, `HAVING`, and post-aggregation notes |

## Source cross-check

Verified against current Apache Pinot source and tests:

- `BaseSingleStageBrokerRequestHandler` and `CommonConstants.Broker.DEFAULT_BROKER_QUERY_LIMIT`
- `GroupByUtils`, `DeterministicConcurrentIndexedTable`, and `TableResizer`
- `QueryOptionsUtils`, `CalciteSqlParser`, and their unit tests

## Validation

- Pinot docs validator: PASS (634 Markdown files, 3,461 links, no broken file links)
- `QueryOptionsUtilsTest#shouldConvertCaseInsensitiveMapToUseCorrectValues`: PASS
- `DeterministicIndexedTableTest` and `GroupByTrimTest`: PASS (13 tests)
- `git diff --check`: PASS
