### PR TITLE
Document MSE worker spread stats

### DIFF
--- a/build-with-pinot/querying-and-sql/multi-stage-query/operator-types/leaf.md
+++ b/build-with-pinot/querying-and-sql/multi-stage-query/operator-types/leaf.md
@@ -40,6 +40,12 @@ Type: Long
 
 The number of groups emitted by the operator.
 
+### activeWorkers
+
+Type: Int
+
+The number of stage workers that had at least one segment assigned. Compare this value with the stage `parallelism` reported by the mailbox send operator to identify idle leaf workers. A worker can be active even when its segments produce no rows.
+
 ### table
 
 Type: String

--- a/build-with-pinot/querying-and-sql/multi-stage-query/operator-types/mailbox-receive.md
+++ b/build-with-pinot/querying-and-sql/multi-stage-query/operator-types/mailbox-receive.md
@@ -38,6 +38,12 @@ Type: Long
 
 The number of groups emitted by the operator. This operator should always emit as many rows as its upstream operator.
 
+### activeWorkers
+
+Type: Int
+
+The number of stage workers that received at least one row. Compare this value with the stage `parallelism` and with adjacent send or leaf operators to identify where data became concentrated.
+
 ### fanIn
 
 Type: Long

--- a/build-with-pinot/querying-and-sql/multi-stage-query/operator-types/mailbox-send.md
+++ b/build-with-pinot/querying-and-sql/multi-stage-query/operator-types/mailbox-send.md
@@ -47,6 +47,24 @@ Type: Long
 
 The number of groups emitted by the operator. This operator should always emit as many rows as its upstream operator.
 
+### activeWorkers
+
+Type: Int
+
+The number of stage workers that sent at least one row. Compare this value with `parallelism` to detect workers that emitted no data.
+
+### maxEmittedRows
+
+Type: Long
+
+The largest number of rows emitted by any single worker. Compare it with `minNonzeroEmittedRows` to measure row-distribution skew.
+
+### minNonzeroEmittedRows
+
+Type: Long
+
+The smallest number of rows emitted by a worker that sent at least one row. Workers that sent no rows are excluded; use `activeWorkers` to detect them.
+
 ### stage
 
 Type: number

--- a/build-with-pinot/querying-and-sql/multi-stage-query/understanding-stage-stats.md
+++ b/build-with-pinot/querying-and-sql/multi-stage-query/understanding-stage-stats.md
@@ -12,6 +12,10 @@ Starting in Pinot 1.6.0, the `stageStats` tree also includes leaf-stage pipeline
 
 Each operator has its own set of statistics, which are collected during the execution of the query. See the [Operator Types](../../../build-with-pinot/querying-and-sql/multi-stage-query/operator-types) section to learn more about the different operator types and their statistics.
 
+Use `activeWorkers` to detect uneven work distribution. `LEAF`, `MAILBOX_RECEIVE`, and `MAILBOX_SEND` count activity differently: a leaf worker is active when it has at least one segment, a receive worker when it receives at least one row, and a send worker when it sends at least one row. Compare each value with the stage's `parallelism`, and compare values down the operator tree to see where a stage narrows.
+
+For `MAILBOX_SEND`, `maxEmittedRows` and `minNonzeroEmittedRows` show the row-count spread across workers that emitted data. A large difference indicates skew. Workers that emitted no rows are excluded from `minNonzeroEmittedRows`; use `activeWorkers` to identify idle workers.
+
 ### Multi-stage stats visualizer [](#multi-stage-stats-visualizer)
 
 The recommended way to analyze the multi-stage stats is to use the visualizer included in the Pinot UI. It can be accessed by running a query in the Pinot controller UI and clicking on the `Visual` button.


### PR DESCRIPTION
Documents activeWorkers for leaf and mailbox operators, the mailbox-send row-spread fields, and how to use them to identify idle workers and skew.\n\nFollow-up to apache/pinot#19364.