### PR TITLE
Document frequency sketch null handling

### DIFF
--- a/functions/sketch/README.md
+++ b/functions/sketch/README.md
@@ -59,3 +59,5 @@ With advanced null handling enabled, integer tuple-sketch aggregations skip rows
 | -------- | ----------- |
 | [FREQUENTLONGSSKETCH](frequentlongssketch.md) | Frequent items sketch for long values |
 | [FREQUENTSTRINGSSKETCH](frequentstringssketch.md) | Frequent items sketch for string values |
+
+With advanced null handling enabled, frequency-sketch functions skip null rows and return `NULL` when no values contribute. Without advanced null handling, the column's default null value contributes to the frequency estimate.

--- a/functions/sketch/frequentlongssketch.md
+++ b/functions/sketch/frequentlongssketch.md
@@ -15,6 +15,8 @@ description: >-
 * `column` (required): Name of the column to aggregate on. Needs to be a type which can be cast into 'LONG'.
 * `maxMapSize`: This value specifies the maximum physical length of the internal hash map. The maxMapSize must be a power of 2 and the default value is 256.
 
+With advanced null handling enabled, Pinot skips null rows instead of counting the column's default null value as an item. If no rows contribute, the function returns `NULL`. Without advanced null handling, Pinot includes the column's default null value. Pinot limits aggregation to the rows in each processing block, so values left in a reused internal buffer are not counted again.
+
 ## Usage Example
 
 ```sql

--- a/functions/sketch/frequentstringssketch.md
+++ b/functions/sketch/frequentstringssketch.md
@@ -15,6 +15,8 @@ description: >-
 * `column` (required): Name of the column to aggregate on. Needs to be a type which can be cast into 'STRING'.
 * `maxMapSize`: This value specifies the maximum physical length of the internal hash map. The maxMapSize must be a power of 2 and the default value is 256.
 
+With advanced null handling enabled, Pinot skips null rows instead of counting the column's default null value as an item. If no rows contribute, the function returns `NULL`. Without advanced null handling, Pinot includes the column's default null value. Pinot limits aggregation to the rows in each processing block, so values left in a reused internal buffer are not counted again.
+
 ## Usage Example
 
 ```sql


### PR DESCRIPTION
Documents advanced null handling and corrected block-bounded aggregation for `FREQUENTLONGSSKETCH` and `FREQUENTSTRINGSSKETCH`.\n\nFollow-up to apache/pinot#19227.