### PR TITLE
Document offline upsert preload

### DIFF
--- a/build-with-pinot/ingestion/upsert-and-dedup/offline-table-upsert.md
+++ b/build-with-pinot/ingestion/upsert-and-dedup/offline-table-upsert.md
@@ -135,6 +135,30 @@ Reload alone is not enough for these changes.
 
 If you use a hybrid table, avoid overlapping offline and realtime time ranges.
 
+### Preload upsert metadata during server restart
+
+Builds that include [PR #19271](https://github.com/apache/pinot/pull/19271) support upsert preload for `OFFLINE` table data managers. Before loading or replacing an offline segment, Pinot restores the partition's upsert metadata from persisted `validDocIds` snapshots. This can reduce recovery time when a server restarts.
+
+Enable snapshots and preload in the table configuration:
+
+```json
+{
+  "upsertConfig": {
+    "mode": "FULL",
+    "snapshot": "ENABLE",
+    "preload": "ENABLE"
+  }
+}
+```
+
+Also configure a positive preload thread count on the server:
+
+```properties
+pinot.server.instance.max.segment.preload.threads=4
+```
+
+The preload path is a no-op when upsert is not configured or preload is disabled. Each offline segment must have partition metadata so Pinot can restore the correct partition manager. For the shared snapshot lifecycle and restart caveats, see [Enable preload for faster server restarts](upsert.md#enable-preload-for-faster-server-restarts).
+
 ## Related topics
 
 * [Batch Ingestion](../batch-ingestion)

--- a/build-with-pinot/ingestion/upsert-and-dedup/upsert.md
+++ b/build-with-pinot/ingestion/upsert-and-dedup/upsert.md
@@ -600,7 +600,7 @@ The lifecycle for validDocIds snapshots are shows as follows,
 
 ### Enable preload for faster server restarts
 
-Upsert preload feature can make it faster to restore the upsert states when server restarts. To enable the preload feature, set `preload` to `ENABLE`. Snapshot must also be enabled. For example:
+Upsert preload can make it faster to restore upsert state when servers restart. It applies to `REALTIME` tables and, in builds that include [PR #19271](https://github.com/apache/pinot/pull/19271), to `OFFLINE` tables. To enable the preload feature, set `preload` to `ENABLE`. Snapshot must also be enabled. For example:
 
 ```json
 {


### PR DESCRIPTION
## Summary

- document OFFLINE table upsert preload during server restart
- show the existing snapshot, preload, and server thread settings
- clarify that the shared preload guidance applies to REALTIME and OFFLINE tables

## Upstream

Documents apache/pinot#19271.

## Validation

- `git diff --check`