### PR TITLE
docs: document OPEN_STRUCT storage and config (apache/pinot#18643)

### DIFF
--- a/build-with-pinot/indexing/README.md
+++ b/build-with-pinot/indexing/README.md
@@ -30,6 +30,7 @@ Use the decision guide when you know the query shape but not the best index yet.
 * [Range index](range-index.md) for bounded numeric or time filters.
 * [Text search support](text-search-support.md) for tokenized search and text predicates.
 * [JSON index](json-index.md) for nested JSON predicates.
+* `OPEN_STRUCT` field-level indexing for semi-structured object columns that need per-key columnar storage and per-key secondary indexes. See [Complex Type (Array, Map) Handling](../ingestion/complex-type/README.md) and [Table](../../reference/configuration-reference/table.md).
 * [Geospatial support](geospatial-support.md) for distance and spatial filtering.
 * [Star-tree index](star-tree-index.md) for repeatable aggregation and group-by workloads.
 * [Vector index](vector-index.md) for similarity search on embeddings.
@@ -56,6 +57,7 @@ forward indexes and dictionaries for a table.
 | Range index         | Offline            |
 | Text search support | Realtime & Offline |
 | JSON index          | Realtime & Offline |
+| OPEN_STRUCT index   | Realtime & Offline |
 | Geospatial support  | Realtime & Offline |
 | Star-tree index     | Offline            |
 | Vector index        | Realtime & Offline |

--- a/build-with-pinot/ingestion/complex-type/README.md
+++ b/build-with-pinot/ingestion/complex-type/README.md
@@ -8,12 +8,13 @@ Commonly, ingested data has a complex structure. For example, Avro schemas have 
 
 Apache Pinot's data model supports primitive data types (including int, long, float, double, BigDecimal, string, bytes), and limited multi-value types, such as an array of primitive types. Simple data types allow Pinot to build fast indexing structures for good query performance, but does require some handling of the complex structures.
 
-There are two options for complex type handling:
+There are three options for complex type handling:
 
 * Convert the complex-type data into a JSON string and then build a JSON index.
+* Use `OPEN_STRUCT` when an object column should stay in one field, but frequently queried keys need columnar storage and secondary indexes.
 * Use the built-in complex-type handling rules in the ingestion configuration.
 
-On this page, we'll show how to handle these complex-type structures with each of these two approaches. We will process some example data, consisting of the field `group` from the [Meetup events Quickstart example](https://github.com/apache/pinot/tree/master/pinot-tools/src/main/resources/examples/stream/meetupRsvp).
+On this page, we'll show how to handle these complex-type structures with each of these three approaches. We will process some example data, consisting of the field `group` from the [Meetup events Quickstart example](https://github.com/apache/pinot/tree/master/pinot-tools/src/main/resources/examples/stream/meetupRsvp).
 
 This object has two child fields and the child `group` is a nested array with elements of object type.
 
@@ -79,7 +80,94 @@ For the full specification, see [json\_meetupRsvp\_schema.json](https://github.c
 
 With this, you can start to query the nested fields under `group`. For more details about the supported JSON function, see [guide](../../../build-with-pinot/indexing/json-index.md)).
 
-## Ingestion configurations
+## OPEN_STRUCT storage and per-key indexes
+
+Use `OPEN_STRUCT` when your source field is an object or map whose key set evolves over time, but you still want Pinot to store the most important keys as standard columns.
+
+Pinot stores an `OPEN_STRUCT` column in two tiers:
+
+* Dense keys become materialized child columns named `<column>$<key>`.
+* Remaining keys are packed into one sparse JSON column named `<column>$__sparse__`.
+
+Pinot decides which keys are dense in this order:
+
+* Keys listed in `denseKeys` are always materialized.
+* Other keys are materialized when their fill rate is at least `denseKeyMinFillRate` (default `0.5`).
+* If more keys qualify than `maxDenseKeys` allows, Pinot keeps the highest-fill-rate keys as dense and writes the rest to the sparse JSON column.
+
+Dense keys reuse Pinot's standard column infrastructure, so each materialized key gets a forward index and can also use vetted per-key settings for dictionary, inverted, range, and bloom-filter behavior through `valueFieldConfigs`. If you do not configure a dense key explicitly, Pinot defaults to dictionary encoding plus an inverted index for that key.
+
+### Define the schema
+
+Declare the object column as `OPEN_STRUCT`. `childFieldSpecs` is optional, but it is useful when some keys should always keep a specific type:
+
+```json
+{
+  "complexFieldSpecs": [
+    {
+      "name": "attributes",
+      "dataType": "OPEN_STRUCT",
+      "fieldType": "COMPLEX",
+      "childFieldSpecs": {
+        "customerId": {
+          "name": "customerId",
+          "dataType": "STRING",
+          "fieldType": "DIMENSION"
+        },
+        "country": {
+          "name": "country",
+          "dataType": "STRING",
+          "fieldType": "DIMENSION"
+        }
+      }
+    }
+  ]
+}
+```
+
+### Configure dense keys and per-key indexes
+
+Add an `open_struct` entry to the field's `indexes` object in `fieldConfigList`:
+
+```json
+{
+  "fieldConfigList": [
+    {
+      "name": "attributes",
+      "indexes": {
+        "open_struct": {
+          "denseKeys": ["customerId", "country"],
+          "denseKeyMinFillRate": 0.5,
+          "maxDenseKeys": 32,
+          "valueFieldConfigs": [
+            {
+              "name": "customerId",
+              "indexes": {
+                "inverted": {}
+              }
+            },
+            {
+              "name": "country",
+              "indexes": {
+                "bloom": {}
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}
+```
+
+Notes:
+
+* `OPEN_STRUCT` is a field-level index for single-value `OPEN_STRUCT` columns.
+* Pinot can still ingest keys that are not listed in `childFieldSpecs`; it infers a stored type from observed values when possible.
+* When any schema field uses `OPEN_STRUCT`, `$` becomes a reserved character in schema column names because Pinot uses it in generated child-column names.
+* Use the [schema reference](../../../reference/configuration-reference/schema.md) for the exact schema JSON and the [table reference](../../../reference/configuration-reference/table.md) for the full `open_struct` config surface.
+
+## Flatten and unnest with ingestion configurations
 
 Though JSON indexing is a handy way to process the complex types, there are some limitations:
 

--- a/reference/configuration-reference/schema.md
+++ b/reference/configuration-reference/schema.md
@@ -291,6 +291,8 @@ Use complex field specs for complex data types. Pinot currently supports `MAP` a
 
 The `childFieldSpecs` object describes the structure of the `key` and `value` entries inside a `MAP`. For `OPEN_STRUCT`, `childFieldSpecs` is optional: omit it, set it to `{}`, or use it to declare known child fields and their types.
 
+For `OPEN_STRUCT`, declared child fields are the stable contract for keys whose types you want Pinot to preserve exactly. Pinot can still ingest undeclared keys and infers a stored type from the observed values when possible.
+
 ### OPEN_STRUCT childFieldSpecs
 
 `OPEN_STRUCT` accepts schema JSON such as the following:
@@ -319,6 +321,8 @@ You can also provide `childFieldSpecs` for keys whose types you want to declare 
   }
 }
 ```
+
+When any schema field uses `OPEN_STRUCT`, `$` is reserved in every schema column name. Pinot uses `$` in the generated materialized child-column names such as `<column>$<key>` and the shared sparse column `<column>$__sparse__`.
 
 ### key childFieldSpec
 

--- a/reference/configuration-reference/table.md
+++ b/reference/configuration-reference/table.md
@@ -226,6 +226,60 @@ Example RAW forward index with a standalone dictionary:
 }
 ```
 
+#### OPEN_STRUCT index
+
+Use the `open_struct` field-level index on a single-value `OPEN_STRUCT` column when you want Pinot to keep a semi-structured object in one column but materialize frequently used keys as standard Pinot columns.
+
+Pinot stores `OPEN_STRUCT` data in two tiers:
+
+* Dense keys become materialized child columns named `<column>$<key>`.
+* Remaining keys are written into one sparse JSON column named `<column>$__sparse__`.
+
+The `open_struct` config object supports the following properties:
+
+| Property | Description |
+| --- | --- |
+| `denseKeys` | Optional explicit set of keys that Pinot always materializes as dense child columns, regardless of fill rate. |
+| `denseKeyMinFillRate` | Minimum fraction of documents that must contain a key before Pinot materializes it automatically. Default: `0.5`. |
+| `maxDenseKeys` | Maximum number of dense keys to materialize. `-1` means unlimited, `0` disables dense keys entirely, and positive values keep only the highest-fill-rate qualifying keys as dense. |
+| `defaultValueFieldConfig` | Optional fallback `FieldConfig` applied to dense keys that do not appear in `valueFieldConfigs`. |
+| `valueFieldConfigs` | Optional list of per-key `FieldConfig` entries. Each entry's `name` must match an `OPEN_STRUCT` key name. |
+
+Per-key `FieldConfig.indexes` inside `defaultValueFieldConfig` or `valueFieldConfigs` may use only the vetted subset: `dictionary`, `forward`, `inverted`, `range`, and `bloom`. Forward indexes are always written for materialized child columns. When neither `defaultValueFieldConfig` nor `valueFieldConfigs` configures a dense key, Pinot uses dictionary encoding plus an inverted index for that key by default.
+
+Example:
+
+```json
+{
+  "fieldConfigList": [
+    {
+      "name": "attributes",
+      "indexes": {
+        "open_struct": {
+          "denseKeys": ["customerId", "country"],
+          "denseKeyMinFillRate": 0.5,
+          "maxDenseKeys": 32,
+          "valueFieldConfigs": [
+            {
+              "name": "customerId",
+              "indexes": {
+                "inverted": {}
+              }
+            },
+            {
+              "name": "country",
+              "indexes": {
+                "bloom": {}
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}
+```
+
 For realtime tables, you can also give mutable consuming segments a different index layout without changing the
 persisted segment format. Pinot applies the `consuming` override first, validates the effective config through the
 normal table-config path, and then uses that effective view only while the segment is still consuming:


### PR DESCRIPTION
## Summary
- document how `OPEN_STRUCT` stores hot keys as dense child columns and writes the remaining keys to a shared sparse JSON column
- add the canonical `fieldConfigList.indexes.open_struct` reference, including `denseKeys`, `denseKeyMinFillRate`, `maxDenseKeys`, and per-key `valueFieldConfigs`
- improve discoverability by linking `OPEN_STRUCT` from the complex-type and indexing docs, and note the schema-level `$` naming restriction

## Reader Impact
Readers now have one place to understand when to use `OPEN_STRUCT`, how dense versus sparse keys are chosen, how to configure per-key secondary indexes, and which schema naming rule applies when `OPEN_STRUCT` is present.

## Source Cross-Checks
Cross-checked against merged `apache/pinot#18643`, including:
- `OpenStructIndexConfig` for config names, defaults, and dense/sparse selection behavior
- `OpenStructIndexType` and `OpenStructSupportedIndexes` for the supported per-key index subset and single-value validation
- `OpenStructNaming` and `TableConfigUtils` for generated child-column naming and the reserved `$` restriction
- `OpenStructColumnSplitterTest`, `OpenStructIndexTypeTest`, and `OpenStructIngestionCommitTestBase` for storage layout and end-to-end dense/sparse behavior

## Validation
- `git diff --check`
- verified the changed internal docs links resolve to existing files
