### PR TITLE
Document table partitioning for offline, realtime, and hybrid tables

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -500,6 +500,7 @@
   * [Tuning Default MMAP Advice](operate-pinot/tuning/tuning-default-mmap-advice.md)
   * [Real-Time](operate-pinot/tuning/realtime.md)
   * [Routing](operate-pinot/tuning/routing.md)
+  * [Configuring Table Partitioning](operate-pinot/tuning/configuring-table-partitioning.md)
   * [Query Routing Using Adaptive Server Selection](operate-pinot/tuning/query-routing-using-adaptive-server-selection.md)
   * [Query Scheduling](operate-pinot/tuning/query-scheduling.md)
   * [Workload-Based Query Resource Isolation](operate-pinot/tuning/workload-query-isolation.md)

--- a/basics/components/table/README.md
+++ b/basics/components/table/README.md
@@ -51,6 +51,7 @@ Use the following properties to make your tables faster or leaner:
 * Segment
 * Indexing
 * Tenants
+* Partitioning — see [Configuring Table Partitioning](../../../operate-pinot/tuning/configuring-table-partitioning.md) for offline, realtime, and hybrid tables.
 
 ## Segments
 

--- a/operate-pinot/troubleshooting/ingestion-faq.md
+++ b/operate-pinot/troubleshooting/ingestion-faq.md
@@ -49,7 +49,7 @@ The following example partitions the segment based on two columns, `memberID` an
       }
 ```
 
-For multi-column partitioning to work, you must also set `routing.segementPrunerTypes` as follows:
+For multi-column partitioning to work, you must also set `routing.segmentPrunerTypes` as follows:
 
 ```json
 "routing": {

--- a/operate-pinot/tuning/README.md
+++ b/operate-pinot/tuning/README.md
@@ -17,6 +17,7 @@ Control how brokers select servers and how many servers participate in each quer
 | Page | What it covers |
 |---|---|
 | [Optimizing Scatter and Gather](routing.md) | Partition pruning, time pruning, replica-group routing, single-replica routing, preferred pool routing, broker tag enforcement |
+| [Configuring Table Partitioning](configuring-table-partitioning.md) | How-to for `segmentPartitionConfig` on offline, realtime, and hybrid tables |
 | [Adaptive Server Selection](query-routing-using-adaptive-server-selection.md) | Route queries to the fastest available server using latency and in-flight request stats |
 | [Segment Pruning](segment-pruning.md) | Broker-side and server-side pruning strategies (time, partition, bloom filter, column value) to skip irrelevant segments |
 

--- a/operate-pinot/tuning/configuring-table-partitioning.md
+++ b/operate-pinot/tuning/configuring-table-partitioning.md
@@ -1,0 +1,139 @@
+---
+description: >-
+  Configure table partitioning for offline, realtime, and hybrid tables so
+  brokers can prune segments and queries stay aligned with Kafka and batch
+  ingestion.
+---
+
+# Configuring Table Partitioning
+
+Table partitioning tells Pinot how rows are distributed across segments. When a query filters on the partition column with `=` or `IN`, the broker can skip segments that cannot contain matching rows.
+
+This page is the operator how-to for **offline**, **realtime**, and **hybrid** tables. For the full property list, see [`segmentPartitionConfig`](../../reference/configuration-reference/table.md#segment-partition-config). For how pruning works at query time, see [Segment Pruning](segment-pruning.md).
+
+## Three meanings of "partition"
+
+Pinot docs use "partition" in three related but different ways:
+
+| What | Where it lives | What it is for |
+| --- | --- | --- |
+| Stream / Kafka partitions | The topic (or Kinesis shards, Pulsar partitions) | How the producer shards events. Realtime Pinot consumes one stream partition per consuming segment. |
+| Segment partition metadata | `tableIndexConfig.segmentPartitionConfig` | The function Pinot uses to tag each segment with partition ids, then prune at the broker. |
+| Replica-group *instance* partitions | `instanceAssignmentConfigMap` | How servers are grouped so a query fans out to one replica group. See [Instance Assignment](../instance-assignment.md). |
+
+This page configures the **second** of those. Replica-group assignment is an optional layer on top; it does not replace matching Kafka and Pinot partition functions.
+
+## Minimum table config
+
+Every partitioned table needs both of the following. Pruning does not run if you set only `segmentPartitionConfig`.
+
+```json
+{
+  "tableIndexConfig": {
+    "segmentPartitionConfig": {
+      "columnPartitionMap": {
+        "memberId": {
+          "functionName": "Murmur",
+          "numPartitions": 8
+        }
+      }
+    }
+  },
+  "routing": {
+    "segmentPrunerTypes": ["partition"]
+  }
+}
+```
+
+Built-in `functionName` values (case-insensitive): `Modulo`, `Murmur` (alias `Murmur2`), `Murmur3`, `FNV`, `HashCode`, `ByteArray`, and `BoundedColumnValue`. Function-specific options such as `partitionIdNormalizer`, `useRawBytes`, `seed`, `variant`, and `columnValues` are documented in the [table configuration reference](../../reference/configuration-reference/table.md#segment-partition-config).
+
+{% hint style="info" %}
+Partition pruning applies only to **EQUALITY** and **IN** filters on the partition column (for example `memberId = 123` or `memberId IN (1, 2)`). Range filters do not prune by partition.
+{% endhint %}
+
+## Offline tables
+
+Offline ingestion does not inherit a stream partition. You must **pre-partition the input** with the same function and `numPartitions` that the table config declares, then build segments.
+
+1. Set `segmentPartitionConfig` and `routing.segmentPrunerTypes` as above.
+2. Partition files before the Pinot segment build. Each input file should contain as few partition ids as possible — ideally one. Pinot records the partition ids it *sees* in the segment; it does not reshuffle rows across files at query time.
+3. Hadoop preprocessing can partition as part of the MapReduce job. Enable `partition` in `preprocessing.operations` and keep `segmentPartitionConfig` on the table. See [Hadoop batch ingestion](../../build-with-pinot/ingestion/batch-ingestion/hadoop.md). Other batch jobs can use a partitioner that honors the table config (`partitionerType: TABLE_PARTITION_CONFIG`).
+4. After push, confirm segment metadata, for example:
+
+```
+column.memberId.partitionFunction = Murmur
+column.memberId.numPartitions = 8
+column.memberId.partitionValues = 3
+```
+
+If `partitionValues` lists many ids per segment, pruning will not help much. Split the input so each file maps to one partition.
+
+{% hint style="info" %}
+**Multi-column partitioning** is supported for **offline** tables: add more entries under `columnPartitionMap`. Realtime tables persist partition metadata only when there is **exactly one** partition column. See [Ingestion FAQ](../troubleshooting/ingestion-faq.md#does-pinot-support-partition-pruning-on-multiple-partition-columns).
+{% endhint %}
+
+## Realtime tables
+
+Partition **at the producer**, then tell Pinot to use the same function.
+
+1. Key Kafka (or equivalent) records on the partition column. Kafka's default partitioner uses **murmur2**. The matching Pinot function is `Murmur` (not `Modulo`).
+2. Set `numPartitions` to the **full topic** partition count, even if this table consumes only a subset of partitions. Using the subset size breaks broker pruning. Details are in [Segment Pruning](segment-pruning.md#partition-pruning).
+3. Pinot tags each consuming LLC segment with that stream partition id. If `columnPartitionConfig.numPartitions` does not match the per-stream partition count, the controller logs a warning and pruning can be wrong.
+
+```json
+{
+  "tableType": "REALTIME",
+  "tableIndexConfig": {
+    "segmentPartitionConfig": {
+      "columnPartitionMap": {
+        "memberId": {
+          "functionName": "Murmur",
+          "numPartitions": 12
+        }
+      }
+    }
+  },
+  "routing": {
+    "segmentPrunerTypes": ["partition"]
+  }
+}
+```
+
+{% hint style="warning" %}
+Upsert and dedup tables should partition on the **primary key** (or a column that is a function of it) so all events for a key land on one partition and one server. Pinot **rejects** table-config updates that add, remove, or change `segmentPartitionConfig` on upsert/dedup tables. Plan the function and count before you create the table. See the warning on [`segmentPartitionConfig`](../../reference/configuration-reference/table.md#segment-partition-config).
+
+Offline upsert tables **require** `segmentPartitionConfig` so segments of the same partition are assigned together.
+{% endhint %}
+
+## Hybrid tables
+
+A hybrid table is an **OFFLINE** config plus a **REALTIME** config that share the same raw table name. You do not create a third "hybrid" resource. See [Table](../../basics/components/table/README.md#hybrid-table-creation) and the [Hybrid Real-Time + Offline playbook](../../playbooks/hybrid-offline-realtime.md).
+
+For partitioning to work across both sides:
+
+- Use the **same** partition column, `functionName`, and `numPartitions` on both table configs.
+- Partition the Kafka producer and the offline backfill with that same function. If realtime used `Murmur` / Kafka murmur2, the batch job must not silently switch to `Modulo`.
+- After the time boundary moves, queries that filter on the partition column still prune on each side independently. Mismatched functions mean the same `memberId = 123` can map to different ids offline vs realtime.
+
+Replica-group / partitioned replica-group **assignment** (which servers hold which partition) is optional and configured separately. See [Segment Assignment](../segment-assignment.md#partitioned-replica-group-segment-assignment) and [Instance Assignment](../instance-assignment.md). Do not confuse `replicaGroupPartitionConfig.numPartitions` (server groups) with `segmentPartitionConfig` `numPartitions` (data partitions).
+
+## Verify pruning
+
+1. Run a query that filters on the partition column with `=` or `IN`.
+2. Compare `numSegmentsQueried` with the table's segment count. Broker-side drops show up as `numSegmentsPrunedByBroker`. See [Monitoring pruning effectiveness](segment-pruning.md#monitoring-pruning-effectiveness).
+3. If almost every segment is still queried, check that:
+   - `routing.segmentPrunerTypes` includes `"partition"`
+   - Segment metadata actually lists a small `partitionValues` set
+   - Realtime `numPartitions` is the full Kafka topic size
+   - Hybrid offline and realtime configs match
+
+You can enable time pruning and partition pruning together: `"segmentPrunerTypes": ["partition", "time"]`.
+
+## Related pages
+
+- [Table configuration: segmentPartitionConfig](../../reference/configuration-reference/table.md#segment-partition-config)
+- [Segment Pruning](segment-pruning.md)
+- [Routing](routing.md)
+- [Instance Assignment](../instance-assignment.md)
+- [Ingestion FAQ](../troubleshooting/ingestion-faq.md)
+- [Hybrid Real-Time + Offline playbook](../../playbooks/hybrid-offline-realtime.md)

--- a/operate-pinot/tuning/routing.md
+++ b/operate-pinot/tuning/routing.md
@@ -45,6 +45,8 @@ To enable this optimization, `segmentPartitionConfig` must contain the `time` pr
 
 #### Data ingested partitioned by some column.
 
+For a step-by-step recipe covering offline, realtime, and hybrid tables, see [Configuring Table Partitioning](configuring-table-partitioning.md).
+
 Apart from the ascending time, Apache Pinot can also take advantage of other distribution data patterns: Partition by segments. In order to use this feature, the table needs to be configured to use a partition function. Pinot will apply this function to each row in a segment and will store the set of partitions seen in the segment. Later, when a query is executed, Pinot will analyze the query in order to look for partition constraints. For example, when executing a query like `select col1 from Table1 where col2 = 3`, Pinot will calculate the partition associated with `col2 = 3` and will prune segments that do not contain rows on that partition.
 
 {% hint style="info" %}

--- a/operate-pinot/tuning/segment-pruning.md
+++ b/operate-pinot/tuning/segment-pruning.md
@@ -46,7 +46,7 @@ Time pruning is more selective when data is strictly time-ordered. With out-of-o
 
 ### Partition Pruning
 
-Partition pruning skips segments that do not contain records matching the query's partition column filter. This is effective for queries that filter on a partitioned column.
+Partition pruning skips segments that do not contain records matching the query's partition column filter. This is effective for queries that filter on a partitioned column. To configure partitioning for offline, realtime, and hybrid tables, see [Configuring Table Partitioning](configuring-table-partitioning.md).
 
 **Configuration:**
 


### PR DESCRIPTION
## What this PR is about

This PR adds a single operator how-to for **configuring table partitioning** in Apache Pinot.

Pinot can skip irrelevant segments when a query filters on a partition column with `=` or `IN`. That only works if the table is configured correctly *and* the data was partitioned the same way at ingest. Today that information is split across the table-config reference, the routing page, the segment-pruning page, and the ingestion FAQ. An operator who just wants to turn partitioning on for an offline, realtime, or hybrid table has no one page that says “do these steps.”

The new page is `operate-pinot/tuning/configuring-table-partitioning.md`. It is a recipe, not a replacement for the existing reference docs.

Fixes apache/pinot#6095.

## Why we are doing it

Issue #6095 asked for documentation on how to configure partitioning for **offline, realtime, and hybrid** tables. Those three table types share the same config knobs, but the *ingest* work is different:

- **Offline:** you must pre-partition the input files before the segment build. Pinot records the partition ids it sees; it does not reshuffle rows across files.
- **Realtime:** the producer (usually Kafka murmur2) must match Pinot’s `Murmur` function, and `numPartitions` must be the **full topic** size, even if the table consumes only a subset of partitions.
- **Hybrid:** both the OFFLINE and REALTIME configs must use the same column, function, and count, or the same `memberId = 123` can map to different partition ids on each side.

Existing pages also use the word “partition” for three different things, which is a common source of misconfiguration:

| Meaning | What it actually is |
| --- | --- |
| Stream / Kafka partitions | How the producer shards events |
| Segment partition metadata (`segmentPartitionConfig`) | How Pinot tags segments so the broker can prune |
| Replica-group instance partitions | How servers are grouped for query fanout |

This page is about the **second** of those. Replica-group assignment is called out as a separate, optional layer so operators do not confuse `replicaGroupPartitionConfig.numPartitions` (server groups) with `segmentPartitionConfig.numPartitions` (data partitions).

## What we did

1. **Added** `operate-pinot/tuning/configuring-table-partitioning.md` with:
   - The three meanings of “partition” (table above)
   - The shared minimum config: `columnPartitionMap` **plus** `routing.segmentPrunerTypes: ["partition"]` (pruning does not run if you set only one of these)
   - Offline steps: pre-partition input, Hadoop / `TABLE_PARTITION_CONFIG` notes, how to read `partitionValues` in segment metadata
   - Realtime steps: Kafka murmur2 → Pinot `Murmur`, full-topic `numPartitions`, upsert/dedup immutability warning
   - Hybrid steps: keep column, function, and count identical on both table configs
   - How to verify pruning with `numSegmentsQueried` / `numSegmentsPrunedByBroker`
   - Pointers back to the table-config reference, pruning, routing, instance assignment, ingestion FAQ, and the hybrid playbook
   - Function-specific option tables are **not** copied; they stay on the table configuration reference

2. **Linked the new page** so people can find it:
   - `SUMMARY.md` — listed under Performance Tuning, after Routing
   - `operate-pinot/tuning/README.md` — added to the scatter/gather table
   - `basics/components/table/README.md` — added under table properties
   - `operate-pinot/tuning/routing.md` — pointer from the “partitioned by some column” section
   - `operate-pinot/tuning/segment-pruning.md` — pointer from Partition Pruning

3. **Fixed** the long-standing FAQ typo `routing.segementPrunerTypes` → `routing.segmentPrunerTypes` in `operate-pinot/troubleshooting/ingestion-faq.md`.

No Pinot runtime, API, or cluster UI code changes. This is documentation only.

## Test plan

- [ ] Confirm the new page renders in GitBook after merge (relative links to table config, pruning, routing, instance assignment, hybrid playbook).
- [ ] Confirm `SUMMARY.md` lists **Configuring Table Partitioning** under Performance Tuning, after Routing.
- [ ] Spot-check the three inbound links (table README, routing.md, segment-pruning.md).
- [ ] Confirm the FAQ now says `routing.segmentPrunerTypes`.
