### PR TITLE
docs: add multi-stage grouping sets support

### DIFF
--- a/build-with-pinot/querying-and-sql/sql-reference.md
+++ b/build-with-pinot/querying-and-sql/sql-reference.md
@@ -54,7 +54,7 @@ FROM table_reference
 [ OPTION ( key = value [, key = value ]* ) ]
 ```
 
-In the single-stage engine (SSE), the `GROUP BY` clause also accepts grouping constructs such as
+Both query engines accept grouping constructs in the `GROUP BY` clause, such as
 `ROLLUP(...)`, `CUBE(...)`, and `GROUPING SETS (...)`. See [GROUP BY](#group-by) for syntax and limits.
 
 ### Column Expressions
@@ -304,9 +304,10 @@ GROUP BY city
 - Aggregation functions and non-aggregation columns cannot be mixed in the `SELECT` list without a `GROUP BY`.
 - Aggregate expressions are not allowed inside the `GROUP BY` clause.
 
-### GROUPING SETS, ROLLUP, and CUBE (SSE Only)
+### GROUPING SETS, ROLLUP, and CUBE
 
-Pinot's single-stage engine also supports grouped subtotal queries:
+Both Pinot query engines support grouped subtotal queries. To run a grouping-set query on the multi-stage engine,
+enable it with `SET useMultistageEngine=true`.
 
 ```sql
 SELECT country, city, SUM(revenue) AS total_revenue
@@ -324,11 +325,6 @@ Use the following forms:
 `()` represents the grand-total grouping set. Pinot de-duplicates repeated grouping sets, so
 `GROUPING SETS ((a), (a), ())` returns only one `(a)` subtotal.
 
-{% hint style="warning" %}
-`GROUPING SETS`, `ROLLUP`, and `CUBE` currently run only on the single-stage engine. Do not set
-`useMultistageEngine=true` for these queries.
-{% endhint %}
-
 ```sql
 SELECT country, city, SUM(revenue) AS total_revenue
 FROM sales
@@ -338,12 +334,14 @@ GROUP BY GROUPING SETS ((country, city), (country), ())
 Important limits and caveats:
 
 - Pinot requires at least one aggregation function somewhere in the query (`SELECT`, `HAVING`, or `ORDER BY`)
-- A query can reference at most `31` distinct grouping columns and expand to at most `4096` grouping sets
-- `DISTINCT` is not supported together with `GROUPING SETS`, `ROLLUP`, or `CUBE`
+- A query can expand to at most `4096` grouping sets. In particular, a `CUBE` can contain at most `12` grouping levels.
+- The number of grouping columns is unlimited, but each `GROUPING()` or `GROUPING_ID()` call accepts at most `31` arguments.
+- MSE grouping-set queries do not support ordered aggregate expressions with `WITHIN GROUP` or aggregate hints.
+- With `usePhysicalOptimizer=true`, MSE grouping-set queries do not support joins.
 - Rolled-up columns are returned as real `NULL` values even when null handling is disabled
 - Existing non-grouping-set queries remain wire-compatible during a rolling upgrade, but do not issue grouping-set queries until all servers are upgraded
 
-### GROUPING() and GROUPING_ID() (SSE Only)
+### GROUPING() and GROUPING_ID()
 
 Use `GROUPING()` and `GROUPING_ID()` to tell subtotal rows apart from genuine data `NULL`s:
 
@@ -762,8 +760,8 @@ The following table summarizes feature support across the single-stage engine (S
 | Feature | SSE | MSE |
 |---|---|---|
 | SELECT, WHERE, GROUP BY, HAVING, ORDER BY, LIMIT | Yes | Yes |
-| GROUPING SETS / ROLLUP / CUBE | Yes | No |
-| GROUPING() / GROUPING_ID() | Yes | No |
+| GROUPING SETS / ROLLUP / CUBE | Yes | Yes |
+| GROUPING() / GROUPING_ID() | Yes | Yes |
 | DISTINCT | Yes | Yes |
 | Aggregation functions | Yes | Yes |
 | CASE WHEN | Yes | Yes |

--- a/build-with-pinot/querying-and-sql/sse-vs-mse.md
+++ b/build-with-pinot/querying-and-sql/sse-vs-mse.md
@@ -4,7 +4,7 @@ description: Understand the differences between the single-stage engine (SSE) an
 
 # Query Engines (SSE vs MSE)
 
-Pinot ships two supported query engines. The **single-stage engine (SSE)** uses a scatter-gather model and is the default for simple analytic queries. The **multi-stage engine (MSE)** supports distributed joins, window functions, subqueries, set operations, and many advanced SQL operations. `GROUPING SETS`, `ROLLUP`, `CUBE`, `GROUPING()`, and `GROUPING_ID()` are a current exception: they run on SSE only.
+Pinot ships two supported query engines. The **single-stage engine (SSE)** uses a scatter-gather model and is the default for simple analytic queries. The **multi-stage engine (MSE)** supports distributed joins, window functions, subqueries, set operations, and many advanced SQL operations, including `GROUPING SETS`, `ROLLUP`, `CUBE`, `GROUPING()`, and `GROUPING_ID()`.
 
 SSE is the default because it has lower overhead for the most common Pinot workloads; that default does not imply that MSE is experimental. MSE is Pinot's supported engine for queries that require relational operators beyond simple scatter-gather execution.
 
@@ -17,7 +17,7 @@ SSE is the default because it has lower overhead for the most common Pinot workl
 | If your query needs… | Use | Why |
 | --- | --- | --- |
 | Basic filtering, projection, aggregation | SSE | Lowest overhead; simple scatter-gather model |
-| `GROUP BY GROUPING SETS`, `ROLLUP`, `CUBE`, `GROUPING()`, or `GROUPING_ID()` | SSE | These grouping features are currently implemented only in SSE |
+| `GROUP BY GROUPING SETS`, `ROLLUP`, `CUBE`, `GROUPING()`, or `GROUPING_ID()` | SSE or MSE | Supported by both engines; use MSE when the query also needs multi-stage features |
 | JOINs | MSE | JOIN support requires the multi-stage engine |
 | Window functions | MSE | Window functions require multi-stage execution |
 | Colocated or partitioned joins | MSE | These are multi-stage patterns |
@@ -34,20 +34,20 @@ The single-stage engine uses a scatter-gather execution model. The broker receiv
 **Choose SSE when:**
 
 - The query is a plain scatter-gather read over one or more tables
-- You need `GROUP BY GROUPING SETS`, `ROLLUP`, `CUBE`, `GROUPING()`, or `GROUPING_ID()`
 - You only need functions available in both engines
 - You want the lowest conceptual and operational overhead
 
 SSE is the default fit for the most common Pinot workloads: filter, project, group, and aggregate.
 
-### Grouping sets on SSE
+### Grouping sets
 
-`GROUPING SETS`, `ROLLUP`, `CUBE`, `GROUPING()`, and `GROUPING_ID()` currently execute only on SSE. Leave
-`useMultistageEngine` unset or set it to `false` for those queries.
+`GROUPING SETS`, `ROLLUP`, `CUBE`, `GROUPING()`, and `GROUPING_ID()` execute on both engines. To run them
+on MSE, set `useMultistageEngine=true`. See [GROUP BY](sql-reference.md#group-by) for syntax, limits, and
+MSE-specific restrictions.
 
-During a rolling upgrade, existing queries that do not use grouping sets remain wire-compatible. The new
-grouping-set feature itself should be used only after all servers are upgraded; otherwise Pinot rejects the
-query with an actionable "upgrade all servers" error instead of returning a partial or incorrect result.
+During a rolling upgrade, existing queries that do not use grouping sets remain wire-compatible. Use grouping-set
+queries only after all servers are upgraded. Older servers do not understand the grouping-set request metadata and
+can return an error or incorrect result.
 
 ## Multi-stage engine (MSE)
 
@@ -59,7 +59,7 @@ The multi-stage engine decouples the data exchange layer from the query engine l
 
 **Choose MSE when:**
 
-- You need `JOIN`, window functions, or subqueries
+- You need `JOIN`, window functions, subqueries, or grouping sets with other multi-stage features
 - You need distributed query execution with intermediate stages
 - You are running complex ANSI SQL
 


### PR DESCRIPTION
## Summary
- document `GROUPING SETS`, `ROLLUP`, `CUBE`, `GROUPING()`, and `GROUPING_ID()` support in the multi-stage engine
- correct the SQL reference compatibility matrix and grouping-set limits
- describe MSE-specific restrictions and rolling-upgrade requirements

## Source validation
Cross-checked against apache/pinot#18817 and the merged parser, planner, and integration tests for grouping sets.

## Validation
- `git diff --check`
- verified the updated internal documentation link target exists