### PR TITLE
Document UNION ALL local exchanges

### DIFF
--- a/build-with-pinot/querying-and-sql/multi-stage-query/hints.md
+++ b/build-with-pinot/querying-and-sql/multi-stage-query/hints.md
@@ -19,10 +19,12 @@ Type: Boolean
 
 Default: planner chosen
 
-When the option is unset, the V1 planner auto-detects whether each set-op input is already partitioned compatibly and can use a direct exchange. You can override that decision explicitly:
+When the option is unset, the V1 planner uses a local exchange for `UNION ALL` inputs and auto-detects whether other set-op inputs are already partitioned compatibly. You can override that decision explicitly:
 
 * `'true'` forces a pre-partitioned direct exchange on every input.
 * `'false'` forces a shuffled hash exchange on every input.
+
+For `UNION ALL`, only `'false'` changes the default behavior. Use it as a per-query fallback when retaining the input worker layout causes undesirable skew. If input worker counts do not align, Pinot automatically promotes the affected local exchange to a hash exchange.
 
 This hint is only honored by the V1 planner. The V2 physical optimizer ignores it and determines set-op colocation on its own.
 

--- a/build-with-pinot/querying-and-sql/multi-stage-query/operator-types/union.md
+++ b/build-with-pinot/querying-and-sql/multi-stage-query/operator-types/union.md
@@ -32,9 +32,11 @@ Apply this option with `setOpOptions(is_colocated_by_set_op_keys='...')` to cont
 
 * `'true'` forces a pre-partitioned direct exchange.
 * `'false'` forces a shuffled hash exchange.
-* Unset leaves the V1 planner's auto-detection in place.
+* Unset uses a local exchange for `UNION ALL` and leaves other decisions to the V1 planner's auto-detection.
 
 `UNION ALL` is always safe with `'true'` because it only concatenates rows. Plain `UNION` is only safe with `'true'` when all inputs are partitioned compatibly on one or more projected columns so equal full output rows land on the same worker.
+
+For `UNION ALL`, only `'false'` changes the default behavior. It restores a full-row hash shuffle, which can be useful if carrying input skew into the union stage is undesirable. Pinot automatically falls back to a hash exchange for local inputs whose worker counts do not align.
 
 Use the outer-wrap form described in [Hints](../hints.md#setopoptions) for plain `UNION`. Pinot rewrites distinct `UNION` to an aggregate over `UNION ALL`, so the inline hint on the first branch does not apply there.
 


### PR DESCRIPTION
Documents the V1 planner's new default local exchange for UNION ALL, the per-query hash-shuffle fallback, and automatic promotion when worker counts do not align.\n\nFollow-up to apache/pinot#19330.