### PR TITLE
Document multi-stage UUID queries

### DIFF
--- a/reference/configuration-reference/schema.md
+++ b/reference/configuration-reference/schema.md
@@ -146,6 +146,8 @@ For an upsert or dedup table with a UUID primary key, producers must send canoni
 
 Query results render `UUID` values, including multi-value UUID columns, as canonical lowercase RFC 4122 strings. This applies to JSON and Arrow responses from `SELECT`, `GROUP BY`, `DISTINCT`, and join queries.
 
+Both the single-stage and multi-stage query engines support UUID literals and predicates. The multi-stage planner carries UUID literals through the existing 16-byte binary request encoding, while group-by, join, and dynamic-filter execution uses the UUID column's stored `BYTES` representation.
+
 UUID columns can be used as `GROUP BY` keys and in `HAVING` predicates. For multi-value UUID group keys, keep the dictionary enabled. The single-stage query engine also supports UUID inputs for `DISTINCTCOUNT`, `DISTINCTCOUNTHLL`, `DISTINCTCOUNTHLLPLUS`, `DISTINCTCOUNTBITMAP`, `DISTINCTCOUNTTHETASKETCH`, and `DISTINCTCOUNTCPCSKETCH` on single-value and multi-value columns. `DISTINCTCOUNTULL` supports single-value UUID columns only.
 
 Distinct-count sketches hash the stored 16-byte UUID value. Therefore, an approximate count or raw sketch over a UUID column is not expected to match the result of applying the same function to `CAST(uuidColumn AS STRING)`.


### PR DESCRIPTION
## Summary

- document UUID literal and predicate support in both query engines
- explain the multi-stage binary literal representation
- identify the existing stored-type paths used by group-by, joins, and dynamic filters

Follows apache/pinot#18874.

## Validation

- `git diff --check`