### PR TITLE
docs: document immutable ingestion transforms

### DIFF
--- a/build-with-pinot/ingestion/ingestion-level-transformations.md
+++ b/build-with-pinot/ingestion/ingestion-level-transformations.md
@@ -73,7 +73,19 @@ The full request and response examples for these endpoints are in the [controlle
 
 ### Built-in Pinot functions
 
-All the functions defined in [this directory](https://github.com/apache/pinot/tree/02cb2d4970c71a2ea5b4c140a860fbf220e11bd3/pinot-common/src/main/java/org/apache/pinot/common/function/scalar) annotated with `@ScalarFunction` (for example, [toEpochSeconds](https://github.com/apache/pinot/blob/02cb2d4970c71a2ea5b4c140a860fbf220e11bd3/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/DateTimeFunctions.java#L78)) are supported ingestion transformation functions.
+Pinot supports registered scalar functions for ingestion transformations. Functions are annotated with `@ScalarFunction`; for example, [toEpochSeconds](https://github.com/apache/pinot/blob/02cb2d4970c71a2ea5b4c140a860fbf220e11bd3/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/DateTimeFunctions.java#L78).
+
+#### Immutable function requirement
+
+New or changed persisted ingestion transforms can use only scalar functions whose result depends solely on their explicit arguments (`IMMUTABLE` functions). Pinot applies this rule to:
+
+- `ingestionConfig.transformConfigs` in table configs
+- schema-level `transformFunction` definitions
+- `upsertConfig.postPartialUpsertTransformConfigs` for partial-upsert tables
+
+The check includes nested scalar function calls. For example, `now()`, `ago()`, `agoMV()`, and unseeded `rand()` are not valid in a new or changed persisted transform because they can produce different values for the same input. `rand(seed)` is valid because its result is derived from its explicit seed.
+
+Pinot keeps exact existing transform definitions running for compatibility. If you add or modify a persisted transform, replace any non-immutable function with an input-derived alternative before submitting the schema or table config. This validation does not change the functions' query-time behavior. Groovy expressions continue through Pinot's existing Groovy validation rather than scalar-function volatility metadata.
 
 Below are some commonly used built-in Pinot functions for ingestion transformations.
 

--- a/functions/udf/README.md
+++ b/functions/udf/README.md
@@ -111,6 +111,24 @@ static String mySubStr(String input, Integer beginIndex) {
 }
 ```
 
+#### Declare function volatility for ingestion
+
+If a scalar UDF can be used in a persisted ingestion transform, declare its volatility accurately. Pinot accepts only `IMMUTABLE` scalar functions in new or changed ingestion transforms. `IMMUTABLE` functions depend only on their explicit arguments; `STABLE` functions can change between queries; and `VOLATILE` functions can change for each invocation or have side effects. `STABLE` and `VOLATILE` functions remain available in queries but are not valid in new or changed persisted ingestion transforms.
+
+`@ScalarFunction` defaults to `IMMUTABLE` for compatibility. Leave that default only when it is correct for the function. For a UDF that reads time, randomness, mutable state, or an external system, set the appropriate category explicitly:
+
+```java
+import org.apache.pinot.spi.annotations.FunctionVolatility;
+import org.apache.pinot.spi.annotations.ScalarFunction;
+
+@ScalarFunction(volatility = FunctionVolatility.VOLATILE)
+static long currentTime() {
+  return System.currentTimeMillis();
+}
+```
+
+Function volatility is separate from `isDeterministic`, which controls Pinot's compile-time query evaluation behavior. A UDF with `isDeterministic = false` is also treated as `VOLATILE` for persisted ingestion-transform validation.
+
 * Place the compiled JAR in the `/plugins` directory in pinot. You will need to restart all Pinot instances if they are already running.
 * Now, you can use the function in a query as follows:
 


### PR DESCRIPTION
## Summary

- document the immutable-only rule for new and changed persisted ingestion transforms
- explain legacy-transform compatibility and examples of disallowed and allowed functions
- document `@ScalarFunction` volatility for UDF authors

## Source cross-check

Cross-checked against `apache/pinot#18932`, including `ScalarFunction`, `FunctionInfo`, `TableConfigUtils`, and `SchemaUtils`.

## Validation

- `git diff --check`
- verified balanced fenced code blocks in the changed Markdown files