### PR TITLE
Document corrected mailbox send stats

### DIFF
--- a/build-with-pinot/querying-and-sql/multi-stage-query/operator-types/mailbox-send.md
+++ b/build-with-pinot/querying-and-sql/multi-stage-query/operator-types/mailbox-send.md
@@ -36,6 +36,11 @@ Type: Long
 
 The summation of time spent by all threads executing the operator. This means that the wall time spent in the operation may be smaller that this value if the parallelism is larger than 1.
 
+For streaming stage stats, Pinot accounts the mailbox send operator's current end-of-stream block before serializing
+its stats. The reported value therefore includes the input work performed by that call, including when the stage emits
+no data block. Derived self time (`executionTimeMs` minus child time) should not be negative. The snapshot still excludes
+the small amount of work required to serialize the stats and hand the end-of-stream block to the exchange.
+
 ### emittedRows
 
 Type: Long

--- a/build-with-pinot/querying-and-sql/multi-stage-query/understanding-stage-stats.md
+++ b/build-with-pinot/querying-and-sql/multi-stage-query/understanding-stage-stats.md
@@ -63,6 +63,11 @@ The Pinot UI stats visualizer is a convenient way to see the multi-stage stats, 
 
 When a query uses the streaming stats transport (`SET streamStats=true` or broker default `pinot.broker.mse.stream.stats=true`), the response also includes a `streamStatsCoverage` array. It is indexed by stage ID and reports how many workers responded cleanly, how many reported stats that the broker could not merge, and how many workers were still missing for that stage.
 
+In streaming mode, mailbox send operators account their in-progress end-of-stream call before attaching stats to that
+block. This prevents derived `selfExecutionTimeMs`, `selfClockTimeMs`, `selfAllocatedMB`, and `selfGcTimeMs` values from
+becoming negative merely because a parent's final call had not yet been registered. The mailbox send snapshot does not
+include the subsequent time used to serialize the stats and deliver the end-of-stream block.
+
 ```json
 {
   "streamStatsCoverage": [

--- a/operate-pinot/upgrade-notes.md
+++ b/operate-pinot/upgrade-notes.md
@@ -17,6 +17,16 @@ recommended component upgrade order, see
 
 ## Upcoming Release
 
+### Streaming mailbox send stats no longer under-report the final block
+
+In multi-stage queries using streaming stats transport, a `MAILBOX_SEND` operator now accounts its in-progress end-of-stream call before serializing the stage-stats snapshot. Previously, its parent snapshot could omit the final call while already including completed child work. This produced missing or understated `executionTimeMs`, `memoryUsedBytes`, and `gcTimeMs`, especially for stages that emitted no data block, and could make derived self metrics negative.
+
+Operator execution totals and the broker-reported non-streaming stats path are unchanged. The serialized mailbox snapshot still excludes the small amount of work performed after collection to serialize the stats and hand the end-of-stream block to the exchange.
+
+**Action required.** Dashboards and alerts should stop treating negative `selfExecutionTimeMs`, `selfClockTimeMs`, `selfAllocatedMB`, or `selfGcTimeMs` as expected artifacts of streaming stats. Values collected before the upgrade can retain the old under-reporting.
+
+*Source: [PR #19365](https://github.com/apache/pinot/pull/19365)*
+
 ### BYTES array literals require upgraded servers
 
 Both query engines now support `BYTES_ARRAY` literals built from SQL binary values, for example `ARRAY[X'00', X'0102', X'FF']`. They can be projected directly, nested in expressions, or compared with ingested multi-value `BYTES` columns. Query responses encode values as hexadecimal strings and report `BYTES_ARRAY` in result metadata.


### PR DESCRIPTION
Documents the streaming stage-stats correction from apache/pinot#19365.

- explain when MAILBOX_SEND accounts its final call
- clarify non-negative derived self metrics
- record the remaining snapshot boundary and upgrade impact

Upstream: https://github.com/apache/pinot/pull/19365