### PR TITLE
Document funnel null handling

### DIFF
--- a/functions/funnel/README.md
+++ b/functions/funnel/README.md
@@ -2,6 +2,12 @@
 
 Apache Pinot supports a few funnel functions:
 
+## Null handling
+
+When [advanced null handling](../../build-with-pinot/querying-and-sql/null-value-support.md#advanced-null-handling-support) is enabled, funnel functions ignore rows whose timestamp is null. `FUNNELCOUNT` also ignores a row when any `CORRELATE_BY` column is null. Null step predicates are treated as not matched, while null optional extra fields do not discard an otherwise matched event.
+
+With advanced null handling disabled, Pinot continues to read each column's configured default null value.
+
 ## FunnelMaxStep
 
 `FunnelMaxStep` evaluates user interactions within a specified time window to determine the furthest step reached in a predefined sequence of actions. By analyzing event timestamps and conditions set for each step, it identifies the maximum progression point for each user, ensuring that the sequence follows the configured order or other specific rules like strict timestamp increases or event uniqueness. This function is instrumental in funnel analysis, helping businesses and analysts understand user behavior, measure conversion rates, and identify potential drop-offs in critical user journeys.


### PR DESCRIPTION
## Summary

- document how funnel functions treat null timestamps and correlation keys
- clarify null predicate and extra-field behavior
- preserve the disabled-mode default-value behavior

Upstream: https://github.com/apache/pinot/pull/19332