### PR TITLE
Document segment upload destination binding

### DIFF
--- a/operate-pinot/upgrade-notes.md
+++ b/operate-pinot/upgrade-notes.md
@@ -17,6 +17,16 @@ recommended component upgrade order, see
 
 ## Upcoming Release
 
+### Segment uploads now bind authorization to the final destination table
+
+The v1 `POST /segments` endpoint now requires a consistent destination table across the `tableName` request parameter, optional `Pinot-TableName` header, and embedded `segment.table.name` metadata. Missing, blank, invalid, or conflicting values return HTTP 400. Pinot authorizes the canonical destination before fetching a segment source or mutating deep storage or ZooKeeper.
+
+Intentional promotion or reuse of an existing segment artifact whose embedded source-table metadata differs from its destination must use `POST /v2/segments`. The v2 endpoint preserves destination override behavior while binding authorization and database headers to the final destination. Pinot's Purge and Refresh minion tasks now use v2 because they can reuse existing artifacts; conversion tasks that regenerate destination-bound metadata remain on v1.
+
+**Action required.** Audit custom segment-upload clients. For v1 uploads, send an explicit destination and ensure every supplied table identifier matches. Move workflows that intentionally override embedded table metadata to `/v2/segments`, and grant the caller permission on the destination table rather than relying on cluster-level create access or a source-table identity.
+
+*Source: [PR #19231](https://github.com/apache/pinot/pull/19231)*
+
 ### EXPR_MIN, EXPR_MAX, and time-series aggregation now honor null handling
 
 With query option `enableNullHandling=true`, `EXPR_MIN` and `EXPR_MAX` now skip a row when any measuring column is `NULL`. A null projection column remains valid payload and does not disqualify the row. Previously, a null measuring value was read as the column's default value and could incorrectly win the minimum or maximum comparison.

--- a/tutorials/data-ingestion/create-pinot-segments.md
+++ b/tutorials/data-ingestion/create-pinot-segments.md
@@ -133,11 +133,21 @@ Sample Schema:
 
 #### Pushing offline segments to Pinot
 
-You can use curl to push a segment to pinot:
+You can use curl to push a segment to Pinot. For the v1 `/segments` endpoint, supply the destination table explicitly:
 
 ```
-curl -X POST -F segment=@<segment-tar-file-path> http://controllerHost:controllerPort/segments
+curl -X POST -F segment=@<segment-tar-file-path> \
+  "http://controllerHost:controllerPort/segments?tableName=<tableName>"
 ```
+
+The v1 endpoint strictly binds the destination table across the `tableName` request parameter, the optional
+`Pinot-TableName` header, and the `segment.table.name` embedded in the segment metadata. If more than one is supplied,
+all values must identify the same table; missing, blank, invalid, or conflicting values return HTTP 400. Authorization
+is evaluated for that exact destination table before Pinot fetches or stores segment data.
+
+Use `/v2/segments` when intentionally uploading an existing segment artifact to a different destination table, such as
+promoting or reusing a segment whose embedded source-table metadata differs from the destination. The v2 endpoint keeps
+destination override behavior while still binding authorization and database headers to the final destination.
 
 Alternatively you can use the pinot-admin.sh utility to upload one or more segments:
 


### PR DESCRIPTION
Documents the compatibility and security behavior added by apache/pinot#19231.

- show explicit destination binding for v1 uploads
- explain identifier consistency and HTTP 400 failures
- direct intentional segment promotion and artifact reuse to v2
- add upgrade guidance for custom upload clients

Upstream: https://github.com/apache/pinot/pull/19231