### PR TITLE
Document multi-value distinct count support

### DIFF
--- a/functions/aggregation/distinctcountull.md
+++ b/functions/aggregation/distinctcountull.md
@@ -13,6 +13,8 @@ For exact distinct counting, see [DISTINCTCOUNT](distinctcount.md).
 * `ullSketchColumn` (required): Name of the column to aggregate on.
 * `ullSketchPrecision` (optional): p which is the precision parameter, which controls both the size and accuracy of the sketch. If not supplied, the Helix default is used.
 
+The input column can be single-value or multi-value. For a multi-value column, Pinot adds every value in each row to the sketch.
+
 ## Usage examples
 
 These examples are based on the [Batch Quick Start](../../basics/getting-started/quick-start.md#batch-processing).

--- a/functions/aggregation/segmentpartitioneddistinctcount.md
+++ b/functions/aggregation/segmentpartitioneddistinctcount.md
@@ -16,6 +16,8 @@ This function relies on the expression values being partitioned for each segment
 
 > SEGMENTPARTITIONEDDISTINCTCOUNT(colName)
 
+The input column can be single-value or multi-value. For a multi-value column, Pinot counts each distinct value contained in the rows. The partitioning requirement still applies to every value: the same value must not occur in different segments.
+
 ## Usage Examples
 
 These examples are based on the [Batch Quick Start](../../basics/getting-started/quick-start.md#batch-processing).

--- a/functions/sketch/distinctcountull.md
+++ b/functions/sketch/distinctcountull.md
@@ -17,6 +17,8 @@ For exact distinct counting, see [DISTINCTCOUNT](../../functions/aggregation/dis
 * `column` (required): Name of the column to aggregate on.
 * `p` (optional): The precision parameter that controls the number of registers used by the sketch. Higher values give more accurate results but use more memory. Default is `12`.
 
+The input column can be single-value or multi-value. For a multi-value column, Pinot adds every value in each row to the sketch.
+
 ## Usage Examples
 
 ```sql

--- a/reference/configuration-reference/schema.md
+++ b/reference/configuration-reference/schema.md
@@ -148,7 +148,7 @@ Query results render `UUID` values, including multi-value UUID columns, as canon
 
 Both the single-stage and multi-stage query engines support UUID literals and predicates. The multi-stage planner carries UUID literals through the existing 16-byte binary request encoding, while group-by, join, and dynamic-filter execution uses the UUID column's stored `BYTES` representation.
 
-UUID columns can be used as `GROUP BY` keys and in `HAVING` predicates. For multi-value UUID group keys, keep the dictionary enabled. The single-stage query engine also supports UUID inputs for `DISTINCTCOUNT`, `DISTINCTCOUNTHLL`, `DISTINCTCOUNTHLLPLUS`, `DISTINCTCOUNTBITMAP`, `DISTINCTCOUNTTHETASKETCH`, and `DISTINCTCOUNTCPCSKETCH` on single-value and multi-value columns. `DISTINCTCOUNTULL` supports single-value UUID columns only.
+UUID columns can be used as `GROUP BY` keys and in `HAVING` predicates. For multi-value UUID group keys, keep the dictionary enabled. The single-stage query engine also supports UUID inputs for `DISTINCTCOUNT`, `DISTINCTCOUNTHLL`, `DISTINCTCOUNTHLLPLUS`, `DISTINCTCOUNTBITMAP`, `DISTINCTCOUNTTHETASKETCH`, `DISTINCTCOUNTCPCSKETCH`, and `DISTINCTCOUNTULL` on single-value and multi-value columns.
 
 Distinct-count sketches hash the stored 16-byte UUID value. Therefore, an approximate count or raw sketch over a UUID column is not expected to match the result of applying the same function to `CAST(uuidColumn AS STRING)`.
 


### PR DESCRIPTION
Documents multi-value column support added by apache/pinot#19302 for:

- `DISTINCTCOUNTULL`
- `SEGMENTPARTITIONEDDISTINCTCOUNT`
- multi-value UUID inputs to `DISTINCTCOUNTULL`

Upstream: https://github.com/apache/pinot/pull/19302