### PR TITLE
docs: document JSONPath numeric scalar conversions

### DIFF
--- a/functions/json/jsonpathdouble.md
+++ b/functions/json/jsonpathdouble.md
@@ -69,6 +69,20 @@ This function can be used in the [table config](../../reference/configuration-re
 }
 ```
 
+## Value conversion
+
+`JSONPATHDOUBLE` converts a matched value to a double as follows:
+
+| Matched value | Result |
+| --- | --- |
+| Number | The value's double representation |
+| Boolean | `true` becomes `1.0`; `false` becomes `0.0` |
+| `TIMESTAMP` in materialized input | Epoch milliseconds |
+| `DATE` in materialized input | Days since the Unix epoch |
+| `TIME` in materialized input | Milliseconds since midnight |
+
+The `TIMESTAMP`, `DATE`, and `TIME` conversions apply when an extractor has already materialized the input as a record object instead of JSON text. `TIME` values drop sub-millisecond precision. Missing or null values, non-numeric values, and conversion errors return `defaultValue` when it is supplied.
+
 ## Fast and first-match variants
 
 Use the opt-in variants below when the path is a **simple linear path**: `$` followed only by `.name`, `['literal.key']`, or `[0]` segments. For more complex JsonPath features such as wildcards, deep scan (`..`), filters, unions, slices, negative indexes, or a bare `$`, Pinot falls back to the existing `JSONPATHDOUBLE` behavior.

--- a/functions/json/jsonpathlong.md
+++ b/functions/json/jsonpathlong.md
@@ -69,6 +69,20 @@ This function can be used in the [table config](../../reference/configuration-re
 }
 ```
 
+## Value conversion
+
+`JSONPATHLONG` converts a matched value to a long as follows:
+
+| Matched value | Result |
+| --- | --- |
+| Number | The value's long representation |
+| Boolean | `true` becomes `1`; `false` becomes `0` |
+| `TIMESTAMP` in materialized input | Epoch milliseconds |
+| `DATE` in materialized input | Days since the Unix epoch |
+| `TIME` in materialized input | Milliseconds since midnight |
+
+The `TIMESTAMP`, `DATE`, and `TIME` conversions apply when an extractor has already materialized the input as a record object instead of JSON text. Missing or null values, non-numeric values, and conversion errors return `defaultValue` when it is supplied.
+
 ## Fast and first-match variants
 
 Use the opt-in variants below when the path is a **simple linear path**: `$` followed only by `.name`, `['literal.key']`, or `[0]` segments. For more complex JsonPath features such as wildcards, deep scan (`..`), filters, unions, slices, negative indexes, or a bare `$`, Pinot falls back to the existing `JSONPATHLONG` behavior.


### PR DESCRIPTION
## Summary

Documents how `JSONPATHLONG` and `JSONPATHDOUBLE` convert numeric, boolean, and materialized temporal values. Readers can now see the behavior of the standard, FAST, and FIRSTMATCH function families when transforming extractor-produced record objects.

## Structure

- Added a `Value conversion` section to the existing `JSONPATHLONG` reference page.
- Added the matching section to the existing `JSONPATHDOUBLE` reference page.
- No navigation or URL changes were required because both pages are already linked from the JSON function index.

## Source cross-check

Cross-checked against `JsonFunctions.jsonValueToLong`, `JsonFunctions.jsonValueToDouble`, and `JsonFunctionsTest` in `apache/pinot` after apache/pinot#19138.

## Validation

- `git diff --check`
- Confirmed existing JSON function index links for both updated pages.