### PR TITLE
Document offline upsert comparison-column requirement

### DIFF
--- a/build-with-pinot/ingestion/upsert-and-dedup/offline-table-upsert.md
+++ b/build-with-pinot/ingestion/upsert-and-dedup/offline-table-upsert.md
@@ -18,6 +18,8 @@ For duplicate keys, Pinot keeps the row with the greatest comparison value.
 
 If you do not set `comparisonColumns`, Pinot uses the table time column.
 
+An offline upsert table must define either `upsertConfig.comparisonColumns` or `segmentsConfig.timeColumnName`. Pinot rejects the table configuration when neither is set; segment creation time is not used as an implicit comparison value.
+
 Offline upsert replaces full rows.
 
 It does not merge partial rows.


### PR DESCRIPTION
Documents the user-facing validation behavior restored by apache/pinot#19177.

- States that offline upsert requires explicit comparison columns or a table time column.
- Clarifies that segment creation time is not an implicit fallback.