### PR TITLE
docs: document jsonPathString scalar rendering

### DIFF
--- a/build-with-pinot/ingestion/ingestion-level-transformations.md
+++ b/build-with-pinot/ingestion/ingestion-level-transformations.md
@@ -195,6 +195,8 @@ Transform functions can be defined on columns in the ingestion config of the tab
 Pinot evaluates ingestion transforms against normalized extractor values, not the raw source-format encoding. For typed input formats such as Avro, Parquet, ORC, Thrift, and Protocol Buffers, booleans stay `Boolean`, `Byte` and `Short` values widen to `Integer`, logical dates and times surface as `java.time.LocalDate`, `java.time.LocalTime`, or `java.sql.Timestamp`, multi-value fields surface as `Object[]`, and maps or nested records surface as `Map<Object, Object>`. Pinot coerces those intermediate values to the column's declared schema type after the transform step.
 
 If you have an older transform that depended on format-specific quirks such as stringified booleans or raw epoch date and time values, update the transform to handle the normalized value or cast it explicitly.
+
+For `JSONPATHSTRING`, `JSONPATHSTRINGFAST`, and `JSONPATHSTRINGFIRSTMATCH`, this means typed leaves on those already-materialized trees now render `UUID`, `LocalDate`, and `LocalTime` values as unquoted canonical or ISO-8601 strings instead of JSON-quoted strings. The change is specific to ingestion-time typed objects and does not change behavior for normal JSON-string input.
 {% endhint %}
 
 ```javascript

--- a/functions/json/jsonpathstring.md
+++ b/functions/json/jsonpathstring.md
@@ -74,6 +74,10 @@ This function can be used in the [table config](../../reference/configuration-re
 }
 ```
 
+{% hint style="info" %}
+When `JSONPATHSTRING` reads from an already-materialized object tree during ingestion, it preserves the extractor's runtime types instead of reparsing JSON text. For typed leaves such as `UUID`, `LocalDate`, and `LocalTime`, `JSONPATHSTRING`, `JSONPATHSTRINGFAST`, and `JSONPATHSTRINGFIRSTMATCH` now return the canonical or ISO-8601 string without JSON quotes. This compatibility change does not affect normal JSON-string input, where the parser still produces ordinary JSON scalar types.
+{% endhint %}
+
 ## Fast and first-match variants
 
 Use the opt-in variants below when the path is a **simple linear path**: `$` followed only by `.name`, `['literal.key']`, or `[0]` segments. For more complex JsonPath features such as wildcards, deep scan (`..`), filters, unions, slices, negative indexes, or a bare `$`, Pinot falls back to the existing `JSONPATHSTRING` behavior.
@@ -84,7 +88,7 @@ Like `JSONPATHSTRING`, both variants are intended for [ingestion transformation 
 
 > JSONPATHSTRINGFAST(jsonField, 'jsonPath', \[defaultValue])
 
-`JSONPATHSTRINGFAST` resolves supported paths in a single forward pass over the JSON text instead of building the full Jayway DOM first. It keeps the same result as `JSONPATHSTRING`, including the same `defaultValue` handling, and falls back to the existing implementation when the path is not a simple linear path or the input is not a JSON object or array.
+`JSONPATHSTRINGFAST` resolves supported paths in a single forward pass over the JSON text instead of building the full Jayway DOM first. It keeps the same result as `JSONPATHSTRING`, including the same `defaultValue` handling and the same unquoted rendering for `UUID`, `LocalDate`, and `LocalTime` leaves on already-materialized object trees, and falls back to the existing implementation when the path is not a simple linear path or the input is not a JSON object or array.
 
 Use `JSONPATHSTRINGFAST` when you want lower ingestion CPU cost without changing semantics.
 


### PR DESCRIPTION
## Summary
- document the `JSONPATHSTRING` compatibility change from apache/pinot#19029
- clarify that unquoted `UUID`, `LocalDate`, and `LocalTime` rendering only applies when ingestion transforms read already-materialized object trees
- note that `JSONPATHSTRINGFAST` and `JSONPATHSTRINGFIRSTMATCH` keep identical results

## Validation
- cross-checked the behavior against `/Users/xiangfu/claude-workspace/pinot-doc-expert/pinot` and merged upstream PR apache/pinot#19029
- ran `git diff --check`
