### PR TITLE
Document integer tuple sketch null handling

### DIFF
--- a/functions/sketch/README.md
+++ b/functions/sketch/README.md
@@ -51,6 +51,8 @@ The [Tuple Sketch](https://datasketches.apache.org/docs/Tuple/TupleOverview.html
 | [AVGVALUEINTEGERSUMTUPLESKETCH](avgvalueintegersumtuplesketch.md) | Average of summary values |
 | [SUMVALUESINTEGERSUMTUPLESKETCH](sumvaluesintegersumtuplesketch.md) | Sum of summary values |
 
+With advanced null handling enabled, integer tuple-sketch aggregations skip rows whose sketch column is null. If no sketches contribute, `DISTINCTCOUNTTUPLESKETCH` and `SUMVALUESINTEGERSUMTUPLESKETCH` return `NULL`, `DISTINCTCOUNTRAWINTEGERSUMTUPLESKETCH` returns `NULL`, and `AVGVALUEINTEGERSUMTUPLESKETCH` returns `NULL`. Without advanced null handling, Pinot aggregates the column's default null value and preserves the legacy empty-sketch identities.
+
 ## Frequency Sketches
 
 | Function | Description |

--- a/functions/sketch/avgvalueintegersumtuplesketch.md
+++ b/functions/sketch/avgvalueintegersumtuplesketch.md
@@ -18,6 +18,8 @@ The [Tuple Sketch](https://datasketches.apache.org/docs/Tuple/TupleOverview.html
    * `nominalEntries`: The nominal entries used to create the sketch. (Default 65536)
    * `accumulatorThreshold`: How many sketches should be kept in memory before merging. (Default 2)
 
+With advanced null handling enabled, rows whose sketch column is null are skipped. The function returns `NULL` when no sketches contribute. Without advanced null handling, Pinot uses the column's default null value; an empty input also returns `NULL` because there are no retained entries to average.
+
 These examples are based on the [Batch Quick Start](../../basics/getting-started/quick-start.md#batch-processing).  A new Tuple Sketch metric called `playerHomeRuns` was created during ingestion by updating the ingestion config as follows:
 
 ```json

--- a/functions/sketch/distinctcountrawintegersumtuplesketch.md
+++ b/functions/sketch/distinctcountrawintegersumtuplesketch.md
@@ -18,6 +18,8 @@ The [Tuple Sketch](https://datasketches.apache.org/docs/Tuple/TupleOverview.html
    * `nominalEntries`: The nominal entries used to create the sketch. (Default 65536)
    * `accumulatorThreshold`: How many sketches should be kept in memory before merging. (Default 2)
 
+With advanced null handling enabled, rows whose sketch column is null are skipped. The function returns `NULL` when no sketches contribute. Without advanced null handling, Pinot uses the column's default null value and an empty input returns the serialized empty sketch.
+
 These examples are based on the [Batch Quick Start](../../basics/getting-started/quick-start.md#batch-processing).  A new Tuple Sketch metric called `playerHomeRuns` was created during ingestion by updating the ingestion config as follows:
 
 ```json

--- a/functions/sketch/distinctcounttuplesketch.md
+++ b/functions/sketch/distinctcounttuplesketch.md
@@ -18,6 +18,8 @@ The [Tuple Sketch](https://datasketches.apache.org/docs/Tuple/TupleOverview.html
    * `nominalEntries`: The nominal entries used to create the sketch. (Default 65536)
    * `accumulatorThreshold`: How many sketches should be kept in memory before merging. (Default 2)
 
+With advanced null handling enabled, rows whose sketch column is null are skipped. The function returns `NULL` when no sketches contribute. Without advanced null handling, Pinot uses the column's default null value and an empty input retains the legacy estimate of `0`.
+
 These examples are based on the [Batch Quick Start](../../basics/getting-started/quick-start.md#batch-processing).  A new Tuple Sketch metric called `playerHomeRuns` was created during ingestion by updating the ingestion config as follows:
 
 ```json

--- a/functions/sketch/sumvaluesintegersumtuplesketch.md
+++ b/functions/sketch/sumvaluesintegersumtuplesketch.md
@@ -18,6 +18,8 @@ The [Tuple Sketch](https://datasketches.apache.org/docs/Tuple/TupleOverview.html
    * `nominalEntries`: The nominal entries used to create the sketch. (Default 65536)
    * `accumulatorThreshold`: How many sketches should be kept in memory before merging. (Default 2)
 
+With advanced null handling enabled, rows whose sketch column is null are skipped. The function returns `NULL` when no sketches contribute. Without advanced null handling, Pinot uses the column's default null value and an empty input retains the legacy sum of `0`.
+
 These examples are based on the [Batch Quick Start](../../basics/getting-started/quick-start.md#batch-processing).  A new Tuple Sketch metric called `playerHomeRuns` was created during ingestion by updating the ingestion config as follows:
 
 ```json


### PR DESCRIPTION
Documents advanced null handling for the integer tuple-sketch aggregation family, including null-row filtering and empty-input results.\n\nFollow-up to apache/pinot#19217.