### PR TITLE
Document absent MAP and OPEN_STRUCT key semantics

### DIFF
--- a/build-with-pinot/ingestion/complex-type/README.md
+++ b/build-with-pinot/ingestion/complex-type/README.md
@@ -183,7 +183,7 @@ For a materialized key, Pinot reads the generated child column and can use its d
 
 Keys stored in the shared sparse column are also available through the item operator. Pinot exposes each sparse key as a virtual typed data source, so projections, filters, grouping, and aggregations use the same SQL syntax as dense keys. Sparse keys use scan-based execution by default. Set `sparseJsonIndex` to `true` to build a JSON index over the sparse column; Pinot can use it for compatible string-key equality and `IN` predicates, while other predicates continue to scan the virtual data source.
 
-A key that is absent from a document returns its type's default value and is marked null when null handling is enabled. A key that is absent from the segment returns `NULL`; `IS NULL` matches all documents and other predicates match none.
+A key that is absent from a document returns its type's default null value and is marked null when null handling is enabled. The same rule applies when a key is absent from an entire segment: Pinot uses the key's declared type and `defaultNullValue` from `childFieldSpecs`, or a single-value `STRING` field with the standard default when the key is undeclared. With null handling enabled, the lookup returns `NULL`, `IS NULL` matches every document, and value predicates do not match nulls. With null handling disabled, projections and predicates see the configured or type-specific default value instead. For example, if an absent declared `STRING` key has `"defaultNullValue": "N/A"`, `attributes['key'] = 'N/A'` matches every document in that segment.
 
 Notes:
 

--- a/build-with-pinot/querying-and-sql/sql-reference.md
+++ b/build-with-pinot/querying-and-sql/sql-reference.md
@@ -90,7 +90,7 @@ FROM events
 GROUP BY attributes['country']
 ```
 
-If a key is missing, Pinot returns the value type's default null value. For example, a missing STRING map value returns `"null"` and a missing INT map value returns `Integer.MIN_VALUE`.
+If a key is missing, Pinot uses the value field's configured `defaultNullValue`, or the type-specific default when none is configured. For example, a missing STRING map value uses `"null"` and a missing INT map value uses `Integer.MIN_VALUE` by default. This behavior is consistent even when the key is absent from an entire segment. With null handling enabled, the lookup is also marked null, so it returns SQL `NULL`, `IS NULL` matches, and value predicates do not match it. With null handling disabled, projections and predicates see the configured or type-specific default value.
 
 For schema syntax, see [Schema Configuration](../../reference/configuration-reference/schema.md#complexfieldspecs).
 


### PR DESCRIPTION
Documents the query behavior introduced by apache/pinot#19439.

- distinguish null-enabled SQL behavior from default-value behavior when null handling is disabled
- explain whole-segment absent keys, declared types, and custom `defaultNullValue` values
- keep the SQL MAP reference consistent with the OPEN_STRUCT guide

Validation: `scripts/validate-docs.py --strict` and `git diff --check`