### PR TITLE
Document BYTES array literals

### DIFF
--- a/build-with-pinot/querying-and-sql/sql-reference.md
+++ b/build-with-pinot/querying-and-sql/sql-reference.md
@@ -755,6 +755,7 @@ For more details, see [Null value support](../../build-with-pinot/querying-and-s
 - **Double quotes** (`"`) delimit identifiers (column names, table names). Use double quotes for reserved keywords or special characters: `SELECT "timestamp", "date" FROM myTable`.
 - **Single quotes** (`'`) delimit string literals: `WHERE city = 'NYC'`. Escape an embedded single quote by doubling it: `'it''s'`.
 - **Decimal literals** should be enclosed in single quotes to preserve precision.
+- **Binary literals** use hexadecimal SQL syntax such as `X'0102'`. Construct a `BYTES_ARRAY` with `ARRAY[X'00', X'0102', X'FF']`. Pinot supports these literals in projections, nested expressions, and predicates in both query engines; response values are hexadecimal strings and result metadata reports `BYTES_ARRAY`.
 
 ---
 

--- a/functions/array/arraysoverlap.md
+++ b/functions/array/arraysoverlap.md
@@ -51,3 +51,13 @@ WHERE ARRAYS_OVERLAP(longArrayCol, ARRAY[CAST(2 AS BIGINT), CAST(10 AS BIGINT)])
 ```
 
 Returns all rows where `longArrayCol` shares at least one value with the filter array.
+
+For a multi-value `BYTES` column, use SQL binary literals inside the array:
+
+```sql
+SELECT id, byte_values
+FROM events
+WHERE ARRAYS_OVERLAP(byte_values, ARRAY[X'0102', X'CAFE'])
+```
+
+The stored column uses `"dataType": "BYTES"` and `"singleValueField": false` in the Pinot schema. Query response values are hexadecimal strings.

--- a/operate-pinot/upgrade-notes.md
+++ b/operate-pinot/upgrade-notes.md
@@ -17,6 +17,16 @@ recommended component upgrade order, see
 
 ## Upcoming Release
 
+### BYTES array literals require upgraded servers
+
+Both query engines now support `BYTES_ARRAY` literals built from SQL binary values, for example `ARRAY[X'00', X'0102', X'FF']`. They can be projected directly, nested in expressions, or compared with ingested multi-value `BYTES` columns. Query responses encode values as hexadecimal strings and report `BYTES_ARRAY` in result metadata.
+
+The single-stage Thrift `Literal` union adds append-only field 17, `list<binary> bytesArrayValue`. New readers remain compatible with existing literal fields, but old servers do not implement BYTES-array execution. A new broker sending this literal to an old server therefore does not provide usable mixed-version behavior.
+
+**Action required.** Upgrade servers before enabling queries that use BYTES array literals. During a rolling upgrade, do not send these queries to old servers. Review clients that inspect result metadata so they accept `BYTES_ARRAY` and hexadecimal response values.
+
+*Source: [PR #19247](https://github.com/apache/pinot/pull/19247)*
+
 ### Segment uploads now bind authorization to the final destination table
 
 The v1 `POST /segments` endpoint now requires a consistent destination table across the `tableName` request parameter, optional `Pinot-TableName` header, and embedded `segment.table.name` metadata. Missing, blank, invalid, or conflicting values return HTTP 400. Pinot authorizes the canonical destination before fetching a segment source or mutating deep storage or ZooKeeper.


### PR DESCRIPTION
Documents the end-to-end BYTES_ARRAY support added by apache/pinot#19247.

- define SQL binary and BYTES array literal syntax
- add a BYTES ARRAYS_OVERLAP example
- document response representation and rolling-upgrade constraints

Upstream: https://github.com/apache/pinot/pull/19247