### PR TITLE
docs: warn against metadata TTL with upsert compaction

### DIFF
--- a/operate-pinot/upsert-compact-merge-task.md
+++ b/operate-pinot/upsert-compact-merge-task.md
@@ -10,6 +10,10 @@ The Upsert Compact Merge Task, also known as the small segment merger, allows yo
 
 This task is only supported for REALTIME tables with upsert enabled.
 
+{% hint style="warning" %}
+Do not configure `UpsertCompactMergeTask` when `upsertConfig.metadataTTL` is greater than zero. Pinot rejects this combination when it schedules the task because the compaction and metadata-TTL cleanup paths use incompatible definitions of valid records. Disable the task or unset `metadataTTL`; changing `metadataTTL` requires a server restart to take effect.
+{% endhint %}
+
 > **ℹ️ New in Pinot 1.3.0**: This task was introduced in version 1.3.0 to address segment proliferation in upsert tables. It works alongside the existing UpsertCompactionTask but focuses on merging multiple small segments rather than compacting individual segments.
 
 > **⚠️ Important Bug Fix**: An issue was identified ([#15846](https://github.com/apache/pinot/issues/15846)) in the initial implementation, which has been fixed via [PR #16034](https://github.com/apache/pinot/pull/16034) and [PR #16086](https://github.com/apache/pinot/pull/16086). These fixes are not present in Pinot 1.3.0. If you plan to use this task, make sure to cherry-pick these PRs or wait for Pinot 1.4.0 release.

--- a/operate-pinot/upsert-compaction-task.md
+++ b/operate-pinot/upsert-compaction-task.md
@@ -4,6 +4,10 @@ The Upsert Compaction Task allows you reclaim disk space occupied by older versi
 
 This task is only supported for REALTIME tables with upsert enabled.
 
+{% hint style="warning" %}
+Do not configure `UpsertCompactionTask` when `upsertConfig.metadataTTL` is greater than zero. Pinot rejects this combination when it schedules the task because the compaction and metadata-TTL cleanup paths use incompatible definitions of valid records. Disable the task or unset `metadataTTL`; changing `metadataTTL` requires a server restart to take effect.
+{% endhint %}
+
 ### Task overview
 
 The Upsert Compaction Task selects completed segments for compaction based on the provided task configuration and generates a replacement segment for each segment that meets the selection criteria.


### PR DESCRIPTION
## Summary
- document that metadata TTL cannot be combined with upsert compaction or compact-merge tasks
- explain the scheduler validation and the required remediation

## Source validation
Cross-checked against apache/pinot#19057 and the merged task-generator validation.

## Validation
- `git diff --check`