### PR TITLE
Document controller cluster permissions

### DIFF
--- a/operate-pinot/authentication/basic-auth-access-control.md
+++ b/operate-pinot/authentication/basic-auth-access-control.md
@@ -155,6 +155,16 @@ This configuration will automatically allow other pinot components to access pin
 If `*.principals.<user>.tables`is not configured, all tables are accessible to \<user>.
 {% endhint %}
 
+Controller Basic Auth enforces `CREATE`, `READ`, `UPDATE`, and `DELETE` permissions for both table-specific and cluster-level endpoints. A principal with an explicit permission list is denied operations outside that list. Omitting the permission list, or configuring an empty list, preserves the legacy wildcard behavior.
+
+Invalid credentials return HTTP `401`. Valid credentials without the required permission or table access return HTTP `403`. Table allow lists apply only when the endpoint targets a table; cluster-level endpoints use the CRUD permission declared by the endpoint.
+
+{% hint style="warning" %}
+Before rolling out cluster-permission enforcement to controllers, grant the server identity used by `pinot.server.segment.uploader.auth.token` cluster-level `CREATE` permission. Segment completion callbacks mutate controller state. If you use an action-aware custom policy, also grant that identity `COMMIT_SEGMENT`. Update the identity before upgrading controllers to prevent real-time segment commits from failing authorization.
+{% endhint %}
+
+Log-download endpoints require `READ`. The deprecated `/auth/verify` endpoint remains an exception: invalid credentials produce its legacy boolean `false` response instead of an HTTP `401`.
+
 #### Broker authentication and authorization
 
 Pinot-Broker, similar to pinot-controller above, has supported access control for a while now and we added a default implementation for HTTP Basic Auth. Since pinot-broker does not provide a web UI by itself, authentication is only relevant for SQL queries hitting the broker's REST API.

--- a/operate-pinot/authentication/zkbasicauthaccesscontrol.md
+++ b/operate-pinot/authentication/zkbasicauthaccesscontrol.md
@@ -47,6 +47,8 @@ controller.admin.access.control.factory.class=org.apache.pinot.controller.api.ac
 
 After a controller restart, any access to controller APIs requires authentication information. Whether from internal components, external users, or the Web UI.
 
+The controller applies each user's CRUD permissions to cluster-level endpoints as well as table-specific endpoints. An explicit permission list is restrictive; an empty permission list retains legacy wildcard access. Invalid credentials return HTTP `401`, while an authenticated user without the required permission receives HTTP `403`. Before upgrading controllers, follow the [segment-uploader rolling upgrade requirement](basic-auth-access-control.md#controller-authentication-and-authorization).
+
 **5. Enable ACL enforcement on the Broker**
 
 ```


### PR DESCRIPTION
## Summary

- document cluster-level CRUD enforcement for controller Basic Auth
- clarify 401 versus 403 behavior and legacy wildcard permissions
- add the segment-uploader identity requirement for rolling upgrades
- cover static and ZooKeeper-managed Basic Auth

Follows apache/pinot#19234.

## Validation

- `git diff --check`