### PR TITLE
Document optional tuple sketch parameters

### DIFF
--- a/functions/sketch/avgvalueintegersumtuplesketch.md
+++ b/functions/sketch/avgvalueintegersumtuplesketch.md
@@ -13,7 +13,7 @@ The [Tuple Sketch](https://datasketches.apache.org/docs/Tuple/TupleOverview.html
 > avgValueIntegerSumTupleSketch(**\<tupleSketchColumn>, \<tupleSketchParams>**) -> Long
 
 * `tupleSketchColumn` (required): Name of the column to aggregate on.  This must be an existing tuple sketch serialized as bytes.
-* `tupleSketchParams` (required): Semicolon-separated parameter string for constructing the intermediate tuple-sketches.
+* `tupleSketchParams` (optional): Semicolon-separated parameter string for constructing the intermediate tuple sketches, such as `nominalEntries=4096;accumulatorThreshold=10`. The one- and two-argument forms are supported by both query engines.
   * The supported parameters are:
    * `nominalEntries`: The nominal entries used to create the sketch. (Default 65536)
    * `accumulatorThreshold`: How many sketches should be kept in memory before merging. (Default 2)

--- a/functions/sketch/distinctcountrawintegersumtuplesketch.md
+++ b/functions/sketch/distinctcountrawintegersumtuplesketch.md
@@ -13,7 +13,7 @@ The [Tuple Sketch](https://datasketches.apache.org/docs/Tuple/TupleOverview.html
 > distinctCountRawIntegerSumTupleSketch(**\<tupleSketchColumn>, \<tupleSketchParams>**) -> HexEncoded
 
 * `tupleSketchColumn` (required): Name of the column to aggregate on.  This must be an existing tuple sketch serialized as bytes.
-* `tupleSketchParams` (required): Semicolon-separated parameter string for constructing the intermediate tuple-sketches.
+* `tupleSketchParams` (optional): Semicolon-separated parameter string for constructing the intermediate tuple sketches, such as `nominalEntries=4096;accumulatorThreshold=10`. The one- and two-argument forms are supported by both query engines.
   * The supported parameters are:
    * `nominalEntries`: The nominal entries used to create the sketch. (Default 65536)
    * `accumulatorThreshold`: How many sketches should be kept in memory before merging. (Default 2)

--- a/functions/sketch/distinctcounttuplesketch.md
+++ b/functions/sketch/distinctcounttuplesketch.md
@@ -13,7 +13,7 @@ The [Tuple Sketch](https://datasketches.apache.org/docs/Tuple/TupleOverview.html
 > distinctCountTupleSketch(**\<tupleSketchColumn>, \<tupleSketchParams>**) -> Long
 
 * `tupleSketchColumn` (required): Name of the column to aggregate on.  This must be an existing tuple sketch serialized as bytes.
-* `tupleSketchParams` (required):  Semicolon-separated parameter string for constructing the intermediate tuple-sketches.
+* `tupleSketchParams` (optional): Semicolon-separated parameter string for constructing the intermediate tuple sketches, such as `nominalEntries=65536;accumulatorThreshold=10`. The one- and two-argument forms are supported by both query engines.
   * The supported parameters are:
    * `nominalEntries`: The nominal entries used to create the sketch. (Default 65536)
    * `accumulatorThreshold`: How many sketches should be kept in memory before merging. (Default 2)

--- a/functions/sketch/sumvaluesintegersumtuplesketch.md
+++ b/functions/sketch/sumvaluesintegersumtuplesketch.md
@@ -13,7 +13,7 @@ The [Tuple Sketch](https://datasketches.apache.org/docs/Tuple/TupleOverview.html
 > sumValuesIntegerSumTupleSketch(**\<tupleSketchColumn>, \<tupleSketchParams>**) -> Long
 
 * `tupleSketchColumn` (required): Name of the column to aggregate on.  This must be an existing tuple sketch serialized as bytes.
-* `tupleSketchParams` (required): Semicolon-separated parameter string for constructing the intermediate tuple-sketches.
+* `tupleSketchParams` (optional): Semicolon-separated parameter string for constructing the intermediate tuple sketches, such as `nominalEntries=65536;accumulatorThreshold=10`. The one- and two-argument forms are supported by both query engines.
   * The supported parameters are:
    * `nominalEntries`: The nominal entries used to create the sketch. (Default 65536)
    * `accumulatorThreshold`: How many sketches should be kept in memory before merging. (Default 2)


### PR DESCRIPTION
Marks the tuple-sketch parameter argument as optional and notes that both one- and two-argument forms are supported by both query engines.\n\nFollow-up to apache/pinot#19312.