### PR TITLE
Clarify consistent push and rollback wording

### DIFF
--- a/operate-pinot/consistent-push-and-rollback.md
+++ b/operate-pinot/consistent-push-and-rollback.md
@@ -16,7 +16,7 @@ Pinot supports atomic update on segment level, which means that when data consis
 
 Furthermore, Pinot currently does not support data rollback features. In case of a bad data push, the table owner needs to re-run the flow with the previous data and re-ingest data to Pinot. This end-to-end process can take hours and the Pinot table can potentially be in a bad state during this long period.
 
-The consistent push and rollback protocol allows a user to **atomically switch between data snapshots and rollback to the previous data in the case of a bad data push**. For complete motivation and reasoning, refer to the design doc above. Currently, we only support **OFFLINE table REFRESH use cases**.
+The consistent push and rollback protocol allows a user to **consistently switch between data snapshots (atomic at the broker level) and rollback to the previous data in the case of a bad data push**. For complete motivation and reasoning, refer to the design doc above. Currently, we only support **OFFLINE table REFRESH use cases**.
 
 ### How this works
 


### PR DESCRIPTION
## Summary

The docs currently state that the consistent push and rollback protocol allows a user to **atomically switch** between data snapshots. That overstates the guarantee: the switch is *consistent* per query, but not atomic system-wide.

The [original design doc](https://docs.google.com/document/d/1PUy4wSUPFyEWEW3a88Mipdug3cPj4EpV__lx-BVUTYk/edit?tab=t.0#heading=h.bfszlip9ndda) says: "We aim to support atomic switching (**on broker level**)." That phrasing scopes atomicity to a single broker's view of a query — it does not promise that every broker in the cluster flips to the new snapshot at the same instant. Because segment replacement is coordinated via the segment lineage metadata in ZooKeeper and each broker refreshes its routing table independently, different brokers can observe the switch at slightly different times. A client sending queries to broker A and broker B during that window may see A already on the new snapshot while B is still serving the old one.

So "atomic" is only true from the perspective of a single query hitting a single broker (no interleaving of old/new segments within that query) — it is not a cluster-wide atomic commit. This PR updates the wording to say the switch is **consistent**, and to explicitly note that atomicity is scoped to the broker level, so it's clear to readers that cross-broker atomicity is not guaranteed.

## Test plan

- [x] Doc-only change; rendered the updated sentence to confirm formatting is intact.