### PR TITLE
docs: document minion upload failure retries

### DIFF
--- a/basics/components/cluster/minion.md
+++ b/basics/components/cluster/minion.md
@@ -216,6 +216,10 @@ Pinot ships with the following built-in Minion tasks:
 | [UpsertCompactionTask](../../../operate-pinot/upsert-compaction-task.md) | Compacts individual upsert segments by removing invalidated records | REALTIME (upsert only) |
 | [UpsertCompactMergeTask](../../../operate-pinot/upsert-compact-merge-task.md) | Merges multiple small upsert segments into larger ones to reduce segment count | REALTIME (upsert only) |
 
+{% hint style="info" %}
+`PurgeTask`, `RefreshSegmentTask`, and `UpsertCompactionTask` all rebuild a single segment and upload the replacement segment. If that upload fails, Pinot marks the task attempt as failed instead of reporting success, so the Minion task framework can retry it.
+{% endhint %}
+
 ### SegmentGenerationAndPushTask
 
 The SegmentGenerationAndPushTask can fetch files from an input folder (e.g. from an S3 bucket) and convert them into segments. It converts one file into one segment and keeps the file name in segment metadata to avoid duplicate ingestion.


### PR DESCRIPTION
## Summary
- document the shared Minion retry behavior for single-segment conversion tasks when replacement-segment upload fails
- keep the change on the Minion overview page because the behavior is implemented in the shared executor used by PurgeTask, RefreshSegmentTask, and UpsertCompactionTask

## Source cross-check
- apache/pinot#18813
- local source: `BaseSingleSegmentConversionExecutor`, `PurgeTaskExecutor`, `RefreshSegmentTaskExecutor`, `UpsertCompactionTaskExecutor`

## Validation
- `git diff --check`
- verified no navigation or internal-link changes were needed