### PR TITLE
Document covariance null handling

### DIFF
--- a/functions/statistical/README.md
+++ b/functions/statistical/README.md
@@ -117,7 +117,7 @@ FROM apiMetrics
 
 ## Notes
 
-- All statistical functions return `Double.NaN` or `Double.NEGATIVE_INFINITY` when no records are selected.
+- With advanced null handling enabled, covariance functions skip a row when either input is null. They return `NULL` when no rows contribute; `COVAR_SAMP` also returns `NULL` when fewer than two rows contribute. Without advanced null handling, Pinot uses column default null values.
 - These functions operate on numeric columns only (`INT`, `LONG`, `FLOAT`, `DOUBLE`).
 - For variance and standard deviation, use the `_POP` variant when you have the entire population and the `_SAMP` variant when working with a sample.
 - All statistical functions are supported in both the Single-Stage Engine (SSE) and Multi-Stage Engine (MSE).

--- a/functions/statistical/covar_pop.md
+++ b/functions/statistical/covar_pop.md
@@ -14,6 +14,8 @@ COVAR_POP(col1, col2) = E[col1 * col2] - E[col1]E[col2]
 
 `COVAR_POP(col1, col2) -> double`
 
+When advanced null handling is enabled, a row contributes only when both columns are non-null. The function returns `NULL` when no rows contribute. Without advanced null handling, Pinot uses each column's configured default null value.
+
 ## Usage Examples
 
 These examples are based on the [Batch Quick Start](../../basics/getting-started/quick-start.md#batch-processing).

--- a/functions/statistical/covar_samp.md
+++ b/functions/statistical/covar_samp.md
@@ -14,6 +14,8 @@ COVAR_SAMP(col1, col2) = COVAR_POP(col1, col2) * besselCorrection
 
 `COVAR_SAMP(col1, col2) -> double`
 
+When advanced null handling is enabled, a row contributes only when both columns are non-null. The function returns `NULL` when no rows contribute or when fewer than two rows contribute, because sample covariance is undefined in those cases. Without advanced null handling, Pinot uses each column's configured default null value.
+
 ## Usage Examples
 
 These examples are based on the [Batch Quick Start](../../basics/getting-started/quick-start.md#batch-processing).


### PR DESCRIPTION
Documents the null-handling behavior of `COVAR_POP` and `COVAR_SAMP`, including the requirement that both inputs be non-null and the empty or insufficient-input results.\n\nFollow-up to apache/pinot#19211.