### PR TITLE
docs: document LEAD and LAG null handling

### DIFF
--- a/build-with-pinot/querying-and-sql/function-index.md
+++ b/build-with-pinot/querying-and-sql/function-index.md
@@ -477,8 +477,8 @@ Window functions require the [multi-stage engine (MSE)](../../reference/configur
 | [`ROW_NUMBER`](../../functions/window/row_number.md) | `ROW_NUMBER() OVER (...)` | LONG | Sequential row number within partition | MSE |
 | [`RANK`](../../functions/window/rank.md) | `RANK() OVER (...)` | LONG | Rank with gaps for ties | MSE |
 | [`DENSE_RANK`](../../functions/window/dense_rank.md) | `DENSE_RANK() OVER (...)` | LONG | Rank without gaps for ties | MSE |
-| `LAG` | `LAG(col [, offset [, default]]) OVER (...)` | varies | Value from a preceding row | MSE |
-| `LEAD` | `LEAD(col [, offset [, default]]) OVER (...)` | varies | Value from a following row | MSE |
+| `LAG` | `LAG(col [, offset [, default]]) [IGNORE NULLS \| RESPECT NULLS] OVER (...)` | varies | Value from a preceding row | MSE |
+| `LEAD` | `LEAD(col [, offset [, default]]) [IGNORE NULLS \| RESPECT NULLS] OVER (...)` | varies | Value from a following row | MSE |
 | `FIRST_VALUE` | `FIRST_VALUE(col) OVER (...)` | varies | First value in the window frame | MSE |
 | `LAST_VALUE` | `LAST_VALUE(col) OVER (...)` | varies | Last value in the window frame | MSE |
 | [`SUM`](../../functions/aggregation/sum.md) | `SUM(col) OVER (...)` | DOUBLE | Running/windowed sum | MSE |

--- a/functions/aggregation/lag.md
+++ b/functions/aggregation/lag.md
@@ -9,7 +9,7 @@ Returns the value from a preceding row in the same result set, based on a specif
 ### Signature
 
 ```sql
-LAG(any expression [, bigint offset [, any default]])
+LAG(any expression [, bigint offset [, any default]]) [IGNORE NULLS | RESPECT NULLS] OVER (...)
 ```
 
 ### Arguments
@@ -17,6 +17,20 @@ LAG(any expression [, bigint offset [, any default]])
 * expression: The column or calculation from which the value is to be returned.
 * offset: The number of rows before the current row from which to retrieve the value. The default is 1 if not specified.
 * default: The value to return if the offset goes beyond the scope of the window. If not specified, NULL is returned.
+
+### Null handling
+
+Use `IGNORE NULLS` after the `LAG` call to skip null expression values when Pinot counts the offset. Use `RESPECT NULLS` to count null values; it is the default behavior.
+
+When `IGNORE NULLS` cannot find a preceding non-null value at the requested offset, Pinot returns the optional `default` value, or `NULL` when no default is specified.
+
+```sql
+SELECT
+    sales_date,
+    sales_amount,
+    LAG(sales_amount) IGNORE NULLS OVER (ORDER BY sales_date) AS previous_non_null_sales
+FROM daily_sales;
+```
 
 ### Example
 

--- a/functions/aggregation/lead.md
+++ b/functions/aggregation/lead.md
@@ -9,14 +9,28 @@ Returns the value from a following row in the same result set, based on a specif
 ### Signature
 
 ```sql
-LEAD(any expression [, bigint offset [, any default]])
+LEAD(any expression [, bigint offset [, any default]]) [IGNORE NULLS | RESPECT NULLS] OVER (...)
 ```
 
 ### Arguments
 
 * expression: The column or calculation from which the value is to be returned.
-* offset: The number of rows before the current row from which to retrieve the value. The default is 1 if not specified.
+* offset: The number of rows after the current row from which to retrieve the value. The default is 1 if not specified.
 * default: The value to return if the offset goes beyond the scope of the window. If not specified, NULL is returned.
+
+### Null handling
+
+Use `IGNORE NULLS` after the `LEAD` call to skip null expression values when Pinot counts the offset. Use `RESPECT NULLS` to count null values; it is the default behavior.
+
+When `IGNORE NULLS` cannot find a following non-null value at the requested offset, Pinot returns the optional `default` value, or `NULL` when no default is specified.
+
+```sql
+SELECT
+    sales_date,
+    sales_amount,
+    LEAD(sales_amount) IGNORE NULLS OVER (ORDER BY sales_date) AS next_non_null_sales
+FROM daily_sales;
+```
 
 ### Example
 

--- a/functions/window/README.md
+++ b/functions/window/README.md
@@ -186,8 +186,8 @@ Supported window functions are listed in the following table.
 | [**MIN**](../../functions/aggregation/min.md) | Returns the minimum value of a numeric column as `Double` | `MIN(playerScore)` | `null` |
 | [**MAX**](../../functions/aggregation/max.md) | Returns the maximum value of a numeric column as `Double` | `MAX(playerScore)` | `null` |
 | [**SUM**](../../functions/aggregation/sum.md) | Returns the sum of the values for a numeric column as `Double` | `SUM(playerScore)` | `null` |
-| [LEAD](../../functions/aggregation/lead.md) | The `LEAD` function provides access to a subsequent row within the same result set, without the need for a self-join. | `LEAD(column_name, offset, default_value)` |  |
-| [LAG](../../functions/aggregation/lag.md) | The `LAG` function provides access to a previous row within the same result set, without the need for a self-join. | `LAG(column_name, offset, default_value)` |  |
+| [LEAD](../../functions/aggregation/lead.md) | The `LEAD` function provides access to a subsequent row within the same result set, without the need for a self-join. | `LEAD(column_name [, offset [, default_value]]) [IGNORE NULLS \| RESPECT NULLS]` |  |
+| [LAG](../../functions/aggregation/lag.md) | The `LAG` function provides access to a previous row within the same result set, without the need for a self-join. | `LAG(column_name [, offset [, default_value]]) [IGNORE NULLS \| RESPECT NULLS]` |  |
 | [FIRST_VALUE](../../functions/aggregation/first_value.md) | The `FIRST_VALUE` function returns the value from the first row in the window. | `FIRST_VALUE(salary)` |  |
 | [LAST_VALUE](../../functions/aggregation/last_value.md) | The `LAST_VALUE` function returns the value from the last row in the window | `LAST_VALUE(salary)` |  |
 | [ROW_NUMBER](row_number.md) | Returns the number of the current row within its partition, counting from 1. | `ROW_NUMBER()` |  |


### PR DESCRIPTION
## Reader impact
- Document `IGNORE NULLS` and `RESPECT NULLS` for multi-stage `LEAD` and `LAG` window functions.
- Explain how null-skipping interacts with offsets and default values.

## Source cross-check
- Verified syntax and behavior against `apache/pinot#18202`, `OffsetValueWindowFunction`, `LeadValueWindowFunction`, `LagValueWindowFunction`, and window-function query tests.

## Validation
- `git diff --check`

Closes documentation follow-up for apache/pinot#18202.