### PR TITLE
docs: document T-digest compression floor

### DIFF
--- a/build-with-pinot/indexing/star-tree-index.md
+++ b/build-with-pinot/indexing/star-tree-index.md
@@ -154,9 +154,9 @@ All types of aggregation function that have a bounded-sized intermediate result 
 * PERCENTILE\_EST
 * PERCENTILE\_RAW\_EST
 * PERCENTILE\_TDIGEST
-  * The compression factor for the `TDigest` histogram can be optionally configured in `functionParameters` using the key `compressionFactor`. For example: `{"compressionFactor": 200}`.  If not configured, the default value of `100` will be used.
+  * The compression factor for the `TDigest` histogram can be optionally configured in `functionParameters` using the key `compressionFactor`. For example: `{"compressionFactor": 200}`.  If not configured, the default value of `100` will be used. Values below `10` use an effective compression factor of `10`.
 * PERCENTILE\_RAW\_TDIGEST
-  * The compression factor for the `TDigest` histogram can be optionally configured in `functionParameters` using the key `compressionFactor`. For example: `{"compressionFactor": 200}`. If not configured, the default value of `100` will be used.
+  * The compression factor for the `TDigest` histogram can be optionally configured in `functionParameters` using the key `compressionFactor`. For example: `{"compressionFactor": 200}`. If not configured, the default value of `100` will be used. Values below `10` use an effective compression factor of `10`.
 * DISTINCT\_COUNT\_BITMAP
   * NOTE: The intermediate result _RoaringBitmap_ is not bounded-sized, use carefully on high cardinality columns.
 * DISTINCT\_COUNT\_HLL

--- a/functions/aggregation/percentiletdigest.md
+++ b/functions/aggregation/percentiletdigest.md
@@ -6,7 +6,7 @@ description: >-
 
 # percentiletdigest
 
-Returns the Nth percentile of the group using [T-digest algorithm](https://raw.githubusercontent.com/tdunning/t-digest/master/docs/t-digest-paper/histo.pdf). An optional compression\_factor can be specified to control the accuracy with a tradeoff in memory usage (i.e. higher compression\_factor gives better accuracy but takes more memory). The default compression\_factor is 100.
+Returns the Nth percentile of the group using [T-digest algorithm](https://raw.githubusercontent.com/tdunning/t-digest/master/docs/t-digest-paper/histo.pdf). An optional compression\_factor can be specified to control the accuracy with a tradeoff in memory usage (i.e. higher compression\_factor gives better accuracy but takes more memory). The default compression\_factor is 100. Pinot uses an effective minimum compression factor of 10, so values below 10 behave as 10.
 
 ## Signature
 

--- a/functions/aggregation/percentiletdigestmv.md
+++ b/functions/aggregation/percentiletdigestmv.md
@@ -6,7 +6,7 @@ description: >-
 
 # percentiletdigestmv
 
-Returns the Nth percentile of the group using [T-digest algorithm](https://raw.githubusercontent.com/tdunning/t-digest/master/docs/t-digest-paper/histo.pdf). An optional compression\_factor can be specified to control the accuracy with a tradeoff in memory usage (i.e. higher compression\_factor gives better accuracy but takes more memory). The default compression\_factor is 100.
+Returns the Nth percentile of the group using [T-digest algorithm](https://raw.githubusercontent.com/tdunning/t-digest/master/docs/t-digest-paper/histo.pdf). An optional compression\_factor can be specified to control the accuracy with a tradeoff in memory usage (i.e. higher compression\_factor gives better accuracy but takes more memory). The default compression\_factor is 100. Pinot uses an effective minimum compression factor of 10, so values below 10 behave as 10.
 
 ## Signature
 


### PR DESCRIPTION
## Summary

Documents the compression-factor floor introduced with the t-digest 3.3 upgrade.

- Clarifies `PERCENTILETDIGEST` and `PERCENTILETDIGESTMV` inputs below 10 use effective compression 10.
- Adds the same behavior to star-tree `PERCENTILE_TDIGEST` and `PERCENTILE_RAW_TDIGEST` configuration guidance.

## Source cross-check

Cross-checked against `apache/pinot#19015`, including `PercentileTDigestAccumulator`, `PercentileTDigestMVAggregationFunction`, `PercentileTDigestValueAggregator`, and the star-tree value-aggregator factories.

## Validation

- `git diff --check`