### PR TITLE
Document EXPR min/max and time-series null handling

### DIFF
--- a/functions/aggregation/arg_min-arg_max.md
+++ b/functions/aggregation/arg_min-arg_max.md
@@ -45,8 +45,9 @@ Note:
 
 1. In cases where multiple rows share the same extreme values in the measuring columns, all such rows will be returned by the function.
 2. If the goal is to project multiple different columns that correspond to the same set of measuring columns, you can achieve this by invoking the function multiple times, each time specifying a different projection column.
-3. This impl does not work with AS clause (e.g. `SELECT exprmin(longCol, doubleCol) AS exprmin` won't work)
-4. Putting `exprmin/exprmax` column inside order by clause (e.g. `SELECT intCol, exprmin(longCol, doubleCol) FROM table GROUP BY intCol ORDER BY exprmin(longCol, doubleCol)`) is not supported as semantically ordering multi-column multi-row `exprmin/exprmax` results doesn't make sense
-5. Currently projecting MV bytes column doesn't work for now due to an issue
+3. With query option `enableNullHandling=true`, a row is excluded when any measuring column is `NULL`, because its composite comparison key is undefined. A `NULL` projection value does not exclude a row; it is returned if that row wins the comparison.
+4. This impl does not work with AS clause (e.g. `SELECT exprmin(longCol, doubleCol) AS exprmin` won't work)
+5. Putting `exprmin/exprmax` column inside order by clause (e.g. `SELECT intCol, exprmin(longCol, doubleCol) FROM table GROUP BY intCol ORDER BY exprmin(longCol, doubleCol)`) is not supported as semantically ordering multi-column multi-row `exprmin/exprmax` results doesn't make sense
+6. Currently projecting MV bytes column doesn't work for now due to an issue
 
 For more detailed examples, see: [https://github.com/apache/pinot/pull/10636](https://github.com/apache/pinot/pull/10636)

--- a/operate-pinot/upgrade-notes.md
+++ b/operate-pinot/upgrade-notes.md
@@ -17,6 +17,18 @@ recommended component upgrade order, see
 
 ## Upcoming Release
 
+### EXPR_MIN, EXPR_MAX, and time-series aggregation now honor null handling
+
+With query option `enableNullHandling=true`, `EXPR_MIN` and `EXPR_MAX` now skip a row when any measuring column is `NULL`. A null projection column remains valid payload and does not disqualify the row. Previously, a null measuring value was read as the column's default value and could incorrectly win the minimum or maximum comparison.
+
+The same functions also correct a pre-existing single-stage bug for queries that match more than one processing block in a segment. Measuring and projection values are now read from the current block, and a later winning row replaces stale projection values instead of appending to them. Corrected results apply regardless of the null-handling option.
+
+`TIMESERIESAGGREGATE` now skips rows whose value or timestamp is null when null handling is enabled. This function is used by time-series plan nodes rather than SQL, and receives the time-series query options through the query context.
+
+**Action required.** Review consumers that rely on `EXPR_MIN`, `EXPR_MAX`, or time-series aggregation over nullable inputs. Corrected queries can select a different row or return no aggregate where the old behavior incorporated column defaults. Also review `EXPR_MIN` and `EXPR_MAX` queries matching more than 10,000 documents per segment, because their result rows can change even when null handling is disabled.
+
+*Source: [PR #19357](https://github.com/apache/pinot/pull/19357)*
+
 ### Keep brokers at least as new as servers during rolling upgrades
 
 Servers can now preserve null aggregate and group-by results in the single-stage engine's DataTable response even when query null handling is disabled. This fixes failures or corrupted neighboring values for queries whose aggregate result is null, such as `MAX(stringColumn)` over an empty result set.


### PR DESCRIPTION
Documents the behavior changes from apache/pinot#19357.

- define EXPR_MIN and EXPR_MAX null semantics
- call out corrected multi-block aggregation results
- add upgrade guidance for time-series aggregation and affected consumers

Upstream: https://github.com/apache/pinot/pull/19357