### PR TITLE
Document ignored OPEN_STRUCT keys

### DIFF
--- a/build-with-pinot/ingestion/complex-type/README.md
+++ b/build-with-pinot/ingestion/complex-type/README.md
@@ -137,6 +137,7 @@ Add an `open_struct` entry to the field's `indexes` object in `fieldConfigList`:
       "indexes": {
         "open_struct": {
           "denseKeys": ["customerId", "country"],
+          "ignoredKeys": ["debug", "internalTrace"],
           "denseKeyMinFillRate": 0.5,
           "maxDenseKeys": 32,
           "sparseJsonIndex": true,
@@ -160,6 +161,8 @@ Add an `open_struct` entry to the field's `indexes` object in `fieldConfigList`:
   ]
 }
 ```
+
+Use `ignoredKeys` for object keys that Pinot should discard during ingestion. An ignored key is not materialized as a dense child column, is not written to the sparse column, and cannot be queried. Ignored keys must not also appear in `denseKeys`, `valueFieldConfigs`, or the schema's `childFieldSpecs`.
 
 ### Query OPEN_STRUCT keys
 
@@ -186,6 +189,7 @@ Notes:
 
 * `OPEN_STRUCT` is a field-level index for single-value `OPEN_STRUCT` columns.
 * Pinot can still ingest keys that are not listed in `childFieldSpecs`; it infers a stored type from observed values when possible.
+* Changes to `ignoredKeys` affect only newly ingested data. Existing sealed segments retain values ingested under the earlier configuration.
 * When any schema field uses `OPEN_STRUCT`, `$` becomes a reserved character in schema column names because Pinot uses it in generated child-column names.
 * Use the [schema reference](../../../reference/configuration-reference/schema.md) for the exact schema JSON and the [table reference](../../../reference/configuration-reference/table.md) for the full `open_struct` config surface.
 

--- a/reference/configuration-reference/monitoring-metrics.md
+++ b/reference/configuration-reference/monitoring-metrics.md
@@ -39,6 +39,7 @@ Pinot provides metrics out of the box so that you can monitor every aspect of pe
 | ROWS_WITH_ERRORS | number of rows that either didn't get transformed or didn't get indexed. |  |
 | OPEN_STRUCT_TYPE_COERCION_FAILURES | Per-table, per-column, per-key count of values dropped because they could not be coerced to the key's declared or established type. | Meter |
 | OPEN_STRUCT_TYPE_INFERENCE_FAILURES | Per-table, per-column, per-key count of values stored as serialized strings because their Java type could not be mapped to a Pinot data type. | Meter |
+| OPEN_STRUCT_IGNORED_KEY_DROPS | Per-table, per-column count of non-null `OPEN_STRUCT` entries discarded because their keys are listed in `ignoredKeys`. Pinot batches updates when an offline segment creator closes or a realtime segment seals. | Meter |
 | OPEN_STRUCT_LAST_SEGMENT_DENSE_KEY_COUNT | Dense keys in the most recently sealed segment for an `OPEN_STRUCT` column. This is a last-segment value, not a table-wide total. | Gauge |
 | OPEN_STRUCT_LAST_SEGMENT_SPARSE_KEY_COUNT | Sparse keys in the most recently sealed segment for an `OPEN_STRUCT` column. This is a last-segment value, not a table-wide total. | Gauge |
 | OPEN_STRUCT_LAST_SEGMENT_KEY_COUNT | Total unique dense and sparse keys in the most recently sealed segment for an `OPEN_STRUCT` column. | Gauge |

--- a/reference/configuration-reference/table.md
+++ b/reference/configuration-reference/table.md
@@ -246,6 +246,7 @@ The `open_struct` config object supports the following properties:
 | Property | Description |
 | --- | --- |
 | `denseKeys` | Optional explicit set of keys that Pinot always materializes as dense child columns, regardless of fill rate. |
+| `ignoredKeys` | Optional set of keys to discard during ingestion. Pinot does not materialize these keys or write them to the sparse column, so they are not queryable. An ignored key cannot also appear in `denseKeys`, `valueFieldConfigs`, or the schema's `childFieldSpecs`. Changes affect only newly ingested data; existing sealed segments are unchanged. |
 | `denseKeyMinFillRate` | Minimum fraction of documents that must contain a key before Pinot materializes it automatically. Default: `0.5`. |
 | `maxDenseKeys` | Maximum number of dense keys to materialize. `-1` means unlimited, `0` disables dense keys entirely, and positive values keep only the highest-fill-rate qualifying keys as dense. |
 | `sparseJsonIndex` | Whether to build a JSON index over the shared sparse column. Default: `false`. When enabled, compatible string-key equality and `IN` filters can use the JSON index; other sparse-key operations use the virtual scan path. |
@@ -265,6 +266,7 @@ Example:
       "indexes": {
         "open_struct": {
           "denseKeys": ["customerId", "country"],
+          "ignoredKeys": ["debug", "internalTrace"],
           "denseKeyMinFillRate": 0.5,
           "maxDenseKeys": 32,
           "sparseJsonIndex": true,


### PR DESCRIPTION
Documents the new `ignoredKeys` option for `OPEN_STRUCT` columns, including ingestion behavior, validation conflicts, non-retroactive updates, and the associated drop meter.

Follow-up to apache/pinot#19314.